### PR TITLE
refactor(shared): renames, reusability, tests, cleanup, etc.

### DIFF
--- a/packages/teleport-component-generator/src/builder/generators/js-ast-to-code.ts
+++ b/packages/teleport-component-generator/src/builder/generators/js-ast-to-code.ts
@@ -1,8 +1,8 @@
 import babelGenerator from '@babel/generator'
-import * as types from '@babel/types'
+import { Node } from '@babel/types'
 
 import { CodeGeneratorFunction } from '@teleporthq/teleport-types'
 
-export const generator: CodeGeneratorFunction<types.Node> = (ast) => {
+export const generator: CodeGeneratorFunction<Node> = (ast) => {
   return babelGenerator(ast).code
 }

--- a/packages/teleport-plugin-import-statements/src/index.ts
+++ b/packages/teleport-plugin-import-statements/src/index.ts
@@ -4,6 +4,7 @@ import {
   ComponentPlugin,
   ChunkDefinition,
   ComponentDependency,
+  ImportIdentifier,
 } from '@teleporthq/teleport-types'
 import { FILE_TYPE } from '@teleporthq/teleport-shared/lib/constants'
 
@@ -38,17 +39,11 @@ export const createPlugin: ComponentPluginFactory<ImportPluginConfig> = (config)
 
 export default createPlugin()
 
-interface ImportDependency {
-  identifier: string
-  namedImport: boolean
-  originalName: string
-}
-
 const groupDependenciesByPackage = (
   dependencies: Record<string, ComponentDependency>,
   packageType?: string
 ) => {
-  const result: Record<string, ImportDependency[]> = {}
+  const result: Record<string, ImportIdentifier[]> = {}
 
   Object.keys(dependencies)
     .filter((key) => (packageType && dependencies[key].type === packageType) || !packageType)
@@ -68,7 +63,7 @@ const groupDependenciesByPackage = (
       const originalName = dep.meta && dep.meta.originalName ? dep.meta.originalName : key
 
       result[dep.path].push({
-        identifier: key,
+        identifierName: key,
         namedImport,
         originalName,
       })
@@ -79,7 +74,7 @@ const groupDependenciesByPackage = (
 
 const addImportChunk = (
   chunks: ChunkDefinition[],
-  dependencies: Record<string, ImportDependency[]>,
+  dependencies: Record<string, ImportIdentifier[]>,
   newChunkName: string,
   fileId: string | null
 ) => {

--- a/packages/teleport-plugin-react-app-routing/package.json
+++ b/packages/teleport-plugin-react-app-routing/package.json
@@ -24,7 +24,6 @@
     "build:watch:component": "tsc -w"
   },
   "dependencies": {
-    "@babel/types": "^7.3.3",
     "@teleporthq/teleport-shared": "^0.8.1",
     "@teleporthq/teleport-types": "^0.8.1"
   }

--- a/packages/teleport-plugin-react-app-routing/src/utils.ts
+++ b/packages/teleport-plugin-react-app-routing/src/utils.ts
@@ -1,4 +1,3 @@
-import * as t from '@babel/types'
 import { ComponentDependency } from '@teleporthq/teleport-types'
 
 export const registerRouterDeps = (dependencies: Record<string, ComponentDependency>): void => {
@@ -32,18 +31,4 @@ export const registerRouterDeps = (dependencies: Record<string, ComponentDepende
       namedImport: true,
     },
   }
-}
-
-export const makePureComponent = (params: { name: string; jsxTagTree: t.JSXElement }) => {
-  const { name, jsxTagTree } = params
-  const returnStatement = t.returnStatement(jsxTagTree)
-  const arrowFunction = t.arrowFunctionExpression(
-    [t.identifier('props')],
-    t.blockStatement([returnStatement] || [])
-  )
-
-  const declarator = t.variableDeclarator(t.identifier(name), arrowFunction)
-  const component = t.variableDeclaration('const', [declarator])
-
-  return component
 }

--- a/packages/teleport-plugin-react-base-component/src/node-handlers.ts
+++ b/packages/teleport-plugin-react-base-component/src/node-handlers.ts
@@ -25,7 +25,7 @@ import {
   addChildJSXTag,
 } from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
 
-import { generateASTDefinitionForJSXTag } from '@teleporthq/teleport-shared/lib/builders/ast-builders'
+import { createJSXTag } from '@teleporthq/teleport-shared/lib/builders/ast-builders'
 
 import { ERROR_LOG_NAME } from './constants'
 
@@ -66,7 +66,7 @@ export const generateNodeSyntax: NodeSyntaxGenerator<
 const generateElementNode = (node: UIDLElementNode, accumulators: ReactComponentAccumulators) => {
   const { dependencies, stateDefinitions, propDefinitions, nodesLookup } = accumulators
   const { elementType, children, key, attrs, dependency, events } = node.content
-  const elementTag = generateASTDefinitionForJSXTag(elementType)
+  const elementTag = createJSXTag(elementType)
 
   if (attrs) {
     Object.keys(attrs).forEach((attrKey) => {

--- a/packages/teleport-plugin-react-base-component/src/utils.ts
+++ b/packages/teleport-plugin-react-base-component/src/utils.ts
@@ -3,7 +3,7 @@ import * as types from '@babel/types'
 import { convertValueToLiteral } from '@teleporthq/teleport-shared/lib/utils/ast-js-utils'
 import {
   addAttributeToJSXTag,
-  addDynamicAttributeOnTag,
+  addDynamicAttributeToJSXTag,
 } from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
 import { capitalize } from '@teleporthq/teleport-shared/lib/utils/string-utils'
 import { getRepeatIteratorNameAndKey } from '@teleporthq/teleport-shared/lib/utils/uidl-utils'
@@ -193,11 +193,11 @@ export const addAttributeToNode: AttributeAssignCodeMod<types.JSXElement> = (
         content: { id },
       } = attributeValue
       const prefix = getReactVarNameForDynamicReference(attributeValue)
-      addDynamicAttributeOnTag(tag, attributeKey, id, prefix)
+      addDynamicAttributeToJSXTag(tag, attributeKey, id, prefix)
       return
     case 'static':
       const { content } = attributeValue
-      addAttributeToJSXTag(tag, { name: attributeKey, value: content })
+      addAttributeToJSXTag(tag, attributeKey, content)
       return
     default:
       throw new Error(

--- a/packages/teleport-plugin-react-css-modules/package.json
+++ b/packages/teleport-plugin-react-css-modules/package.json
@@ -24,7 +24,6 @@
     "build:watch:component": "tsc -w"
   },
   "dependencies": {
-    "@babel/types": "^7.3.3",
     "@teleporthq/teleport-shared": "^0.8.1",
     "@teleporthq/teleport-types": "^0.8.1"
   }

--- a/packages/teleport-plugin-react-inline-styles/package.json
+++ b/packages/teleport-plugin-react-inline-styles/package.json
@@ -24,7 +24,6 @@
     "build:watch:component": "tsc -w"
   },
   "dependencies": {
-    "@babel/types": "^7.3.3",
     "@teleporthq/teleport-shared": "^0.8.1",
     "@teleporthq/teleport-types": "^0.8.1"
   }

--- a/packages/teleport-plugin-react-inline-styles/src/index.ts
+++ b/packages/teleport-plugin-react-inline-styles/src/index.ts
@@ -1,7 +1,5 @@
-import * as t from '@babel/types'
-
-import { addJSXTagStyles } from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
-import { ParsedASTNode } from '@teleporthq/teleport-shared/lib/utils/ast-js-utils'
+import { addAttributeToJSXTag } from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
+import { createDynamicStyleExpression } from '@teleporthq/teleport-shared/lib/builders/css-builders'
 import {
   cleanupNestedStyles,
   transformDynamicStyles,
@@ -39,15 +37,11 @@ export const createPlugin: ComponentPluginFactory<InlineStyleConfig> = (config) 
 
         // Nested styles are ignored
         const rootStyles = cleanupNestedStyles(style)
-        const inlineStyles = transformDynamicStyles(rootStyles, (styleValue) => {
-          const expression =
-            styleValue.content.referenceType === 'state'
-              ? t.identifier(styleValue.content.id)
-              : t.memberExpression(t.identifier('props'), t.identifier(styleValue.content.id))
-          return new ParsedASTNode(expression)
-        })
+        const inlineStyles = transformDynamicStyles(rootStyles, (styleValue) =>
+          createDynamicStyleExpression(styleValue)
+        )
 
-        addJSXTagStyles(jsxASTTag, inlineStyles)
+        addAttributeToJSXTag(jsxASTTag, 'style', inlineStyles)
       }
     })
 

--- a/packages/teleport-plugin-react-jss/package.json
+++ b/packages/teleport-plugin-react-jss/package.json
@@ -24,7 +24,6 @@
     "build:watch:component": "tsc -w"
   },
   "dependencies": {
-    "@babel/types": "^7.3.3",
     "@teleporthq/teleport-shared": "^0.8.1",
     "@teleporthq/teleport-types": "^0.8.1"
   }

--- a/packages/teleport-plugin-react-jss/src/utils.ts
+++ b/packages/teleport-plugin-react-jss/src/utils.ts
@@ -1,9 +1,0 @@
-import * as t from '@babel/types'
-
-export const makeJSSDefaultExport = (componentName: string, stylesName: string) => {
-  return t.exportDefaultDeclaration(
-    t.callExpression(t.callExpression(t.identifier('injectSheet'), [t.identifier(stylesName)]), [
-      t.identifier(componentName),
-    ])
-  )
-}

--- a/packages/teleport-plugin-react-styled-components/src/index.ts
+++ b/packages/teleport-plugin-react-styled-components/src/index.ts
@@ -5,8 +5,11 @@ import {
   transformDynamicStyles,
 } from '@teleporthq/teleport-shared/lib/utils/uidl-utils'
 import { dashCaseToUpperCamelCase } from '@teleporthq/teleport-shared/lib/utils/string-utils'
-import { addDynamicAttributeOnTag } from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
-import { createJSXSpreadAttribute } from '@teleporthq/teleport-shared/lib/builders/ast-builders'
+import {
+  addDynamicAttributeToJSXTag,
+  addSpreadAttributeToJSXTag,
+  renameJSXTag,
+} from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
 
 interface StyledComponentsConfig {
   componentChunkName: string
@@ -38,7 +41,7 @@ export const createPlugin: ComponentPluginFactory<StyledComponentsConfig> = (con
           if (styleValue.content.referenceType === 'prop') {
             switch (timesReferred) {
               case 1:
-                addDynamicAttributeOnTag(root, attribute, styleValue.content.id, 'props')
+                addDynamicAttributeToJSXTag(root, attribute, styleValue.content.id, 'props')
                 return `\$\{props => props.${attribute}\}`
               default:
                 return `\$\{props => props.${styleValue.content.id}\}`
@@ -51,10 +54,10 @@ export const createPlugin: ComponentPluginFactory<StyledComponentsConfig> = (con
         })
 
         if (timesReferred > 1) {
-          root.openingElement.attributes.push(createJSXSpreadAttribute('props'))
+          addSpreadAttributeToJSXTag(root, 'props')
         }
 
-        root.openingElement.name.name = className
+        renameJSXTag(root, className)
 
         const code = {
           type: 'js',

--- a/packages/teleport-plugin-react-styled-jsx/__tests__/utils.ts
+++ b/packages/teleport-plugin-react-styled-jsx/__tests__/utils.ts
@@ -1,0 +1,13 @@
+import { generateStyledJSXTag } from '../src/utils'
+
+describe('generateStyledJSXTag', () => {
+  it('returns JSXTag', () => {
+    const result = generateStyledJSXTag('randomString')
+
+    expect(result.type).toBe('JSXElement')
+    expect(result.openingElement.type).toBe('JSXOpeningElement')
+    expect(result.openingElement.name).toHaveProperty('name', 'style')
+    expect(result.closingElement.type).toBe('JSXClosingElement')
+    expect(result.closingElement.name).toHaveProperty('name', 'style')
+  })
+})

--- a/packages/teleport-plugin-react-styled-jsx/src/index.ts
+++ b/packages/teleport-plugin-react-styled-jsx/src/index.ts
@@ -1,5 +1,4 @@
 import { addClassStringOnJSXTag } from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
-import { generateStyledJSXTag } from '@teleporthq/teleport-shared/lib/builders/ast-builders'
 import { camelCaseToDashCase } from '@teleporthq/teleport-shared/lib/utils/string-utils'
 import {
   transformDynamicStyles,
@@ -8,6 +7,7 @@ import {
 } from '@teleporthq/teleport-shared/lib/utils/uidl-utils'
 import { createCSSClass } from '@teleporthq/teleport-shared/lib/builders/css-builders'
 import { ComponentPluginFactory, ComponentPlugin } from '@teleporthq/teleport-types'
+import { generateStyledJSXTag } from './utils'
 
 interface StyledJSXConfig {
   componentChunkName: string

--- a/packages/teleport-plugin-react-styled-jsx/src/utils.ts
+++ b/packages/teleport-plugin-react-styled-jsx/src/utils.ts
@@ -1,0 +1,19 @@
+import {
+  stringAsTemplateLiteral,
+  addAttributeToJSXTag,
+  addChildJSXText,
+} from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
+
+import {
+  createJSXTag,
+  createJSXExpresionContainer,
+} from '@teleporthq/teleport-shared/lib/builders/ast-builders'
+
+export const generateStyledJSXTag = (content: string) => {
+  const templateLiteral = stringAsTemplateLiteral(content)
+  const styleContent = createJSXExpresionContainer(templateLiteral)
+  const styleTag = createJSXTag('style', [styleContent])
+  addChildJSXText(styleTag, '\n') // for better formatting
+  addAttributeToJSXTag(styleTag, 'jsx')
+  return styleTag
+}

--- a/packages/teleport-project-generator-react-next/src/utils.ts
+++ b/packages/teleport-project-generator-react-next/src/utils.ts
@@ -3,7 +3,7 @@ import {
   addChildJSXTag,
   addChildJSXText,
 } from '@teleporthq/teleport-shared/lib/utils/ast-jsx-utils'
-import { generateASTDefinitionForJSXTag } from '@teleporthq/teleport-shared/lib/builders/ast-builders'
+import { createJSXTag } from '@teleporthq/teleport-shared/lib/builders/ast-builders'
 
 import * as types from '@babel/types'
 
@@ -15,12 +15,12 @@ import { ProjectUIDL, ChunkDefinition } from '@teleporthq/teleport-types'
 export const createDocumentFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions) => {
   const { settings, meta, assets, manifest } = uidl.globals
 
-  const htmlNode = generateASTDefinitionForJSXTag('html')
-  const headNode = generateASTDefinitionForJSXTag('Head')
-  const bodyNode = generateASTDefinitionForJSXTag('body')
+  const htmlNode = createJSXTag('html')
+  const headNode = createJSXTag('Head')
+  const bodyNode = createJSXTag('body')
 
-  const mainNode = generateASTDefinitionForJSXTag('Main')
-  const nextScriptNode = generateASTDefinitionForJSXTag('NextScript')
+  const mainNode = createJSXTag('Main')
+  const nextScriptNode = createJSXTag('NextScript')
   addChildJSXTag(bodyNode, mainNode)
   addChildJSXTag(bodyNode, nextScriptNode)
 
@@ -28,27 +28,27 @@ export const createDocumentFileChunks = (uidl: ProjectUIDL, options: EntryFileOp
   addChildJSXTag(htmlNode, bodyNode)
 
   if (settings.language) {
-    addAttributeToJSXTag(htmlNode, { name: 'lang', value: settings.language })
+    addAttributeToJSXTag(htmlNode, 'lang', settings.language)
   }
 
   if (settings.title) {
-    const titleTag = generateASTDefinitionForJSXTag('title')
+    const titleTag = createJSXTag('title')
     addChildJSXText(titleTag, settings.title)
     addChildJSXTag(headNode, titleTag)
   }
 
   if (manifest) {
-    const linkTag = generateASTDefinitionForJSXTag('link')
-    addAttributeToJSXTag(linkTag, { name: 'rel', value: 'manifest' })
-    addAttributeToJSXTag(linkTag, { name: 'href', value: '/static/manifest.json' })
+    const linkTag = createJSXTag('link')
+    addAttributeToJSXTag(linkTag, 'rel', 'manifest')
+    addAttributeToJSXTag(linkTag, 'href', '/static/manifest.json')
     addChildJSXTag(headNode, linkTag)
   }
 
   meta.forEach((metaItem) => {
-    const metaTag = generateASTDefinitionForJSXTag('meta')
+    const metaTag = createJSXTag('meta')
     Object.keys(metaItem).forEach((key) => {
       const metaValue = prefixPlaygroundAssetsURL(options.assetsPrefix, metaItem[key])
-      addAttributeToJSXTag(metaTag, { name: key, value: metaValue })
+      addAttributeToJSXTag(metaTag, key, metaValue)
     })
     addChildJSXTag(headNode, metaTag)
   })
@@ -58,39 +58,33 @@ export const createDocumentFileChunks = (uidl: ProjectUIDL, options: EntryFileOp
 
     // link stylesheet (external css, font)
     if ((asset.type === 'style' || asset.type === 'font') && assetPath) {
-      const linkTag = generateASTDefinitionForJSXTag('link')
-      addAttributeToJSXTag(linkTag, { name: 'rel', value: 'stylesheet' })
-      addAttributeToJSXTag(linkTag, { name: 'href', value: assetPath })
+      const linkTag = createJSXTag('link')
+      addAttributeToJSXTag(linkTag, 'rel', 'stylesheet')
+      addAttributeToJSXTag(linkTag, 'href', assetPath)
       addChildJSXTag(headNode, linkTag)
     }
 
     // inline style
     if (asset.type === 'style' && asset.content) {
-      const styleTag = generateASTDefinitionForJSXTag('style')
-      addAttributeToJSXTag(styleTag, {
-        name: 'dangerouslySetInnerHTML',
-        value: { __html: asset.content },
-      })
+      const styleTag = createJSXTag('style')
+      addAttributeToJSXTag(styleTag, 'dangerouslySetInnerHTML', { __html: asset.content })
       addChildJSXTag(headNode, styleTag)
     }
 
     // script (external or inline)
     if (asset.type === 'script') {
-      const scriptTag = generateASTDefinitionForJSXTag('script')
-      addAttributeToJSXTag(scriptTag, { name: 'type', value: 'text/javascript' })
+      const scriptTag = createJSXTag('script')
+      addAttributeToJSXTag(scriptTag, 'type', 'text/javascript')
       if (assetPath) {
-        addAttributeToJSXTag(scriptTag, { name: 'src', value: assetPath })
+        addAttributeToJSXTag(scriptTag, 'src', assetPath)
         if (asset.meta && asset.meta.defer) {
-          addAttributeToJSXTag(scriptTag, { name: 'defer', value: true })
+          addAttributeToJSXTag(scriptTag, 'defer', true)
         }
         if (asset.meta && asset.meta.async) {
-          addAttributeToJSXTag(scriptTag, { name: 'async', value: true })
+          addAttributeToJSXTag(scriptTag, 'async', true)
         }
       } else if (asset.content) {
-        addAttributeToJSXTag(scriptTag, {
-          name: 'dangerouslySetInnerHTML',
-          value: { __html: asset.content },
-        })
+        addAttributeToJSXTag(scriptTag, 'dangerouslySetInnerHTML', { __html: asset.content })
       }
 
       if (asset.meta && asset.meta.target === 'body') {
@@ -102,14 +96,14 @@ export const createDocumentFileChunks = (uidl: ProjectUIDL, options: EntryFileOp
 
     // icon
     if (asset.type === 'icon' && assetPath) {
-      const iconTag = generateASTDefinitionForJSXTag('link')
-      addAttributeToJSXTag(iconTag, { name: 'rel', value: 'shortcut icon' })
-      addAttributeToJSXTag(iconTag, { name: 'href', value: assetPath })
+      const iconTag = createJSXTag('link')
+      addAttributeToJSXTag(iconTag, 'rel', 'shortcut icon')
+      addAttributeToJSXTag(iconTag, 'href', assetPath)
 
       if (typeof asset.meta === 'object') {
         const assetMeta = asset.meta
         Object.keys(assetMeta).forEach((metaKey) => {
-          addAttributeToJSXTag(iconTag, { name: metaKey, value: assetMeta[metaKey] })
+          addAttributeToJSXTag(iconTag, metaKey, assetMeta[metaKey])
         })
       }
 

--- a/packages/teleport-shared/__tests__/builders/ast-builders.ts
+++ b/packages/teleport-shared/__tests__/builders/ast-builders.ts
@@ -1,82 +1,110 @@
 import {
   createDefaultExport,
-  generateStyledJSXTag,
   createConstAssignment,
-  createJSXSpreadAttribute,
   createGenericImportStatement,
-  generateASTDefinitionForJSXTag,
+  createJSXTag,
+  createSelfClosingJSXTag,
+  createFunctionCall,
+  createFunctionalComponent,
 } from '../../src/builders/ast-builders'
+import * as types from '@babel/types'
 
-describe('AST builder', () => {
-  describe('createConstAssignment', () => {
-    it('should creat assignment for a const', () => {
-      const result = createConstAssignment('testConst')
-      expect(result.type).toBe('VariableDeclaration')
-      expect(result.kind).toBe('const')
-      expect(result.declarations[0].type).toBe('VariableDeclarator')
-      expect(result.declarations[0].id.name).toBe('testConst')
-    })
+describe('createConstAssignment', () => {
+  it('should creat assignment for a const', () => {
+    const result = createConstAssignment('testConst')
+    expect(result.type).toBe('VariableDeclaration')
+    expect(result.kind).toBe('const')
+    expect(result.declarations[0].type).toBe('VariableDeclarator')
+    expect((result.declarations[0].id as types.Identifier).name).toBe('testConst')
   })
-  describe('createDefaultExport', () => {
-    it('should creat default export', () => {
-      const result = createDefaultExport('testConst')
-      expect(result.type).toBe('ExportDefaultDeclaration')
-      expect(result.declaration).toHaveProperty('name')
-      expect(result.declaration.name).toBe('testConst')
-    })
+})
+describe('createDefaultExport', () => {
+  it('should creat default export', () => {
+    const result = createDefaultExport('testConst')
+    expect(result.type).toBe('ExportDefaultDeclaration')
+    expect(result.declaration).toHaveProperty('name')
+    expect((result.declaration as types.Identifier).name).toBe('testConst')
+  })
+})
+
+describe('createGenericImportStatement', () => {
+  it('should creat generic import statements', () => {
+    const imports = [
+      { identifierName: 'Card', namedImport: false, originalName: 'Card' },
+      { identifierName: 'React', namedImport: false, originalName: 'React' },
+      { identifierName: 'useState', namedImport: true, originalName: 'useState' },
+    ]
+    const result = createGenericImportStatement('../testConst', imports)
+    expect(result.type).toBe('ImportDeclaration')
+    expect(result.specifiers.length).toEqual(imports.length)
+    expect(result.source).toHaveProperty('value')
+    expect(result.source.value).toBe('../testConst')
+  })
+  it('should creat generic import statements if no import array is provided', () => {
+    const result = createGenericImportStatement('../testConst', [])
+    expect(result.type).toBe('ImportDeclaration')
+    expect(result.source).toHaveProperty('value')
+    expect(result.source.value).toBe('../testConst')
+  })
+})
+
+describe('createJSXTag', () => {
+  it('returns a valid JSX tag', () => {
+    const result = createJSXTag('randomString')
+
+    expect(result.type).toBe('JSXElement')
+    expect(result.openingElement.type).toBe('JSXOpeningElement')
+    expect(result.openingElement.name).toHaveProperty('name', 'randomString')
+    expect(result.closingElement.type).toBe('JSXClosingElement')
+    expect(result.closingElement.name).toHaveProperty('name', 'randomString')
+  })
+})
+
+describe('createSelfClosingJSXTag', () => {
+  it('returns a valid JSX tag', () => {
+    const result = createSelfClosingJSXTag('randomString')
+
+    expect(result.type).toBe('JSXElement')
+    expect(result.openingElement.type).toBe('JSXOpeningElement')
+    expect(result.openingElement.name).toHaveProperty('name', 'randomString')
+    expect(result.selfClosing).toBe(true)
+  })
+})
+
+describe('createFunctionCall', () => {
+  it('works with no arguments', () => {
+    const result = createFunctionCall('console.log', [])
+
+    expect(result.type).toBe('CallExpression')
+    expect(result.arguments.length).toBe(0)
+    expect((result.callee as types.Identifier).name).toBe('console.log')
   })
 
-  describe('createGenericImportStatement', () => {
-    it('should creat generic import statements', () => {
-      const imports = [
-        { identifier: 'Card', namedImport: false, originalName: 'Card' },
-        { identifier: 'React', namedImport: false, originalName: 'React' },
-        { identifier: 'useState', namedImport: true, originalName: 'useState' },
-      ]
-      const result = createGenericImportStatement('../testConst', imports)
-      expect(result.type).toBe('ImportDeclaration')
-      expect(result.specifiers.length).toEqual(imports.length)
-      expect(result.source).toHaveProperty('value')
-      expect(result.source.value).toBe('../testConst')
-    })
-    it('should creat generic import statements if no import array is provided', () => {
-      const result = createGenericImportStatement('../testConst', [])
-      expect(result.type).toBe('ImportDeclaration')
-      expect(result.source).toHaveProperty('value')
-      expect(result.source.value).toBe('../testConst')
-    })
+  it('works with arguments of different types', () => {
+    const result = createFunctionCall('console.log', [0, '1'])
+
+    expect(result.type).toBe('CallExpression')
+    expect(result.arguments.length).toBe(2)
+    expect(result.arguments[0].type).toBe('NumericLiteral')
+    expect(result.arguments[1].type).toBe('StringLiteral')
+    expect((result.callee as types.Identifier).name).toBe('console.log')
   })
 
-  describe('generateStyledJSXTag', () => {
-    it('returns JSXTag', () => {
-      const result = generateStyledJSXTag('randomString')
+  it('works with AST as arguments', () => {
+    const result = createFunctionCall('console.log', [0, createJSXTag('App')])
 
-      expect(result.type).toBe('JSXElement')
-      expect(result.openingElement.type).toBe('JSXOpeningElement')
-      expect(result.openingElement.name).toHaveProperty('name', 'style')
-      expect(result.closingElement.type).toBe('JSXClosingElement')
-      expect(result.closingElement.name).toHaveProperty('name', 'style')
-    })
+    expect(result.type).toBe('CallExpression')
+    expect(result.arguments.length).toBe(2)
+    expect(result.arguments[0].type).toBe('NumericLiteral')
+    expect(result.arguments[1].type).toBe('JSXElement')
+    expect((result.callee as types.Identifier).name).toBe('console.log')
   })
+})
 
-  describe('generateASTDefinitionForJSXTag', () => {
-    it('returns ASTDefinitionForJSXTag', () => {
-      const result = generateASTDefinitionForJSXTag('randomString')
-
-      expect(result.type).toBe('JSXElement')
-      expect(result.openingElement.type).toBe('JSXOpeningElement')
-      expect(result.openingElement.name).toHaveProperty('name', 'randomString')
-      expect(result.closingElement.type).toBe('JSXClosingElement')
-      expect(result.closingElement.name).toHaveProperty('name', 'randomString')
-    })
-  })
-
-  describe('createJSXSpreadAttribute', () => {
-    it('runs with success', () => {
-      const result = createJSXSpreadAttribute('randomString')
-
-      expect(result.type).toBe('JSXSpreadAttribute')
-      expect(result.argument).toHaveProperty('name', 'randomString')
-    })
+describe('createFunctionalComponent', () => {
+  it('returns a valid AST node', () => {
+    const result = createFunctionalComponent('MyComponent', createSelfClosingJSXTag('App'))
+    expect(result.type).toBe('VariableDeclaration')
+    expect((result.declarations[0].id as types.Identifier).name).toBe('MyComponent')
   })
 })

--- a/packages/teleport-shared/__tests__/utils/ast-jsx-utils.ts
+++ b/packages/teleport-shared/__tests__/utils/ast-jsx-utils.ts
@@ -1,12 +1,136 @@
-import { stringAsTemplateLiteral } from '../../src/utils/ast-jsx-utils'
+import {
+  stringAsTemplateLiteral,
+  addSpreadAttributeToJSXTag,
+  renameJSXTag,
+  addClassStringOnJSXTag,
+  addAttributeToJSXTag,
+  addDynamicAttributeToJSXTag,
+} from '../../src/utils/ast-jsx-utils'
+import { createJSXTag } from '../../src/builders/ast-builders'
+import {
+  JSXSpreadAttribute,
+  JSXIdentifier,
+  JSXAttribute,
+  StringLiteral,
+  JSXExpressionContainer,
+  Identifier,
+  NumberLiteral,
+} from '@babel/types'
 
-describe('AST JSX utils', () => {
-  describe('stringAsTemplateLiteral', () => {
-    it('returns TemplateLiteral', () => {
-      const result = stringAsTemplateLiteral('randomString')
+describe('stringAsTemplateLiteral', () => {
+  it('returns TemplateLiteral', () => {
+    const result = stringAsTemplateLiteral('randomString')
 
-      expect(result.type).toBe('TemplateLiteral')
-      expect(result.quasis[0].type).toBe('TemplateElement')
-    })
+    expect(result.type).toBe('TemplateLiteral')
+    expect(result.quasis[0].type).toBe('TemplateElement')
+  })
+})
+
+describe('addSpreadAttributeToJSXTag', () => {
+  it('runs with success', () => {
+    const tag = createJSXTag('random')
+    addSpreadAttributeToJSXTag(tag, 'randomString')
+
+    const attr = tag.openingElement.attributes[0]
+    expect(attr.type).toBe('JSXSpreadAttribute')
+    expect((attr as JSXSpreadAttribute).argument).toHaveProperty('name', 'randomString')
+  })
+})
+
+describe('renameJSXTag', () => {
+  it('runs with success', () => {
+    const tag = createJSXTag('random')
+    renameJSXTag(tag, 'NewName')
+
+    const openTag = tag.openingElement.name as JSXIdentifier
+    const closeTag = tag.closingElement.name as JSXIdentifier
+    expect(openTag.name).toBe('NewName')
+    expect(closeTag.name).toBe('NewName')
+  })
+})
+
+describe('addClassStringOnJSXTag', () => {
+  it('adds a class on an element with no classes', () => {
+    const tag = createJSXTag('button')
+
+    addClassStringOnJSXTag(tag, 'primary')
+    expect(tag.openingElement.attributes[0].type).toBe('JSXAttribute')
+
+    const classAttr = tag.openingElement.attributes[0] as JSXAttribute
+    expect(classAttr.name.name).toBe('className')
+    expect((classAttr.value as StringLiteral).value).toBe('primary')
+  })
+
+  it('adds a class on an element with existing classes', () => {
+    const tag = createJSXTag('button')
+    addAttributeToJSXTag(tag, 'className', 'button')
+
+    addClassStringOnJSXTag(tag, 'primary')
+    expect(tag.openingElement.attributes[0].type).toBe('JSXAttribute')
+
+    const classAttr = tag.openingElement.attributes[0] as JSXAttribute
+    expect(classAttr.name.name).toBe('className')
+    expect((classAttr.value as StringLiteral).value).toBe('button primary')
+  })
+})
+
+describe('addAttributeToJSXTag', () => {
+  it('adds an attribute with no value', () => {
+    const tag = createJSXTag('button')
+
+    addAttributeToJSXTag(tag, 'disabled')
+    expect(tag.openingElement.attributes[0].type).toBe('JSXAttribute')
+
+    const classAttr = tag.openingElement.attributes[0] as JSXAttribute
+    expect(classAttr.name.name).toBe('disabled')
+    expect(classAttr.value).toBe(null)
+  })
+
+  it('adds an attribute with the selected value', () => {
+    const tag = createJSXTag('button')
+
+    addAttributeToJSXTag(tag, 'data-attr', 'random-value')
+    expect(tag.openingElement.attributes[0].type).toBe('JSXAttribute')
+
+    const classAttr = tag.openingElement.attributes[0] as JSXAttribute
+    expect(classAttr.name.name).toBe('data-attr')
+    expect((classAttr.value as StringLiteral).value).toBe('random-value')
+  })
+
+  it('adds an attribute as a JSX expression when non-string', () => {
+    const tag = createJSXTag('button')
+
+    addAttributeToJSXTag(tag, 'data-attr', 1)
+    expect(tag.openingElement.attributes[0].type).toBe('JSXAttribute')
+
+    const classAttr = tag.openingElement.attributes[0] as JSXAttribute
+    expect(classAttr.name.name).toBe('data-attr')
+    expect(((classAttr.value as JSXExpressionContainer).expression as NumberLiteral).value).toBe(1)
+  })
+})
+
+describe('addDynamicAttributeToJSXTag', () => {
+  it('adds the dynamic JSX expression on the opening tag', () => {
+    const tag = createJSXTag('button')
+
+    addDynamicAttributeToJSXTag(tag, 'dynamicValue', 'title')
+    expect(tag.openingElement.attributes[0].type).toBe('JSXAttribute')
+
+    const dynamicAttr = tag.openingElement.attributes[0] as JSXAttribute
+    expect(dynamicAttr.value.type).toBe('JSXExpressionContainer')
+    expect(((dynamicAttr.value as JSXExpressionContainer).expression as Identifier).name).toBe(
+      'title'
+    )
+  })
+
+  it('adds the dynamic JSX expression on the opening tag with prefix', () => {
+    const tag = createJSXTag('button')
+
+    addDynamicAttributeToJSXTag(tag, 'dynamicValue', 'title', 'props')
+    expect(tag.openingElement.attributes[0].type).toBe('JSXAttribute')
+
+    const dynamicAttr = tag.openingElement.attributes[0] as JSXAttribute
+    expect(dynamicAttr.value.type).toBe('JSXExpressionContainer')
+    expect((dynamicAttr.value as JSXExpressionContainer).expression.type).toBe('MemberExpression')
   })
 })

--- a/packages/teleport-shared/src/builders/css-builders.ts
+++ b/packages/teleport-shared/src/builders/css-builders.ts
@@ -1,5 +1,8 @@
 import jss from 'jss'
 import preset from 'jss-preset-default'
+import * as types from '@babel/types'
+import { UIDLDynamicReference } from '@teleporthq/teleport-types'
+import { ParsedASTNode } from '../utils/ast-js-utils'
 
 jss.setup(preset())
 
@@ -14,4 +17,24 @@ export const createCSSClass = (className: string, styleObject: Record<string, st
       }
     )
     .toString()
+}
+
+export const createDynamicStyleExpression = (styleValue: UIDLDynamicReference, t = types) => {
+  switch (styleValue.content.referenceType) {
+    case 'state':
+    case 'local':
+      return new ParsedASTNode(t.identifier(styleValue.content.id))
+    case 'prop':
+      return new ParsedASTNode(
+        t.memberExpression(t.identifier('props'), t.identifier(styleValue.content.id))
+      )
+    default:
+      throw new Error(
+        `createDynamicStyleExpression received unsupported ${JSON.stringify(
+          styleValue,
+          null,
+          2
+        )} UIDLDynamicReference value`
+      )
+  }
 }

--- a/packages/teleport-shared/src/utils/ast-jsx-utils.ts
+++ b/packages/teleport-shared/src/utils/ast-jsx-utils.ts
@@ -1,5 +1,5 @@
 import * as types from '@babel/types'
-import { objectToObjectExpression, convertValueToLiteral } from './ast-js-utils'
+import { convertValueToLiteral } from './ast-js-utils'
 
 /**
  * Adds a class definition string to an existing string of classes
@@ -51,7 +51,7 @@ const getClassAttribute = (
  * @param name the name of the prop
  * @param value the value of the prop (will be concatenated with props. before it)
  */
-export const addDynamicAttributeOnTag = (
+export const addDynamicAttributeToJSXTag = (
   jsxASTNode: types.JSXElement,
   name: string,
   value: string,
@@ -88,17 +88,18 @@ ${str}
 
 export const addAttributeToJSXTag = (
   jsxNode: types.JSXElement,
-  attribute: { name: string; value?: any },
+  attrName: string,
+  attrValue?: any,
   t = types
 ) => {
-  const nameOfAttribute = t.jsxIdentifier(attribute.name)
+  const nameOfAttribute = t.jsxIdentifier(attrName)
   let attributeDefinition
-  if (typeof attribute.value === 'boolean') {
+  if (typeof attrValue === 'boolean') {
     attributeDefinition = t.jsxAttribute(nameOfAttribute)
   } else {
     attributeDefinition = t.jsxAttribute(
       nameOfAttribute,
-      getProperAttributeValueAssignment(attribute.value)
+      getProperAttributeValueAssignment(attrValue)
     )
   }
   jsxNode.openingElement.attributes.push(attributeDefinition)
@@ -132,11 +133,17 @@ export const addChildJSXText = (tag: types.JSXElement, text: string, t = types) 
   tag.children.push(t.jsxText(text), t.jsxText('\n'))
 }
 
-// TODO: Replace with generic add attribute?
-export const addJSXTagStyles = (tag: types.JSXElement, styleMap: any, t = types) => {
-  const styleObjectExpression = objectToObjectExpression(styleMap, t)
-  const styleObjectExpressionContainer = t.jsxExpressionContainer(styleObjectExpression)
+export const addSpreadAttributeToJSXTag = (
+  jsxTag: types.JSXElement,
+  attrName: string,
+  t = types
+) => {
+  jsxTag.openingElement.attributes.push(t.jsxSpreadAttribute(t.identifier(attrName)))
+}
 
-  const styleJSXAttr = t.jsxAttribute(t.jsxIdentifier('style'), styleObjectExpressionContainer)
-  tag.openingElement.attributes.push(styleJSXAttr)
+export const renameJSXTag = (jsxTag: types.JSXElement, newName: string, t = types) => {
+  jsxTag.openingElement.name = t.jsxIdentifier(newName)
+  if (jsxTag.closingElement) {
+    jsxTag.closingElement.name = t.jsxIdentifier(newName)
+  }
 }

--- a/packages/teleport-types/src/generators.ts
+++ b/packages/teleport-types/src/generators.ts
@@ -109,6 +109,12 @@ export interface HastText {
   value: string
 }
 
+export interface ImportIdentifier {
+  identifierName: string
+  namedImport: boolean
+  originalName: string
+}
+
 /* Project Types */
 
 export interface ProjectGenerator {


### PR DESCRIPTION
closes #202 and solves some other loose ends.

main goal was to remove direct dependencies to @babel/types in smaller packages. there are still things to be done, but for now it works.