### PR TITLE
feat(navlinks): transitionTo can now refer to the state key, not the url

### DIFF
--- a/examples/uidl-samples/project.json
+++ b/examples/uidl-samples/project.json
@@ -199,7 +199,7 @@
               "content": {
                 "elementType": "navlink",
                 "attrs": {
-                  "transitionTo": "/"
+                  "transitionTo": "index"
                 },
                 "children": [
                   {
@@ -214,7 +214,7 @@
               "content": {
                 "elementType": "navlink",
                 "attrs": {
-                  "transitionTo": "/about"
+                  "transitionTo": "about"
                 },
                 "children": [
                   {
@@ -229,7 +229,7 @@
               "content": {
                 "elementType": "navlink",
                 "attrs": {
-                  "transitionTo": "/here-we-are"
+                  "transitionTo": "contact-us"
                 },
                 "children": [
                   {

--- a/packages/teleport-generator-core/src/resolver/index.ts
+++ b/packages/teleport-generator-core/src/resolver/index.ts
@@ -38,6 +38,11 @@ export default class Resolver {
     }
 
     const node = cloneObject(uidl.node)
+
+    if (options.projectRouteDefinition) {
+      utils.resolveNavlinks(node, options.projectRouteDefinition)
+    }
+
     utils.resolveNode(node, newOptions)
 
     const nodesLookup = {}

--- a/packages/teleport-generator-shared/src/typings/generators.ts
+++ b/packages/teleport-generator-shared/src/typings/generators.ts
@@ -6,6 +6,7 @@ import {
   UIDLElement,
   UIDLNode,
   UIDLAttributeValue,
+  UIDLStateDefinition,
 } from './uidl'
 
 export type ChunkContent = string | any | any[]
@@ -64,6 +65,7 @@ export interface GeneratorOptions {
   assetsPrefix?: string
   mapping?: Mapping
   skipValidation?: boolean
+  projectRouteDefinition?: UIDLStateDefinition
 }
 
 export type CodeGeneratorFunction<T> = (content: T) => string
@@ -114,11 +116,7 @@ export interface GeneratedFile {
 export interface ComponentFactoryParams {
   componentGenerator: ComponentGenerator
   componentUIDL: ComponentUIDL
-  componentOptions: {
-    assetsPrefix: string
-    localDependenciesPrefix?: string
-    skipValidation?: boolean
-  }
+  generatorOptions: GeneratorOptions
   metadataOptions?: {
     usePathAsFileName?: boolean
     convertDefaultToIndex?: boolean

--- a/packages/teleport-generator-shared/src/utils/project-utils.ts
+++ b/packages/teleport-generator-shared/src/utils/project-utils.ts
@@ -205,14 +205,14 @@ export const createPageOutputs = async (
 export const createComponentOutputs = async (
   params: ComponentFactoryParams
 ): Promise<ComponentGeneratorOutput> => {
-  const { componentGenerator, componentUIDL, componentOptions } = params
+  const { componentGenerator, componentUIDL, generatorOptions } = params
 
   let files: GeneratedFile[] = []
   let dependencies: Record<string, string> = {}
 
   try {
     const compiledComponent = await componentGenerator.generateComponent(componentUIDL, {
-      ...componentOptions,
+      ...generatorOptions,
       skipValidation: true,
     })
 

--- a/packages/teleport-project-generator-react-basic/src/index.ts
+++ b/packages/teleport-project-generator-react-basic/src/index.ts
@@ -72,9 +72,10 @@ const createReactBasicGenerator = (generatorOptions: ProjectGeneratorOptions = {
       const pageParams: ComponentFactoryParams = {
         componentGenerator: reactGenerator,
         componentUIDL,
-        componentOptions: {
+        generatorOptions: {
           assetsPrefix: ASSETS_PREFIX,
           localDependenciesPrefix: LOCAL_DEPENDENCIES_PREFIX,
+          projectRouteDefinition: root.stateDefinitions.route,
         },
       }
       return createPageOutputs(pageParams)
@@ -86,7 +87,10 @@ const createReactBasicGenerator = (generatorOptions: ProjectGeneratorOptions = {
       const componentParams: ComponentFactoryParams = {
         componentGenerator: reactGenerator,
         componentUIDL,
-        componentOptions: { assetsPrefix: ASSETS_PREFIX },
+        generatorOptions: {
+          assetsPrefix: ASSETS_PREFIX,
+          projectRouteDefinition: root.stateDefinitions.route,
+        },
       }
       return createComponentOutputs(componentParams)
     })

--- a/packages/teleport-project-generator-react-next/src/index.ts
+++ b/packages/teleport-project-generator-react-next/src/index.ts
@@ -71,9 +71,10 @@ const createReactNextGenerator = (generatorOptions: ProjectGeneratorOptions = {}
       const pageParams: ComponentFactoryParams = {
         componentGenerator: reactGenerator,
         componentUIDL,
-        componentOptions: {
+        generatorOptions: {
           assetsPrefix: ASSETS_PREFIX,
           localDependenciesPrefix: LOCAL_DEPENDENCIES_PREFIX,
+          projectRouteDefinition: root.stateDefinitions.route,
         },
         metadataOptions: {
           usePathAsFileName: true,
@@ -89,7 +90,10 @@ const createReactNextGenerator = (generatorOptions: ProjectGeneratorOptions = {}
       const componentParams: ComponentFactoryParams = {
         componentUIDL,
         componentGenerator: reactGenerator,
-        componentOptions: { assetsPrefix: ASSETS_PREFIX },
+        generatorOptions: {
+          assetsPrefix: ASSETS_PREFIX,
+          projectRouteDefinition: root.stateDefinitions.route,
+        },
       }
       return createComponentOutputs(componentParams)
     })

--- a/packages/teleport-project-generator-vue-basic/src/index.ts
+++ b/packages/teleport-project-generator-vue-basic/src/index.ts
@@ -66,9 +66,10 @@ const createVueBasicGenerator = (generatorOptions: ProjectGeneratorOptions = {})
       const pageParams: ComponentFactoryParams = {
         componentGenerator: vueGenerator,
         componentUIDL,
-        componentOptions: {
+        generatorOptions: {
           assetsPrefix: ASSETS_PREFIX,
           localDependenciesPrefix: LOCAL_DEPENDENCIES_PREFIX,
+          projectRouteDefinition: root.stateDefinitions.route,
         },
       }
       return createPageOutputs(pageParams)
@@ -80,7 +81,10 @@ const createVueBasicGenerator = (generatorOptions: ProjectGeneratorOptions = {})
       const componentParams: ComponentFactoryParams = {
         componentUIDL,
         componentGenerator: vueGenerator,
-        componentOptions: { assetsPrefix: ASSETS_PREFIX },
+        generatorOptions: {
+          assetsPrefix: ASSETS_PREFIX,
+          projectRouteDefinition: root.stateDefinitions.route,
+        },
       }
 
       return createComponentOutputs(componentParams)

--- a/packages/teleport-project-generator-vue-nuxt/src/index.ts
+++ b/packages/teleport-project-generator-vue-nuxt/src/index.ts
@@ -67,9 +67,10 @@ const createVueNuxtGenerator = (generatorOptions: ProjectGeneratorOptions = {}) 
       const pageParams: ComponentFactoryParams = {
         componentGenerator: vueGenerator,
         componentUIDL,
-        componentOptions: {
+        generatorOptions: {
           assetsPrefix: ASSETS_PREFIX,
           localDependenciesPrefix: LOCAL_DEPENDENCIES_PREFIX,
+          projectRouteDefinition: root.stateDefinitions.route,
         },
         metadataOptions: {
           usePathAsFileName: true,
@@ -86,7 +87,10 @@ const createVueNuxtGenerator = (generatorOptions: ProjectGeneratorOptions = {}) 
       const componentParams: ComponentFactoryParams = {
         componentUIDL,
         componentGenerator: vueGenerator,
-        componentOptions: { assetsPrefix: ASSETS_PREFIX },
+        generatorOptions: {
+          assetsPrefix: ASSETS_PREFIX,
+          projectRouteDefinition: root.stateDefinitions.route,
+        },
       }
       return createComponentOutputs(componentParams)
     })


### PR DESCRIPTION
this is solved at resolve time, based on the state definitions of the route key, which are
accompanied by a meta.path field

closes #189