### PR TITLE
Feature/#118 udil string to json props

### DIFF
--- a/__tests__/unit/shared/utils/uidl-utils.ts
+++ b/__tests__/unit/shared/utils/uidl-utils.ts
@@ -3,6 +3,7 @@ import {
   isUIDLDynamicReference,
   transformStringAssignmentToJson,
   transformStylesAssignmentsToJson,
+  transformAttributesAssignmentsToJson,
 } from '../../../../src/shared/utils/uidl-utils'
 
 import uidlStyleJSON from './uidl-utils-style.json'
@@ -195,5 +196,25 @@ describe('transformStylesAssignmentsToJson', () => {
     }
 
     expect(transformStylesAssignmentsToJson(nestedStyle)).toEqual(expectedStyle)
+  })
+})
+
+describe('transformAttributesAssignmentsToJson', () => {
+  it('transforms attrs styles to new json', () => {
+    const inputStyle = {
+      float: { type: 'static', content: 'left' },
+      width: 32,
+      height: '$state.expandedSize',
+      flexDirection: { type: 'dynamic', content: { referenceType: 'prop', id: 'direction' } },
+    }
+
+    const expectedStyle = {
+      float: { type: 'static', content: 'left' },
+      width: { type: 'static', content: 32 },
+      height: { type: 'dynamic', content: { referenceType: 'state', id: 'expandedSize' } },
+      flexDirection: { type: 'dynamic', content: { referenceType: 'prop', id: 'direction' } },
+    }
+
+    expect(transformAttributesAssignmentsToJson(inputStyle)).toEqual(expectedStyle)
   })
 })

--- a/__tests__/unit/shared/utils/uidl-utils.ts
+++ b/__tests__/unit/shared/utils/uidl-utils.ts
@@ -1,6 +1,8 @@
 import {
   cleanupDynamicStyles,
   isUIDLDynamicReference,
+  transformStringAssignmentToJson,
+  transformStylesAssignmentsToJson,
 } from '../../../../src/shared/utils/uidl-utils'
 
 import uidlStyleJSON from './uidl-utils-style.json'
@@ -33,5 +35,165 @@ describe('isUIDLDynamicReference', () => {
   it('returns valid object back, falsty otherwise', () => {
     expect(isUIDLDynamicReference(validDynamicReference)).toEqual(validDynamicReference)
     expect(isUIDLDynamicReference(invalidReference)).toBeFalsy()
+  })
+})
+
+describe('transformStringAssignmentToJson', () => {
+  const inputOutputMap = {
+    '$props.direction': {
+      type: 'dynamic',
+      content: {
+        referenceType: 'prop',
+        id: 'direction',
+      },
+    },
+
+    '$state.direction': {
+      type: 'dynamic',
+      content: {
+        referenceType: 'state',
+        id: 'direction',
+      },
+    },
+
+    '$local.direction': {
+      type: 'dynamic',
+      content: {
+        referenceType: 'local',
+        id: 'direction',
+      },
+    },
+
+    'static content 1': {
+      type: 'static',
+      content: `static content 1`,
+    },
+  }
+
+  it('transforms props string to json', () => {
+    Object.keys(inputOutputMap).forEach((key) => {
+      expect(transformStringAssignmentToJson(key)).toEqual(inputOutputMap[key])
+    })
+  })
+})
+
+describe('transformStylesAssignmentsToJson', () => {
+  it('transforms static styles to new json', () => {
+    const inputStyle = {
+      float: 'left',
+    }
+
+    const expectedStyle = {
+      float: { type: 'static', content: 'left' },
+    }
+
+    expect(transformStylesAssignmentsToJson(inputStyle)).toEqual(expectedStyle)
+  })
+
+  it('leaves static styles json alone', () => {
+    const inputStyle = {
+      float: { type: 'static', content: 'left' },
+      width: 32,
+    }
+
+    const expectedStyle = {
+      float: { type: 'static', content: 'left' },
+      width: { type: 'static', content: 32 },
+    }
+
+    expect(transformStylesAssignmentsToJson(inputStyle)).toEqual(expectedStyle)
+  })
+
+  it('leaves dynamic styles json alone', () => {
+    const inputStyle = {
+      width: { type: 'dynamic', content: { referenceType: 'prop', id: 'size' } },
+    }
+
+    const expectedStyle = {
+      width: { type: 'dynamic', content: { referenceType: 'prop', id: 'size' } },
+    }
+
+    expect(transformStylesAssignmentsToJson(inputStyle)).toEqual(expectedStyle)
+  })
+
+  it('transforms dynamic styles to new json', () => {
+    const inputStyle = {
+      width: '$props.size',
+    }
+
+    const expectedStyle = {
+      width: { type: 'dynamic', content: { referenceType: 'prop', id: 'size' } },
+    }
+
+    expect(transformStylesAssignmentsToJson(inputStyle)).toEqual(expectedStyle)
+  })
+
+  it('transforms nested styles to new json', () => {
+    const nestedStyle = {
+      '@media(max-widht:300px)': {
+        flex: '1 1 row',
+        width: '$props.size',
+      },
+    }
+
+    const expectedStyle = {
+      '@media(max-widht:300px)': {
+        type: 'nested-style',
+        content: {
+          flex: { type: 'static', content: '1 1 row' },
+          width: { type: 'dynamic', content: { referenceType: 'prop', id: 'size' } },
+        },
+      },
+    }
+
+    expect(transformStylesAssignmentsToJson(nestedStyle)).toEqual(expectedStyle)
+  })
+
+  it('transforms mixed styles to new json', () => {
+    const nestedStyle = {
+      '@media(max-widht:300px)': {
+        flex: '1 1 row',
+        width: '$props.size',
+        parsedValue: {
+          type: 'static',
+          content: 'parsed',
+        },
+      },
+
+      // already parsed, should be left untouched
+      '@media(min-widht:300px)': {
+        type: 'nested-style',
+        content: {
+          flex: { type: 'static', content: '1 1 row' },
+          width: { type: 'dynamic', content: { referenceType: 'prop', id: 'size' } },
+          heght: '$props.size',
+        },
+      },
+    }
+
+    const expectedStyle = {
+      '@media(max-widht:300px)': {
+        type: 'nested-style',
+        content: {
+          flex: { type: 'static', content: '1 1 row' },
+          width: { type: 'dynamic', content: { referenceType: 'prop', id: 'size' } },
+          parsedValue: {
+            type: 'static',
+            content: 'parsed',
+          },
+        },
+      },
+
+      '@media(min-widht:300px)': {
+        type: 'nested-style',
+        content: {
+          flex: { type: 'static', content: '1 1 row' },
+          width: { type: 'dynamic', content: { referenceType: 'prop', id: 'size' } },
+          heght: { type: 'dynamic', content: { referenceType: 'prop', id: 'size' } },
+        },
+      },
+    }
+
+    expect(transformStylesAssignmentsToJson(nestedStyle)).toEqual(expectedStyle)
   })
 })

--- a/src/shared/utils/uidl-utils.ts
+++ b/src/shared/utils/uidl-utils.ts
@@ -260,3 +260,98 @@ export const isUIDLStaticReference = (jsonObject: Record<string, unknown> | stri
 
   return false
 }
+
+/**
+ * Transform properties like
+ * $props.something
+ * $local.something
+ * $state.something
+ *
+ * Into their json alternative which is used in beta release/0.6 and
+ * later.
+ */
+export const transformStringAssignmentToJson = (
+  declaration: string | number
+): UIDLNodeStyleValue | UIDLNodeAttributeValue => {
+  if (typeof declaration === 'number') {
+    return {
+      type: 'static',
+      content: declaration,
+    }
+  }
+
+  const parts = declaration.split('.')
+  const prefix = parts[0]
+  const path = parts.slice(1).join('.')
+
+  if (['$props', '$state', '$local'].indexOf(prefix) !== -1) {
+    let referenceType: 'prop' | 'state' | 'local' = 'prop'
+    if (prefix !== '$props') {
+      referenceType = prefix.replace('$', '') as 'state' | 'local'
+    }
+    return {
+      type: 'dynamic',
+      content: {
+        referenceType,
+        id: path,
+      },
+    }
+  }
+
+  return {
+    type: 'static',
+    content: declaration,
+  }
+}
+
+export const transformStylesAssignmentsToJson = (
+  styleObject: Record<string, unknown>
+): UIDLStyleDefinitions => {
+  const newStyleObject: UIDLStyleDefinitions = {}
+
+  Object.keys(styleObject).reduce((acc, key) => {
+    const styleContentAtKey = styleObject[key]
+    const entityType = typeof styleContentAtKey
+
+    if (['string', 'number'].indexOf(entityType) !== -1) {
+      acc[key] = transformStringAssignmentToJson(styleContentAtKey as string | number)
+      return acc
+    }
+
+    if (!Array.isArray(styleContentAtKey) && entityType === 'object') {
+      // if this value is already properly declared, make sure it is not
+      const { type, content } = styleContentAtKey as Record<string, unknown>
+
+      if (['dynamic', 'static'].indexOf(type as string) !== -1) {
+        acc[key] = styleContentAtKey as UIDLNodeAttributeValue
+        return acc
+      }
+
+      if (type === 'nested-style') {
+        acc[key] = {
+          type: 'nested-style',
+          content: transformStylesAssignmentsToJson(content as Record<string, unknown>),
+        }
+        return acc
+      }
+
+      // if the supported types of objects did not match the previous if statement
+      // we are ready to begin parsing a new nested style
+      acc[key] = {
+        type: 'nested-style',
+        content: transformStylesAssignmentsToJson(styleContentAtKey as Record<string, unknown>),
+      }
+      return acc
+    }
+
+    throw new Error(
+      `transformStylesAssignmentsToJson encountered a style value that is not supported ${JSON.stringify(
+        styleContentAtKey,
+        null,
+        2
+      )}`
+    )
+  }, newStyleObject)
+
+  return newStyleObject
+}

--- a/src/shared/utils/uidl-utils.ts
+++ b/src/shared/utils/uidl-utils.ts
@@ -355,3 +355,48 @@ export const transformStylesAssignmentsToJson = (
 
   return newStyleObject
 }
+
+export const transformAttributesAssignmentsToJson = (
+  attributesObject: Record<string, unknown>
+): Record<string, UIDLNodeAttributeValue> => {
+  const newStyleObject: Record<string, UIDLNodeAttributeValue> = {}
+
+  Object.keys(attributesObject).reduce((acc, key) => {
+    const attributeContent = attributesObject[key]
+    const entityType = typeof attributeContent
+
+    if (['string', 'number'].indexOf(entityType) !== -1) {
+      acc[key] = transformStringAssignmentToJson(attributeContent as
+        | string
+        | number) as UIDLNodeAttributeValue
+      return acc
+    }
+
+    if (!Array.isArray(attributeContent) && entityType === 'object') {
+      // if this value is already properly declared, make sure it is not
+      const { type } = attributeContent as Record<string, unknown>
+      if (['dynamic', 'static'].indexOf(type as string) !== -1) {
+        acc[key] = attributeContent as UIDLNodeAttributeValue
+        return acc
+      }
+
+      throw new Error(
+        `transformAttributesAssignmentsToJson encountered a style value that is not supported ${JSON.stringify(
+          attributeContent,
+          null,
+          2
+        )}`
+      )
+    }
+
+    throw new Error(
+      `transformAttributesAssignmentsToJson encountered a style value that is not supported ${JSON.stringify(
+        attributeContent,
+        null,
+        2
+      )}`
+    )
+  }, newStyleObject)
+
+  return newStyleObject
+}


### PR DESCRIPTION
Re: #118 

Adds a few utility methods for transforming old UIDL values with $props and strings to the new JSON based definitions. They come with unit tests for them. 

The children mapping function is left. Requires changes from @alexnm first. 