### PR TITLE
fix(slots): restrictions for slot node fallback and separate handling for native / prop based slot

### DIFF
--- a/packages/teleport-shared/__tests__/node-handlers/node-to-jsx/index.ts
+++ b/packages/teleport-shared/__tests__/node-handlers/node-to-jsx/index.ts
@@ -1,0 +1,87 @@
+import * as types from '@babel/types'
+import generateJSXSyntax from '../../../src/node-handlers/node-to-jsx'
+
+import { slotNode, elementNode, staticNode } from '../../../src/builders/uidl-builders'
+import {
+  JSXGenerationParams,
+  JSXGenerationOptions,
+} from '../../../src/node-handlers/node-to-jsx/types'
+
+describe('generateJSXSyntax', () => {
+  describe('slot node', () => {
+    const params: JSXGenerationParams = {
+      dependencies: {},
+      propDefinitions: null,
+      stateDefinitions: null,
+      nodesLookup: {},
+    }
+
+    const options: JSXGenerationOptions = {
+      dynamicReferencePrefixMap: {
+        prop: 'props',
+        state: '',
+        local: '',
+      },
+    }
+
+    it('returns a props.children expression', () => {
+      const node = slotNode()
+      const result = generateJSXSyntax(node, params, { ...options, slotHandling: 'props' })
+
+      const expression = result as types.JSXExpressionContainer
+      expect(expression.expression.type).toBe('MemberExpression')
+
+      const memberExpression = expression.expression as types.MemberExpression
+      expect((memberExpression.object as types.Identifier).name).toBe('props')
+      expect(memberExpression.property.name).toBe('children')
+    })
+
+    it('returns a props.children with fallback', () => {
+      const node = slotNode(elementNode('span', {}, [staticNode('fallback')]))
+      const result = generateJSXSyntax(node, params, { ...options, slotHandling: 'props' })
+
+      const expression = result as types.JSXExpressionContainer
+      expect(expression.expression.type).toBe('LogicalExpression')
+
+      const logicalExpression = expression.expression as types.LogicalExpression
+      const memberExpression = logicalExpression.left as types.MemberExpression
+      const fallbackJSXNode = logicalExpression.right as types.JSXElement
+
+      expect((memberExpression.object as types.Identifier).name).toBe('props')
+      expect(memberExpression.property.name).toBe('children')
+
+      expect((fallbackJSXNode.openingElement.name as types.JSXIdentifier).name).toBe('span')
+    })
+
+    it('returns a <slot> tag', () => {
+      const node = slotNode()
+      const result = generateJSXSyntax(node, params, { ...options, slotHandling: 'native' })
+
+      const slotJSXTag = result as types.JSXElement
+      expect((slotJSXTag.openingElement.name as types.JSXIdentifier).name).toBe('slot')
+    })
+
+    it('returns a <slot> tag with fallback', () => {
+      const node = slotNode(elementNode('span', {}, [staticNode('fallback')]))
+      const result = generateJSXSyntax(node, params, { ...options, slotHandling: 'native' })
+
+      const slotJSXTag = result as types.JSXElement
+      expect((slotJSXTag.openingElement.name as types.JSXIdentifier).name).toBe('slot')
+
+      const slotFallbackJSXTag = slotJSXTag.children[0] as types.JSXElement
+      expect((slotFallbackJSXTag.openingElement.name as types.JSXIdentifier).name).toBe('span')
+    })
+
+    it('returns a named <slot> tag', () => {
+      const node = slotNode(null, 'hole')
+      const result = generateJSXSyntax(node, params, { ...options, slotHandling: 'native' })
+
+      const slotJSXTag = result as types.JSXElement
+      expect((slotJSXTag.openingElement.name as types.JSXIdentifier).name).toBe('slot')
+
+      const nameAttr = slotJSXTag.openingElement.attributes[0] as types.JSXAttribute
+      expect(nameAttr.name.name).toBe('name')
+      expect((nameAttr.value as types.StringLiteral).value).toBe('hole')
+    })
+  })
+})

--- a/packages/teleport-shared/src/builders/uidl-builders.ts
+++ b/packages/teleport-shared/src/builders/uidl-builders.ts
@@ -111,7 +111,10 @@ export const dynamicNode = (referenceType: ReferenceType, id: string): UIDLDynam
   }
 }
 
-export const slotNode = (fallback?: UIDLNode, name?: string): UIDLSlotNode => {
+export const slotNode = (
+  fallback?: UIDLElementNode | UIDLStaticValue | UIDLDynamicReference,
+  name?: string
+): UIDLSlotNode => {
   return {
     type: 'slot',
     content: {

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -80,7 +80,7 @@ export interface UIDLSlotNode {
   type: 'slot'
   content: {
     name?: string
-    fallback?: UIDLNode
+    fallback?: UIDLElementNode | UIDLStaticValue | UIDLDynamicReference
   }
 }
 

--- a/packages/teleport-uidl-validator/src/parser/index.ts
+++ b/packages/teleport-uidl-validator/src/parser/index.ts
@@ -13,6 +13,8 @@ import {
   UIDLConditionalNode,
   UIDLRepeatNode,
   UIDLSlotNode,
+  UIDLElementNode,
+  UIDLStaticValue,
 } from '@teleporthq/teleport-types'
 
 interface ParseComponentJSONParams {
@@ -123,7 +125,10 @@ const parseComponentNode = (node: Record<string, unknown>): UIDLNode => {
       const slotNode = node as UIDLSlotNode
 
       if (slotNode.content.fallback) {
-        slotNode.content.fallback = parseComponentNode(slotNode.content.fallback)
+        slotNode.content.fallback = parseComponentNode(slotNode.content.fallback) as
+          | UIDLElementNode
+          | UIDLStaticValue
+          | UIDLDynamicReference
       }
 
       return slotNode


### PR DESCRIPTION
closes #163 

Unfortunately, it will be tricky to define a behavior that works in both slot cases, because of the different nature of the implementations in react/preact on one side and vue/stencil on the other