### PR TITLE
Fix/project.json

### DIFF
--- a/examples/uidl-samples/project.json
+++ b/examples/uidl-samples/project.json
@@ -4,7 +4,7 @@
   "globals": {
     "settings": {
       "language": "en",
-      "title": "UIDL v0.6 Project"
+      "title": "UIDL v0.7 Project"
     },
     "assets": [],
     "meta": []
@@ -192,7 +192,7 @@
       "node": {
         "type": "element",
         "content": {
-          "elementType": "group",
+          "elementType": "container",
           "children": [
             {
               "type": "element",
@@ -553,7 +553,7 @@
       "node": {
         "type": "element",
         "content": {
-          "elementType": "group",
+          "elementType": "container",
           "children": [
             {
               "type": "element",


### PR DESCRIPTION
The `vue-mapping` currently maps `group` to `template`, so the current UIDL is resulting in creating one more `template` tag apart from the parent. Which are not being rendered when we try to execut. So changed them to `container` so it generates `div` instead.

Here is the result that is generated with the current UIDL --> https://github.com/JayaKrishnaNamburu/teleport-github-packer-test/blob/master/components/navbar.vue#L2