### PR TITLE
fix for unformatted css in generated html and js files

### DIFF
--- a/src/core/builder/generators/html-to-string.ts
+++ b/src/core/builder/generators/html-to-string.ts
@@ -1,5 +1,7 @@
 import { format } from 'prettier/standalone'
-import parserPlugin from 'prettier/parser-html'
+
+import parserHTML from 'prettier/parser-html'
+import parserPostCSS from 'prettier/parser-postcss'
 
 import { PRETTIER_CONFIG } from '../../../shared/constants'
 import { GeneratorFunction } from '../../../shared/types'
@@ -10,7 +12,7 @@ export const generator: GeneratorFunction = (htmlObject: any) => {
   const formatted = format(unformatedString, {
     ...PRETTIER_CONFIG,
     htmlWhitespaceSensitivity: 'ignore',
-    plugins: [parserPlugin],
+    plugins: [parserHTML, parserPostCSS],
     parser: 'html',
   })
   return formatted

--- a/src/core/builder/generators/js-ast-to-code.ts
+++ b/src/core/builder/generators/js-ast-to-code.ts
@@ -1,6 +1,7 @@
 import babelGenerator from '@babel/generator'
 import { format } from 'prettier/standalone'
-import parserPlugin from 'prettier/parser-babylon'
+import parserBabylon from 'prettier/parser-babylon'
+import parserPostCSS from 'prettier/parser-postcss'
 
 import { PRETTIER_CONFIG } from '../../../shared/constants'
 import { GeneratorFunction } from '../../../shared/types'
@@ -15,7 +16,7 @@ export const generator: GeneratorFunction = (anyContent) => {
 
   const formatted = format(code, {
     ...PRETTIER_CONFIG,
-    plugins: [parserPlugin],
+    plugins: [parserBabylon, parserPostCSS],
     parser: 'babel',
   })
 


### PR DESCRIPTION
postcss prettier plugin added to html-to-string and js-ast-to-code

formats css in js, as well as css in generated html files