### PR TITLE
refactor(generator-core): Schema to support array as  a default value

### DIFF
--- a/packages/teleport-generator-core/src/uidl-schemas/component.json
+++ b/packages/teleport-generator-core/src/uidl-schemas/component.json
@@ -54,7 +54,24 @@
               "type": "string",
               "enum": ["string", "boolean", "number", "array", "func", "object", "children"]
             },
-            "defaultValue": {},
+            "defaultValue": {
+              "oneOf": [
+                { "type": "number" },
+                { "type": "boolean" },
+                { "type": "string" },
+                { "type": "object" }, 
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "type": "number" },
+                      { "type": "string" },
+                      { "type": "object" }
+                    ]
+                  }
+                }
+              ]
+            },
             "meta": {"type": "object"}
           }
         }


### PR DESCRIPTION

fixes #12

This is the example that i generated after assigning arraya

~~~
SimpleComponent.defaultProps = {
  test: [
    {
      name: 'sdnfdksjfn',
    },
    {
      number: 'dsfndsn',
    },
  ],
}

SimpleComponent.propTypes = {
  test: PropTypes.array,
}
~~~