### PR TITLE
WIP: Feature/#112 object referinging in dynamic assignments

### DIFF
--- a/__tests__/integration/component-assignemnts/attribute-value.ts
+++ b/__tests__/integration/component-assignemnts/attribute-value.ts
@@ -1,5 +1,5 @@
 // @ts-ignore-next-line
-// import ComponentWithInValidPropsJSON from './component-with-invalid-attr-prop.json'
+import ComponentWithInValidPropsJSON from './component-with-invalid-attr-prop.json'
 // @ts-ignore-next-line
 import ComponentWithValidPropsJSON from './component-with-valid-attr-prop.json'
 // @ts-ignore-next-line
@@ -8,7 +8,7 @@ import ComponentWithRepeatPropsJSON from './component-with-repeat.json'
 import { createReactComponentGenerator, createVueComponentGenerator } from '../../../src'
 
 const ComponentWithValidProps = ComponentWithValidPropsJSON as ComponentUIDL
-// const ComponentWithInValidProps = ComponentWithInValidPropsJSON as ComponentUIDL
+const ComponentWithInValidProps = (ComponentWithInValidPropsJSON as unknown) as ComponentUIDL
 const ComponentWithRepeatProps = ComponentWithRepeatPropsJSON as ComponentUIDL
 
 describe('React Props in Component', () => {
@@ -26,13 +26,13 @@ describe('React Props in Component', () => {
       expect(result.code).toContain('test={index}>')
     })
 
-    // it('should fail to add old style attributes on component', async () => {
-    //   const operation = generator.generateComponent(ComponentWithInValidProps, {
-    //     skipValidation: true,
-    //   })
+    it('should fail to add old style attributes on component', async () => {
+      const operation = generator.generateComponent(ComponentWithInValidProps, {
+        skipValidation: true,
+      })
 
-    //   await expect(operation).rejects.toThrow(Error)
-    // })
+      await expect(operation).rejects.toThrow(Error)
+    })
   })
 })
 
@@ -53,11 +53,11 @@ describe('Vue Props in Component Generator', () => {
       expect(result.code).toContain(':test="index"')
     })
 
-    // it('should fail to add old style attributes on component', async () => {
-    //   const operation = generator.generateComponent(ComponentWithInValidProps, {
-    //     skipValidation: true,
-    //   })
-    //   await expect(operation).rejects.toThrow(Error)
-    // })
+    it('should fail to add old style attributes on component', async () => {
+      const operation = generator.generateComponent(ComponentWithInValidProps, {
+        skipValidation: true,
+      })
+      await expect(operation).rejects.toThrow(Error)
+    })
   })
 })

--- a/__tests__/integration/component-assignemnts/attribute-value.ts
+++ b/__tests__/integration/component-assignemnts/attribute-value.ts
@@ -18,6 +18,7 @@ describe('React Props in Component', () => {
     it('should add attributes on component', async () => {
       const result = await generator.generateComponent(ComponentWithValidProps)
       expect(result.code).toContain('props.test')
+      expect(result.code).toContain('props.content.heading')
     })
 
     it('should run repeat attributes and data source', async () => {
@@ -45,6 +46,9 @@ describe('Vue Props in Component Generator', () => {
       expect(result.code).toContain(':data-test')
       expect(result.code).not.toContain(':data-static')
       expect(result.code).toContain('data-static')
+      expect(result.code).toContain('content.heading')
+      expect(result.code).toContain('content: {')
+      expect(result.code).toContain('heading: ')
     })
 
     it('should run repeat attributes and data source', async () => {

--- a/__tests__/integration/component-assignemnts/component-with-valid-attr-prop.json
+++ b/__tests__/integration/component-assignemnts/component-with-valid-attr-prop.json
@@ -5,6 +5,12 @@
     "test": {
       "type": "string",
       "defaultValue": "123"
+    },
+    "content": {
+      "type": "object",
+      "defaultValue": {
+        "heading": "Hello World"
+      }
     }
   },
   "content": {
@@ -20,6 +26,13 @@
       "data-static": {
         "type": "static",
         "content": "I am just a static string"
+      },
+      "data-inner-value": {
+        "type": "dynamic",
+        "content": {
+          "referenceType":"prop",
+          "id": "content.heading"
+        }
       }
     },
     "children": []

--- a/src/plugins/teleport-plugin-vue-base-component/utils.ts
+++ b/src/plugins/teleport-plugin-vue-base-component/utils.ts
@@ -199,9 +199,16 @@ const createVuePropsDefinition = (uidlPropDefinitions: Record<string, PropDefini
       case 'array':
         mappedType = Array
         break
+      case 'object':
+        mappedType = Object
+        break
       default:
         // don't handle anything else
-        return acc
+        throw new Error(
+          `createVuePropsDefinition encountered a unknown PropDefinition, ${JSON.stringify(
+            uidlPropDefinitions[name]
+          )}`
+        )
     }
 
     acc[name] = defaultValue ? { type: mappedType, default: defaultValue } : mappedType

--- a/src/shared/utils/ast-js-utils.ts
+++ b/src/shared/utils/ast-js-utils.ts
@@ -30,6 +30,8 @@ export const objectToObjectExpression = (objectMap: { [key: string]: any }, t = 
       computedLiteralValue = t.arrayExpression(
         value.map((element) => convertValueToLiteral(element))
       )
+    } else if (value === Object) {
+      computedLiteralValue = t.identifier('Object')
     } else if (typeof value === 'object') {
       computedLiteralValue = objectToObjectExpression(value, t)
     } else if (value === String) {


### PR DESCRIPTION
Allows for assignments like:

```
"data-inner-value": {
        "type": "dynamic",
        "content": {
          "referenceType":"prop",
          "id": "content.heading"
        }
      }
```

in both vue and react generators