### PR TITLE
refactor(Better project error): Full stack trace log

### DIFF
--- a/src/shared/utils/project-utils.ts
+++ b/src/shared/utils/project-utils.ts
@@ -229,7 +229,7 @@ export const createComponentOutputs = async (
     files = compiledComponent.files
     dependencies = compiledComponent.dependencies
   } catch (error) {
-    console.warn(`Error on generating "${componentUIDL.name}" component\n`, error)
+    console.warn(`Error on generating "${componentUIDL.name}" component\n`, error.stack)
   }
 
   return { files, dependencies }


### PR DESCRIPTION
The project generator errors only logged the name of the error, not what happened and where. This is a one liner that helps me see better errors.