### PR TITLE
fix(uidl): filename derived from sanitized component name

### DIFF
--- a/packages/teleport-component-generator/src/index.ts
+++ b/packages/teleport-component-generator/src/index.ts
@@ -70,7 +70,7 @@ export const createComponentGenerator = (
       codeChunks = processor(codeChunks)
     })
 
-    const fileName = getComponentFileName(uidl)
+    const fileName = getComponentFileName(resolvedUIDL)
     const files = fileBundler(fileName, codeChunks)
 
     return {

--- a/packages/teleport-uidl-validator/src/uidl-schemas/component.json
+++ b/packages/teleport-uidl-validator/src/uidl-schemas/component.json
@@ -266,7 +266,7 @@
       "additionalProperties": false,
       "properties": {
         "additionalProperties": false,
-        "elementType": {"type": "string"},
+        "elementType": {"type": "string", "pattern": "^([a-zA-Z0-9])*$"},
         "name": {"type": "string"},
         "key": {"type": "string"},
         "dependency": {"$ref": "#/definitions/componentDependency"},


### PR DESCRIPTION
the filename is now taken from the sanitized uidl name. also added a restriction on the elementType
to allow only alphanumeric characters, since the name is taken as a import variable when using
dependencies

fix #235