### PR TITLE
chore(lerna.json): Added scripts for version bumping and releases

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,6 +5,12 @@
   "version": "0.6.0",
   "useWorkspaces": true,
   "npmClient": "yarn",
+  "command": {
+    "version": {
+      "allowBranch": "master",
+      "message": "chore(release): 'publish %s'"
+    }
+  },
   "changelog": {
     "repo": "teleporthq/teleport-code-generators",
     "cacheDir": ".changelog",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "upload:coverage": "codecov",
     "commitizen": "git-cz",
     "add-contributor": "all-contributors add",
-    "publish": "lerna run publish",
+    "changelog": "lerna-changelog",
+    "version": "lerna version",
+    "publish": "lerna publish from-git",
     "local:publish": "lerna exec -- npm publish --registry http://localhost:4873",
     "local:unpublish": "lerna exec -- npm unpublish -f --registry http://localhost:4873"
   },


### PR DESCRIPTION
1. Run ``npm run version`` for bumping version and pushing to github.
2. Run ``npm run publish`` for publishing the packages to npm by taking them from github.

### Changelog
For changelog, run ``npm run changelog``
For generating changelog from the beginning of the project ``npm run changelog:start``

The newly added ``command/version/message`` attributes adds the message to the commit by following the commitzen principles, which makes it blend with other commit messages. 😃 