### PR TITLE
fix(component generators): bind exposed methods to preserve 'this'

### DIFF
--- a/__tests__/unit/component-generators.ts
+++ b/__tests__/unit/component-generators.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-ignore-next-line
 import componentUIDL from '../../examples/uidl-samples/component-author-card.json'
 
 import {
@@ -54,10 +54,8 @@ describe('Vue Component Generator', () => {
   })
 
   describe('with Custom Mapping', () => {
-    const generator = createVueComponentGenerator({
-      customMapping: { container: { type: 'fakediv' } },
-    })
-    // generator.addMapping()
+    const generator = createVueComponentGenerator()
+    generator.addMapping({ container: { type: 'fakediv' } })
 
     it('should render <fakediv> tags', async () => {
       const uidl = JSON.parse(JSON.stringify(componentUIDL))

--- a/__tests__/unit/project-generators.ts
+++ b/__tests__/unit/project-generators.ts
@@ -1,0 +1,51 @@
+// @ts-ignore
+import projectUIDL from '../../examples/uidl-samples/project-routing.json'
+
+import {
+  createReactBasicProject,
+  createReactNextProject,
+  createVueBasicProject,
+  createVueNuxtProject,
+} from '../../src'
+
+describe('React Basic Project Generator', () => {
+  it('runs without crashing', async () => {
+    const uidl = JSON.parse(JSON.stringify(projectUIDL))
+    const result = await createReactBasicProject(uidl)
+
+    expect(result.assetsPath).toBeDefined()
+    expect(result.outputFolder.name).toBe('dist')
+    expect(result.outputFolder.files[0].name).toBe('package')
+  })
+})
+
+describe('React Next Project Generator', () => {
+  it('runs without crashing', async () => {
+    const uidl = JSON.parse(JSON.stringify(projectUIDL))
+    const result = await createReactNextProject(uidl)
+
+    expect(result.assetsPath).toBeDefined()
+    expect(result.outputFolder.name).toBe('dist')
+    expect(result.outputFolder.files[0].name).toBe('package')
+  })
+})
+
+describe('Vue Basic Project Generator', () => {
+  it('runs without crashing', async () => {
+    const uidl = JSON.parse(JSON.stringify(projectUIDL))
+    const result = await createVueBasicProject(uidl)
+
+    expect(result.assetsPath).toBeDefined()
+    expect(result.outputFolder.name).toBe('dist')
+  })
+})
+
+describe('Vue Nuxt Project Generator', () => {
+  it('runs without crashing', async () => {
+    const uidl = JSON.parse(JSON.stringify(projectUIDL))
+    const result = await createVueNuxtProject(uidl)
+
+    expect(result.assetsPath).toBeDefined()
+    expect(result.outputFolder.name).toBe('dist')
+  })
+})

--- a/src/component-generators/react/react-all.ts
+++ b/src/component-generators/react/react-all.ts
@@ -1,3 +1,4 @@
+/* THIS WILL BE SOON REMOVED */
 import { AssemblyLine, Builder, Resolver } from '../../core'
 
 import { createPlugin as reactComponent } from '../../plugins/react/react-base-component'

--- a/src/component-generators/react/react-component.ts
+++ b/src/component-generators/react/react-component.ts
@@ -76,9 +76,9 @@ const createReactGenerator = (params: ReactGeneratorFactoryParams = {}): Compone
 
   return {
     generateComponent,
-    resolveContentNode: resolver.resolveContentNode,
-    addMapping: resolver.addMapping,
-    addPlugin: assemblyLine.addPlugin,
+    resolveContentNode: resolver.resolveContentNode.bind(resolver),
+    addMapping: resolver.addMapping.bind(resolver),
+    addPlugin: assemblyLine.addPlugin.bind(assemblyLine),
   }
 }
 

--- a/src/component-generators/vue/vue-component.ts
+++ b/src/component-generators/vue/vue-component.ts
@@ -69,9 +69,9 @@ ${cssCode}
 
   return {
     generateComponent,
-    resolveContentNode: resolver.resolveContentNode,
-    addMapping: resolver.addMapping,
-    addPlugin: assemblyLine.addPlugin,
+    resolveContentNode: resolver.resolveContentNode.bind(resolver),
+    addMapping: resolver.addMapping.bind(resolver),
+    addPlugin: assemblyLine.addPlugin.bind(assemblyLine),
   }
 }
 


### PR DESCRIPTION
because the addMapping, addPlugin methods were exposed on the generator instance, their this was not properly pointing to the resolver/assembly line instances

fix #3