### PR TITLE
fix(uidl/comp): Validating content if the parent type is static

### DIFF
--- a/packages/teleport-uidl-validator/src/uidl-schemas/component.json
+++ b/packages/teleport-uidl-validator/src/uidl-schemas/component.json
@@ -142,6 +142,20 @@
                 "$ref": "#/definitions/slotNodeContent"
               }]
             }
+          },
+          "if": {
+            "properties": {
+              "type": {
+                "const": "static"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "content": {
+                "$ref": "#/definitions/staticValueContent" 
+              }
+            }
           }
         }
       ]


### PR DESCRIPTION
fixes #258