### PR TITLE
Feature/stencil project generator

### DIFF
--- a/examples/uidl-samples/project.json
+++ b/examples/uidl-samples/project.json
@@ -799,8 +799,8 @@
                         "border-color": "#ccc"
                       },
                       "attrs": {
-                        "rows": "8",
-                        "cols": "30",
+                        "rows": 8,
+                        "cols": 30,
                         "id": "message",
                         "name": "message"
                       }

--- a/packages/teleport-plugin-angular-base-component/src/index.ts
+++ b/packages/teleport-plugin-angular-base-component/src/index.ts
@@ -5,8 +5,10 @@ import {
   UIDLElementNode,
 } from '@teleporthq/teleport-types'
 import { FILE_TYPE, CHUNK_TYPE } from '@teleporthq/teleport-shared/dist/cjs/constants'
+import { createComponentDecorator } from '@teleporthq/teleport-shared/dist/cjs/utils/ast-jsx-utils'
+import { getComponentFileName } from '@teleporthq/teleport-shared/dist/cjs/utils/uidl-utils'
 
-import { generateExportAST, generateComponentDecorator } from './utils'
+import { generateExportAST } from './utils'
 
 import {
   DEFAULT_TS_CHUNK_AFTER,
@@ -80,7 +82,11 @@ export const createPlugin: ComponentPluginFactory<AngularPluginConfig> = (config
       linkAfter: [],
     })
 
-    const componentDecoratorAST = generateComponentDecorator(uidl)
+    const params = {
+      selector: 'app-root',
+      templateUrl: `${getComponentFileName(uidl)}.${FILE_TYPE.HTML}`,
+    }
+    const componentDecoratorAST = createComponentDecorator(params)
 
     chunks.push({
       type: CHUNK_TYPE.AST,

--- a/packages/teleport-plugin-angular-base-component/src/utils.ts
+++ b/packages/teleport-plugin-angular-base-component/src/utils.ts
@@ -3,23 +3,7 @@ import {
   convertValueToLiteral,
   getTSAnnotationForType,
 } from '@teleporthq/teleport-shared/dist/cjs/utils/ast-js-utils'
-import { getComponentFileName } from '@teleporthq/teleport-shared/dist/cjs/utils/uidl-utils'
-import { UIDLPropDefinition, UIDLStateDefinition, ComponentUIDL } from '@teleporthq/teleport-types'
-import { FILE_TYPE } from '@teleporthq/teleport-shared/dist/cjs/constants'
-
-export const generateComponentDecorator = (uidl: ComponentUIDL, t = types) => {
-  const decoratorArgs = [
-    t.objectExpression([
-      t.objectProperty(t.identifier('selector'), t.stringLiteral('app-root')),
-      t.objectProperty(
-        t.identifier('templateUrl'),
-        t.stringLiteral(`${getComponentFileName(uidl)}.${FILE_TYPE.HTML}`)
-      ),
-    ]),
-  ]
-
-  return t.decorator(t.callExpression(t.identifier('Component'), decoratorArgs))
-}
+import { UIDLPropDefinition, UIDLStateDefinition } from '@teleporthq/teleport-types'
 
 export const generateExportAST = (
   componentName: string,

--- a/packages/teleport-plugin-react-base-component/src/index.ts
+++ b/packages/teleport-plugin-react-base-component/src/index.ts
@@ -31,7 +31,6 @@ export const createPlugin: ComponentPluginFactory<ReactPluginConfig> = (config) 
   const reactComponentPlugin: ComponentPlugin = async (structure) => {
     const { uidl, dependencies } = structure
     const { stateDefinitions = {}, propDefinitions = {} } = uidl
-    console.log(stateDefinitions, 'from react base component')
 
     dependencies.React = REACT_LIBRARY_DEPENDENCY
 

--- a/packages/teleport-plugin-react-base-component/src/index.ts
+++ b/packages/teleport-plugin-react-base-component/src/index.ts
@@ -31,6 +31,7 @@ export const createPlugin: ComponentPluginFactory<ReactPluginConfig> = (config) 
   const reactComponentPlugin: ComponentPlugin = async (structure) => {
     const { uidl, dependencies } = structure
     const { stateDefinitions = {}, propDefinitions = {} } = uidl
+    console.log(stateDefinitions, 'from react base component')
 
     dependencies.React = REACT_LIBRARY_DEPENDENCY
 

--- a/packages/teleport-plugin-stencil-app-routing/README.md
+++ b/packages/teleport-plugin-stencil-app-routing/README.md
@@ -1,0 +1,11 @@
+# `@teleporthq/teleport-plugin-stencil-app-routing`
+
+> TODO: description
+
+## Usage
+
+```
+const teleportPluginStencilAppRouting = require('@teleporthq/teleport-plugin-stencil-app-routing');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/teleport-plugin-stencil-app-routing/README.md
+++ b/packages/teleport-plugin-stencil-app-routing/README.md
@@ -1,11 +1,14 @@
 # `@teleporthq/teleport-plugin-stencil-app-routing`
 
-> TODO: description
+A plugin for generating the routing file for a Stencil project.
 
-## Usage
+> This package is part of the [teleport ecosystem](https://github.com/teleporthq/teleport-code-generators). For a complete guide, check out the [official documentation](https://docs.teleporthq.io/).
 
+## Install
+```bash
+npm install @teleporthq/teleport-plugin-stencil-app-routing
 ```
-const teleportPluginStencilAppRouting = require('@teleporthq/teleport-plugin-stencil-app-routing');
-
-// TODO: DEMONSTRATE API
+or
+```bash
+yarn add @teleporthq/teleport-plugin-stencil-app-routing
 ```

--- a/packages/teleport-plugin-stencil-app-routing/package.json
+++ b/packages/teleport-plugin-stencil-app-routing/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@teleporthq/teleport-plugin-stencil-app-routing",
+  "version": "0.8.1",
+  "description": "A plugin for handling the routing file of a Stencil Project",
+  "author": "teleportHQ",
+  "homepage": "https://teleporthq.io/",
+  "license": "MIT",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "bugs": {
+    "url": "https://github.com/teleporthq/teleport-code-generators/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/teleporthq/teleport-code-generators.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "npm run build:cjs & npm run build:esm",
+    "build:cjs": "tsc -p tsconfig-cjs.json",
+    "build:esm": "tsc -p tsconfig-esm.json"
+  },
+  "dependencies": {
+    "@babel/types": "^7.3.3",
+    "@teleporthq/teleport-shared": "^0.8.1",
+    "@teleporthq/teleport-types": "^0.8.1"
+  }
+}

--- a/packages/teleport-plugin-stencil-app-routing/package.json
+++ b/packages/teleport-plugin-stencil-app-routing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teleporthq/teleport-plugin-stencil-app-routing",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "A plugin for handling the routing file of a Stencil Project",
   "author": "teleportHQ",
   "homepage": "https://teleporthq.io/",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@babel/types": "^7.3.3",
-    "@teleporthq/teleport-shared": "^0.8.1",
-    "@teleporthq/teleport-types": "^0.8.1"
+    "@teleporthq/teleport-shared": "^0.9.0",
+    "@teleporthq/teleport-types": "^0.9.0"
   }
 }

--- a/packages/teleport-plugin-stencil-app-routing/src/constants.ts
+++ b/packages/teleport-plugin-stencil-app-routing/src/constants.ts
@@ -1,0 +1,14 @@
+export const STENCIL_CORE_DEPENDENCY = {
+  type: 'library',
+  path: '@stencil/core',
+  version: '1.1.4',
+  meta: {
+    namedImport: true,
+  },
+}
+
+export const DEFAULT_COMPONENT_CHUNK_NAME = 'jsx-component'
+
+export const DEFAULT_COMPONENT_DECORATOR_CHUNK_NAME = 'component-decorator'
+
+export const DEFAULT_IMPORT_CHUNK_NAME = 'import-local'

--- a/packages/teleport-plugin-stencil-app-routing/src/index.ts
+++ b/packages/teleport-plugin-stencil-app-routing/src/index.ts
@@ -44,13 +44,13 @@ export const createPlugin: ComponentPluginFactory<StencilRouterConfig> = (config
       linkAfter: [importChunkName],
     })
 
-    const exportClassAST = createClassDecleration(routes, routeDefinitions)
+    const classDeclarationAST = createClassDecleration(routes, routeDefinitions)
 
     chunks.push({
       name: componentChunkName,
       type: CHUNK_TYPE.AST,
       fileType: FILE_TYPE.TSX,
-      content: exportClassAST,
+      content: classDeclarationAST,
       linkAfter: [componentDecoratorChunkName],
     })
 

--- a/packages/teleport-plugin-stencil-app-routing/src/index.ts
+++ b/packages/teleport-plugin-stencil-app-routing/src/index.ts
@@ -34,7 +34,11 @@ export const createPlugin: ComponentPluginFactory<StencilRouterConfig> = (config
 
     /* The name should be injected only with AppRoot only then it acts as entry point,
     Sending only Root because app is appended while generation of decorators*/
-    const decoratorAST = createComponentDecorator('Root')
+    const params = {
+      tag: 'app-root',
+      shadow: true,
+    }
+    const decoratorAST = createComponentDecorator(params)
 
     chunks.push({
       name: componentDecoratorChunkName,

--- a/packages/teleport-plugin-stencil-app-routing/src/index.ts
+++ b/packages/teleport-plugin-stencil-app-routing/src/index.ts
@@ -1,0 +1,62 @@
+import { extractRoutes } from '@teleporthq/teleport-shared/dist/cjs/utils/uidl-utils'
+import { ComponentPluginFactory, ComponentPlugin } from '@teleporthq/teleport-types'
+import { CHUNK_TYPE, FILE_TYPE } from '@teleporthq/teleport-shared/dist/cjs/constants'
+import { createComponentDecorator } from '@teleporthq/teleport-shared/dist/cjs/utils/ast-jsx-utils'
+import {
+  STENCIL_CORE_DEPENDENCY,
+  DEFAULT_COMPONENT_DECORATOR_CHUNK_NAME,
+  DEFAULT_COMPONENT_CHUNK_NAME,
+  DEFAULT_IMPORT_CHUNK_NAME,
+} from './constants'
+import { createClassDecleration } from './utils'
+
+interface StencilRouterConfig {
+  componentDecoratorChunkName: string
+  componentChunkName: string
+  importChunkName: string
+}
+
+export const createPlugin: ComponentPluginFactory<StencilRouterConfig> = (config) => {
+  const {
+    componentChunkName = DEFAULT_COMPONENT_CHUNK_NAME,
+    componentDecoratorChunkName = DEFAULT_COMPONENT_DECORATOR_CHUNK_NAME,
+    importChunkName = DEFAULT_IMPORT_CHUNK_NAME,
+  } = config || {}
+
+  const stencilAppRouterComponentPlugin: ComponentPlugin = async (structure) => {
+    const { chunks, uidl, dependencies } = structure
+
+    dependencies.Component = STENCIL_CORE_DEPENDENCY
+    dependencies.h = STENCIL_CORE_DEPENDENCY
+
+    const routes = extractRoutes(uidl)
+    const routeDefinitions = uidl.stateDefinitions.route
+
+    // The name should be injected only with AppRoot only then it acts as entry point
+    const decoratorAST = createComponentDecorator('AppRoot')
+
+    chunks.push({
+      name: componentDecoratorChunkName,
+      type: CHUNK_TYPE.AST,
+      fileType: FILE_TYPE.TSX,
+      content: [decoratorAST],
+      linkAfter: [importChunkName],
+    })
+
+    const exportClassAST = createClassDecleration(routes, routeDefinitions)
+
+    chunks.push({
+      name: componentChunkName,
+      type: CHUNK_TYPE.AST,
+      fileType: FILE_TYPE.TSX,
+      content: exportClassAST,
+      linkAfter: [componentDecoratorChunkName],
+    })
+
+    return structure
+  }
+
+  return stencilAppRouterComponentPlugin
+}
+
+export default createPlugin()

--- a/packages/teleport-plugin-stencil-app-routing/src/index.ts
+++ b/packages/teleport-plugin-stencil-app-routing/src/index.ts
@@ -32,8 +32,9 @@ export const createPlugin: ComponentPluginFactory<StencilRouterConfig> = (config
     const routes = extractRoutes(uidl)
     const routeDefinitions = uidl.stateDefinitions.route
 
-    // The name should be injected only with AppRoot only then it acts as entry point
-    const decoratorAST = createComponentDecorator('AppRoot')
+    /* The name should be injected only with AppRoot only then it acts as entry point,
+    Sending only Root because app is appended while generation of decorators*/
+    const decoratorAST = createComponentDecorator('Root')
 
     chunks.push({
       name: componentDecoratorChunkName,

--- a/packages/teleport-plugin-stencil-app-routing/src/utils.ts
+++ b/packages/teleport-plugin-stencil-app-routing/src/utils.ts
@@ -18,14 +18,19 @@ export const createClassDecleration = (routes, routeDefinitions, t = types) => {
 
     const stencilRouteTag = createJSXTag('stencil-route')
     addAttributeToJSXTag(stencilRouteTag, 'url', path)
-    addAttributeToJSXTag(stencilRouteTag, 'component', camelCaseToDashCase(componentName))
+    if (path === '/') {
+      addAttributeToJSXTag(stencilRouteTag, 'exact', true)
+    }
+    addAttributeToJSXTag(stencilRouteTag, 'component', `app-${camelCaseToDashCase(componentName)}`)
     addChildJSXTag(stencilRouteSwitchTag, stencilRouteTag)
   })
 
   const mainTag = createJSXTag('main')
   addChildJSXTag(mainTag, stencilRouterTag)
+  const divTag = createJSXTag('div')
+  addChildJSXTag(divTag, mainTag)
 
-  const returnAST = mainTag as types.JSXElement
+  const returnAST = divTag as types.JSXElement
 
   const classBodyAST = t.classBody([
     t.classMethod(

--- a/packages/teleport-plugin-stencil-app-routing/src/utils.ts
+++ b/packages/teleport-plugin-stencil-app-routing/src/utils.ts
@@ -1,0 +1,45 @@
+import * as types from '@babel/types'
+import { createJSXTag } from '@teleporthq/teleport-shared/dist/cjs/builders/ast-builders'
+import {
+  addChildJSXTag,
+  addAttributeToJSXTag,
+} from '@teleporthq/teleport-shared/dist/cjs/utils/ast-jsx-utils'
+import { extractPageMetadata } from '@teleporthq/teleport-shared/dist/cjs/utils/uidl-utils'
+import { camelCaseToDashCase } from '@teleporthq/teleport-shared/src/utils/string-utils'
+
+export const createClassDecleration = (routes, routeDefinitions, t = types) => {
+  const stencilRouterTag = createJSXTag('stencil-router')
+  const stencilRouteSwitchTag = createJSXTag('stencil-route-switch')
+  addChildJSXTag(stencilRouterTag, stencilRouteSwitchTag)
+
+  routes.forEach((routeNode) => {
+    const pageKey = routeNode.content.value.toString()
+    const { componentName, path } = extractPageMetadata(routeDefinitions, pageKey)
+
+    const stencilRouteTag = createJSXTag('stencil-route')
+    addAttributeToJSXTag(stencilRouteTag, 'url', path)
+    addAttributeToJSXTag(stencilRouteTag, 'component', camelCaseToDashCase(componentName))
+    addChildJSXTag(stencilRouteSwitchTag, stencilRouteTag)
+  })
+
+  const mainTag = createJSXTag('main')
+  addChildJSXTag(mainTag, stencilRouterTag)
+
+  const returnAST = mainTag as types.JSXElement
+
+  const classBodyAST = t.classBody([
+    t.classMethod(
+      'method',
+      t.identifier('render'),
+      [],
+      t.blockStatement([t.returnStatement(returnAST)])
+    ),
+  ])
+
+  const exportClass = t.exportNamedDeclaration(
+    t.classDeclaration(t.identifier('AppRoot'), null, classBodyAST),
+    [],
+    null
+  )
+  return exportClass
+}

--- a/packages/teleport-plugin-stencil-app-routing/tsconfig-cjs.json
+++ b/packages/teleport-plugin-stencil-app-routing/tsconfig-cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "commonjs",
+    "target": "es5"
+  },
+  "include": [
+    "./src"
+  ]
+}

--- a/packages/teleport-plugin-stencil-app-routing/tsconfig-esm.json
+++ b/packages/teleport-plugin-stencil-app-routing/tsconfig-esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": [
+    "./src"
+  ]
+}

--- a/packages/teleport-plugin-stencil-base-component/src/index.ts
+++ b/packages/teleport-plugin-stencil-base-component/src/index.ts
@@ -1,4 +1,5 @@
-import { createClassDeclaration, createComponentDecorator } from './utils'
+import { createClassDeclaration } from './utils'
+import { createComponentDecorator } from '@teleporthq/teleport-shared/dist/cjs/utils/ast-jsx-utils'
 import createJSXSyntax from '@teleporthq/teleport-shared/dist/cjs/node-handlers/node-to-jsx'
 import { JSXGenerationOptions } from '@teleporthq/teleport-shared/dist/cjs/node-handlers/node-to-jsx/types'
 import { ComponentPluginFactory, ComponentPlugin } from '@teleporthq/teleport-types'
@@ -30,7 +31,6 @@ export const createPlugin: ComponentPluginFactory<StencilPluginConfig> = (config
 
     dependencies.Component = STENCIL_CORE_DEPENDENCY
     dependencies.h = STENCIL_CORE_DEPENDENCY
-    console.log(stateDefinitions, 'from stencil base component')
 
     if (Object.keys(propDefinitions).length > 0) {
       dependencies.Prop = STENCIL_CORE_DEPENDENCY

--- a/packages/teleport-plugin-stencil-base-component/src/index.ts
+++ b/packages/teleport-plugin-stencil-base-component/src/index.ts
@@ -11,6 +11,7 @@ import {
   STENCIL_CORE_DEPENDENCY,
 } from './constants'
 import { CHUNK_TYPE, FILE_TYPE } from '@teleporthq/teleport-shared/dist/cjs/constants'
+import { camelCaseToDashCase } from '@teleporthq/teleport-shared/dist/cjs/utils/string-utils'
 
 interface StencilPluginConfig {
   componentChunkName: string
@@ -60,6 +61,7 @@ export const createPlugin: ComponentPluginFactory<StencilPluginConfig> = (config
       dependencyHandling: 'webcomponents',
       stateHandling: 'mutation',
       slotHandling: 'native',
+      customElementTag: (name: string) => `app-${camelCaseToDashCase(name)}`,
     }
 
     const jsxTagStructure = createJSXSyntax(uidl.node, jsxParams, jsxOptions)

--- a/packages/teleport-plugin-stencil-base-component/src/index.ts
+++ b/packages/teleport-plugin-stencil-base-component/src/index.ts
@@ -72,7 +72,12 @@ export const createPlugin: ComponentPluginFactory<StencilPluginConfig> = (config
       jsxTagStructure
     )
 
-    const decoratorAST = createComponentDecorator(uidl.name)
+    const params = {
+      tag: `app-${camelCaseToDashCase(uidl.name)}`,
+      shadow: true,
+    }
+
+    const decoratorAST = createComponentDecorator(params)
 
     structure.chunks.push({
       type: CHUNK_TYPE.AST,

--- a/packages/teleport-plugin-stencil-base-component/src/index.ts
+++ b/packages/teleport-plugin-stencil-base-component/src/index.ts
@@ -30,6 +30,7 @@ export const createPlugin: ComponentPluginFactory<StencilPluginConfig> = (config
 
     dependencies.Component = STENCIL_CORE_DEPENDENCY
     dependencies.h = STENCIL_CORE_DEPENDENCY
+    console.log(stateDefinitions, 'from stencil base component')
 
     if (Object.keys(propDefinitions).length > 0) {
       dependencies.Prop = STENCIL_CORE_DEPENDENCY

--- a/packages/teleport-plugin-stencil-base-component/src/utils.ts
+++ b/packages/teleport-plugin-stencil-base-component/src/utils.ts
@@ -1,11 +1,9 @@
 import * as types from '@babel/types'
 
 import {
-  objectToObjectExpression,
   convertValueToLiteral,
   getTSAnnotationForType,
 } from '@teleporthq/teleport-shared/dist/cjs/utils/ast-js-utils'
-import { camelCaseToDashCase } from '@teleporthq/teleport-shared/dist/cjs/utils/string-utils'
 import { UIDLStateDefinition, UIDLPropDefinition } from '@teleporthq/teleport-types'
 
 export const createClassDeclaration = (
@@ -46,15 +44,4 @@ export const createClassDeclaration = (
 
   const classDeclaration = t.classDeclaration(t.identifier(name), null, classBody, [])
   return t.exportNamedDeclaration(classDeclaration, [])
-}
-
-export const createComponentDecorator = (name: string, t = types) => {
-  return t.decorator(
-    t.callExpression(t.identifier('Component'), [
-      objectToObjectExpression({
-        tag: camelCaseToDashCase(name),
-        shadow: true,
-      }),
-    ])
-  )
 }

--- a/packages/teleport-plugin-vue-app-routing/README.md
+++ b/packages/teleport-plugin-vue-app-routing/README.md
@@ -1,4 +1,4 @@
-# teleport-plugin-vue-app-routing
+# `@teleporthq/teleport-plugin-vue-app-routing`
 
 A plugin for generating the routing file for a Vue project.
 

--- a/packages/teleport-project-generator-nuxt/src/index.ts
+++ b/packages/teleport-project-generator-nuxt/src/index.ts
@@ -29,9 +29,11 @@ export const createNuxtProjectGenerator = () => {
     },
     entry: {
       generator: htmlFileGenerator,
-      appRootOverride: '{{APP}}',
       fileName: 'app',
       path: [],
+      options: {
+        appRootOverride: '{{APP}}',
+      },
     },
     static: {
       prefix: '/static',

--- a/packages/teleport-project-generator-preact/package.json
+++ b/packages/teleport-project-generator-preact/package.json
@@ -2,10 +2,12 @@
   "name": "@teleporthq/teleport-project-generator-preact",
   "version": "0.9.0",
   "description": "Project generator for a standard Preact project",
-  "author": "JayaKrishna <namburu1995@gmail.com>",
+  "author": "teleportHQ",
   "homepage": "https://teleporthq.io/",
   "license": "MIT",
   "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/cjs/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/teleport-project-generator-stencil/README.md
+++ b/packages/teleport-project-generator-stencil/README.md
@@ -1,11 +1,14 @@
-# `teleport-project-generator-stencil`
+# teleport-project-generator-stencil
 
-> TODO: description
+Project generator using Stencil, on top of a standard stencil config.
 
-## Usage
+> This package is part of the [teleport ecosystem](https://github.com/teleporthq/teleport-code-generators). For a complete guide, check out the [official documentation](https://docs.teleporthq.io/).
 
+## Install
+```bash
+npm install @teleporthq/teleport-project-generator-stencil
 ```
-const teleportProjectGeneratorStencil = require('teleport-project-generator-stencil');
-
-// TODO: DEMONSTRATE API
+or
+```bash
+yarn add @teleporthq/teleport-project-generator-stencil
 ```

--- a/packages/teleport-project-generator-stencil/README.md
+++ b/packages/teleport-project-generator-stencil/README.md
@@ -1,0 +1,11 @@
+# `teleport-project-generator-stencil`
+
+> TODO: description
+
+## Usage
+
+```
+const teleportProjectGeneratorStencil = require('teleport-project-generator-stencil');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/teleport-project-generator-stencil/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-stencil/__tests__/end2end/index.ts
@@ -1,0 +1,39 @@
+// @ts-ignore
+import uidlSample from '../../../../examples/test-samples/project-sample.json'
+// @ts-ignore
+import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
+// @ts-ignore
+import template from './template-definition.json'
+import { createStencilProjectGenerator } from '../../src'
+import { ProjectUIDL } from '@teleporthq/teleport-types'
+
+const projectUIDL = uidlSample as ProjectUIDL
+
+describe('Preact Project Generator', () => {
+  const generator = createStencilProjectGenerator()
+
+  it('runs without crashing', async () => {
+    const outputFolder = await generator.generateProject(projectUIDL, template)
+    const assetsPath = generator.getAssetsPath()
+
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(outputFolder.files[0].name).toBe('package')
+
+    const srcFolder = outputFolder.subFolders[0]
+    const rootFiles = srcFolder.subFolders[0].files
+
+    expect(srcFolder.files[0].name).toBe('index')
+    expect(srcFolder.files[0].fileType).toBe('html')
+    expect(srcFolder.files[0].content).toContain('<script type="module" src="build/app.esm.js">')
+    expect(rootFiles[0].name).toBe('app-root')
+    expect(rootFiles[0].fileType).toBe('tsx')
+    expect(srcFolder.subFolders[0].name).toBe('components')
+  })
+
+  it('throws error when invalid UIDL sample is used', async () => {
+    const result = generator.generateProject(invalidUidlSample, template)
+
+    await expect(result).rejects.toThrow(Error)
+  })
+})

--- a/packages/teleport-project-generator-stencil/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-stencil/__tests__/end2end/index.ts
@@ -25,7 +25,7 @@ describe('Preact Project Generator', () => {
 
     expect(srcFolder.files[0].name).toBe('index')
     expect(srcFolder.files[0].fileType).toBe('html')
-    expect(srcFolder.files[0].content).toContain('<script type="module" src="build/app.esm.js">')
+    expect(srcFolder.files[0].content).toContain('<script type="module" src="/build/app.esm.js">')
     expect(rootFiles[0].name).toBe('app-root')
     expect(rootFiles[0].fileType).toBe('tsx')
     expect(srcFolder.subFolders[0].name).toBe('components')

--- a/packages/teleport-project-generator-stencil/__tests__/end2end/template-definition.json
+++ b/packages/teleport-project-generator-stencil/__tests__/end2end/template-definition.json
@@ -1,0 +1,17 @@
+{
+  "name": "stencil",
+  "files": [],
+  "subFolders": [
+    {
+      "name": "src",
+      "files": [],
+      "subFolders": [
+        {
+          "name": "components",
+          "files": [],
+          "subFolders": []              
+        }
+      ]
+    }
+  ]
+}

--- a/packages/teleport-project-generator-stencil/package.json
+++ b/packages/teleport-project-generator-stencil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teleporthq/teleport-project-generator-stencil",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Project generator for a standard stencil project",
   "author": "teleportHQ",
   "homepage": "https://teleporthq.io/",
@@ -25,14 +25,14 @@
     "url": "https://github.com/teleporthq/teleport-code-generators/issues"
   },
   "dependencies": {
-    "@teleporthq/teleport-types": "^0.8.1",
-    "@teleporthq/teleport-shared": "^0.8.1",
-    "@teleporthq/teleport-project-generator": "0.8.1",
-    "@teleporthq/teleport-component-generator": "0.8.1",
-    "@teleporthq/teleport-plugin-import-statements": "0.8.1",
-    "@teleporthq/teleport-postprocessor-prettier-js": "0.8.1",
-    "@teleporthq/teleport-plugin-stencil-app-routing": "^0.8.1",
-    "@teleporthq/teleport-component-generator-stencil": "^0.8.1",
-    "@teleporthq/teleport-postprocessor-prettier-html": "^0.8.1"
+    "@teleporthq/teleport-types": "^0.9.0",
+    "@teleporthq/teleport-shared": "^0.9.0",
+    "@teleporthq/teleport-project-generator": "^0.9.0",
+    "@teleporthq/teleport-component-generator": "^0.9.0",
+    "@teleporthq/teleport-plugin-import-statements": "^0.9.0",
+    "@teleporthq/teleport-postprocessor-prettier-js": "^0.9.0",
+    "@teleporthq/teleport-plugin-stencil-app-routing": "^0.9.0",
+    "@teleporthq/teleport-component-generator-stencil": "^0.9.0",
+    "@teleporthq/teleport-postprocessor-prettier-html": "^0.9.0"
   }
 }

--- a/packages/teleport-project-generator-stencil/package.json
+++ b/packages/teleport-project-generator-stencil/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@teleporthq/teleport-project-generator-stencil",
+  "version": "0.8.1",
+  "description": "Project generator for a standard stencil project",
+  "author": "teleportHQ",
+  "homepage": "https://teleporthq.io/",
+  "license": "MIT",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/teleporthq/teleport-code-generators.git"
+  },
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "npm run build:cjs & npm run build:esm",
+    "build:cjs": "tsc -p tsconfig-cjs.json",
+    "build:esm": "tsc -p tsconfig-esm.json"
+  },
+  "bugs": {
+    "url": "https://github.com/teleporthq/teleport-code-generators/issues"
+  },
+  "dependencies": {
+    "@teleporthq/teleport-types": "^0.8.1",
+    "@teleporthq/teleport-project-generator": "0.8.1",
+    "@teleporthq/teleport-component-generator": "0.8.1",
+    "@teleporthq/teleport-plugin-react-app-routing": "0.8.1",
+    "@teleporthq/teleport-postprocessor-prettier-js": "0.8.1",
+    "@teleporthq/teleport-component-generator-stencil": "^0.8.1",
+    "@teleporthq/teleport-postprocessor-prettier-html": "^0.8.1"
+  }
+}

--- a/packages/teleport-project-generator-stencil/package.json
+++ b/packages/teleport-project-generator-stencil/package.json
@@ -26,10 +26,12 @@
   },
   "dependencies": {
     "@teleporthq/teleport-types": "^0.8.1",
+    "@teleporthq/teleport-shared": "^0.8.1",
     "@teleporthq/teleport-project-generator": "0.8.1",
     "@teleporthq/teleport-component-generator": "0.8.1",
-    "@teleporthq/teleport-plugin-react-app-routing": "0.8.1",
+    "@teleporthq/teleport-plugin-import-statements": "0.8.1",
     "@teleporthq/teleport-postprocessor-prettier-js": "0.8.1",
+    "@teleporthq/teleport-plugin-stencil-app-routing": "^0.8.1",
     "@teleporthq/teleport-component-generator-stencil": "^0.8.1",
     "@teleporthq/teleport-postprocessor-prettier-html": "^0.8.1"
   }

--- a/packages/teleport-project-generator-stencil/src/index.ts
+++ b/packages/teleport-project-generator-stencil/src/index.ts
@@ -1,9 +1,11 @@
 import { createProjectGenerator } from '@teleporthq/teleport-project-generator'
 import { createStencilComponentGenerator } from '@teleporthq/teleport-component-generator-stencil'
 import { createComponentGenerator } from '@teleporthq/teleport-component-generator'
-import { createPlugin as createRouterPlugin } from '@teleporthq/teleport-plugin-react-app-routing'
+import { FILE_TYPE } from '@teleporthq/teleport-shared/dist/cjs/constants'
+import { createPostProcessor } from '@teleporthq/teleport-postprocessor-prettier-js'
+import { createPlugin as createImportPlugin } from '@teleporthq/teleport-plugin-import-statements'
 
-import prettierJS from '@teleporthq/teleport-postprocessor-prettier-js'
+import stencilAppRouting from '@teleporthq/teleport-plugin-stencil-app-routing'
 import prettierHTML from '@teleporthq/teleport-postprocessor-prettier-html'
 
 import { Mapping } from '@teleporthq/teleport-types'
@@ -11,12 +13,15 @@ import { Mapping } from '@teleporthq/teleport-types'
 import stencilProjectMapping from './stencil-mapping.json'
 
 export const createStencilProjectGenerator = () => {
+  const prettierJS = createPostProcessor({ fileType: FILE_TYPE.TSX })
+  const importStatementsPlugin = createImportPlugin({ fileType: FILE_TYPE.TSX })
+
   const stencilComponentGenerator = createStencilComponentGenerator()
   stencilComponentGenerator.addMapping(stencilProjectMapping as Mapping)
 
-  const routerPlugin = createRouterPlugin({ flavor: 'stencil' })
-  const routingComponentGenerator = createStencilComponentGenerator()
-  routingComponentGenerator.addPlugin(routerPlugin)
+  const routingComponentGenerator = createComponentGenerator()
+  routingComponentGenerator.addPlugin(stencilAppRouting)
+  routingComponentGenerator.addPlugin(importStatementsPlugin)
   routingComponentGenerator.addPostProcessor(prettierJS)
 
   const htmlFileGenerator = createComponentGenerator()

--- a/packages/teleport-project-generator-stencil/src/index.ts
+++ b/packages/teleport-project-generator-stencil/src/index.ts
@@ -54,10 +54,10 @@ export const createStencilProjectGenerator = () => {
       options: {
         appRootOverride: `<app-root></app-root>`,
         customScriptTags: [
-          { type: 'module', path: 'build/app.esm.js' },
-          { type: 'nomodule', path: 'buid/app.js' },
+          { type: 'module', path: '/build/app.esm.js' },
+          { type: 'nomodule', path: '/buid/app.js' },
         ],
-        customLinkTags: [{ type: 'stylesheet', path: 'build/app.css' }],
+        customLinkTags: [{ type: 'stylesheet', path: '/build/app.css' }],
       },
     },
     static: {

--- a/packages/teleport-project-generator-stencil/src/index.ts
+++ b/packages/teleport-project-generator-stencil/src/index.ts
@@ -45,12 +45,18 @@ export const createStencilProjectGenerator = () => {
     router: {
       generator: routingComponentGenerator,
       path: ['src', 'components'],
-      fileName: 'app',
+      fileName: 'app-root',
     },
     entry: {
       generator: htmlFileGenerator,
+      appRootOverride: `<app-root></app-root>`,
       path: ['src'],
       fileName: 'index',
+      customScriptTags: [
+        { type: 'module', path: ['build', 'app.esm.js'] },
+        { type: 'nomodule', path: ['buid', 'app.js'] },
+      ],
+      customLinkTags: [{ type: 'stylesheet', path: ['build', 'app.css'] }],
     },
     static: {
       prefix: '/assets',

--- a/packages/teleport-project-generator-stencil/src/index.ts
+++ b/packages/teleport-project-generator-stencil/src/index.ts
@@ -1,0 +1,59 @@
+import { createProjectGenerator } from '@teleporthq/teleport-project-generator'
+import { createStencilComponentGenerator } from '@teleporthq/teleport-component-generator-stencil'
+import { createComponentGenerator } from '@teleporthq/teleport-component-generator'
+import { createPlugin as createRouterPlugin } from '@teleporthq/teleport-plugin-react-app-routing'
+
+import prettierJS from '@teleporthq/teleport-postprocessor-prettier-js'
+import prettierHTML from '@teleporthq/teleport-postprocessor-prettier-html'
+
+import { Mapping } from '@teleporthq/teleport-types'
+
+import stencilProjectMapping from './stencil-mapping.json'
+
+export const createStencilProjectGenerator = () => {
+  const stencilComponentGenerator = createStencilComponentGenerator()
+  stencilComponentGenerator.addMapping(stencilProjectMapping as Mapping)
+
+  const routerPlugin = createRouterPlugin({ flavor: 'stencil' })
+  const routingComponentGenerator = createStencilComponentGenerator()
+  routingComponentGenerator.addPlugin(routerPlugin)
+  routingComponentGenerator.addPostProcessor(prettierJS)
+
+  const htmlFileGenerator = createComponentGenerator()
+  htmlFileGenerator.addPostProcessor(prettierHTML)
+
+  const generator = createProjectGenerator({
+    components: {
+      generator: stencilComponentGenerator,
+      path: ['src', 'components'],
+      options: {
+        createFolderForEachComponent: true,
+      },
+    },
+    pages: {
+      generator: stencilComponentGenerator,
+      path: ['src', 'components'],
+      options: {
+        createFolderForEachComponent: true,
+      },
+    },
+    router: {
+      generator: routingComponentGenerator,
+      path: ['src', 'components'],
+      fileName: 'app',
+    },
+    entry: {
+      generator: htmlFileGenerator,
+      path: ['src'],
+      fileName: 'index',
+    },
+    static: {
+      prefix: '/assets',
+      path: ['src', 'assets'],
+    },
+  })
+
+  return generator
+}
+
+export default createStencilProjectGenerator()

--- a/packages/teleport-project-generator-stencil/src/index.ts
+++ b/packages/teleport-project-generator-stencil/src/index.ts
@@ -53,10 +53,10 @@ export const createStencilProjectGenerator = () => {
       path: ['src'],
       fileName: 'index',
       customScriptTags: [
-        { type: 'module', path: ['build', 'app.esm.js'] },
-        { type: 'nomodule', path: ['buid', 'app.js'] },
+        { type: 'module', path: 'build/app.esm.js' },
+        { type: 'nomodule', path: 'buid/app.js' },
       ],
-      customLinkTags: [{ type: 'stylesheet', path: ['build', 'app.css'] }],
+      customLinkTags: [{ type: 'stylesheet', path: 'build/app.css' }],
     },
     static: {
       prefix: '/assets',

--- a/packages/teleport-project-generator-stencil/src/index.ts
+++ b/packages/teleport-project-generator-stencil/src/index.ts
@@ -49,14 +49,16 @@ export const createStencilProjectGenerator = () => {
     },
     entry: {
       generator: htmlFileGenerator,
-      appRootOverride: `<app-root></app-root>`,
       path: ['src'],
       fileName: 'index',
-      customScriptTags: [
-        { type: 'module', path: 'build/app.esm.js' },
-        { type: 'nomodule', path: 'buid/app.js' },
-      ],
-      customLinkTags: [{ type: 'stylesheet', path: 'build/app.css' }],
+      options: {
+        appRootOverride: `<app-root></app-root>`,
+        customScriptTags: [
+          { type: 'module', path: 'build/app.esm.js' },
+          { type: 'nomodule', path: 'buid/app.js' },
+        ],
+        customLinkTags: [{ type: 'stylesheet', path: 'build/app.css' }],
+      },
     },
     static: {
       prefix: '/assets',

--- a/packages/teleport-project-generator-stencil/src/stencil-mapping.json
+++ b/packages/teleport-project-generator-stencil/src/stencil-mapping.json
@@ -1,0 +1,15 @@
+{
+  "elements": {
+    "navlink": {
+      "elementType": "Link",
+      "dependency": {
+        "type": "library",
+        "path": "@stencil/router",
+        "version": "1.0.1",
+        "meta": {
+          "namedImport": true
+        }
+      }
+    }
+  }
+}

--- a/packages/teleport-project-generator-stencil/src/stencil-mapping.json
+++ b/packages/teleport-project-generator-stencil/src/stencil-mapping.json
@@ -1,7 +1,7 @@
 {
   "elements": {
     "navlink": {
-      "elementType": "Link",
+      "elementType": "stencil-route-link",
       "dependency": {
         "type": "library",
         "path": "@stencil/router",
@@ -9,6 +9,9 @@
         "meta": {
           "namedImport": true
         }
+      },
+      "attrs": {
+        "url":{ "type": "dynamic", "content": { "referenceType": "attr", "id": "transitionTo" } }
       }
     }
   }

--- a/packages/teleport-project-generator-stencil/tsconfig-cjs.json
+++ b/packages/teleport-project-generator-stencil/tsconfig-cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "commonjs",
+    "target": "es5"
+  },
+  "include": [
+    "./src"
+  ]
+}

--- a/packages/teleport-project-generator-stencil/tsconfig-esm.json
+++ b/packages/teleport-project-generator-stencil/tsconfig-esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": [
+    "./src"
+  ]
+}

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -191,7 +191,7 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
     }
   })
 
-  // Stencil need to inject and point out the generated build files
+  // For frameworks that need to inject and point out the generated build files
   if (customScriptTags.length > 0) {
     customScriptTags.forEach((tag: CustomScriptTag) => {
       const { type, path } = tag
@@ -201,7 +201,7 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
       } else {
         addAttributeToNode(scriptTag, 'nomodule', '')
       }
-      addAttributeToNode(scriptTag, 'src', path.join('/'))
+      addAttributeToNode(scriptTag, 'src', path)
       addChildNode(headNode, scriptTag)
     })
   }
@@ -210,7 +210,7 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
     customLinkTags.forEach((tag: CustomLinkTag) => {
       const { path, type } = tag
       const linkTag = createHTMLNode('link')
-      addAttributeToNode(linkTag, 'href', path.join('/'))
+      addAttributeToNode(linkTag, 'href', path)
       addAttributeToNode(linkTag, 'rel', type)
       addChildNode(headNode, linkTag)
     })

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -70,10 +70,12 @@ export const createEntryFile = async (
   // If no function is provided in the strategy, the createHTMLEntryFileChunks is used by default
   const chunkGenerationFunction =
     strategy.entry.chunkGenerationFunction || createHTMLEntryFileChunks
-  const appRootOverride = strategy.entry.appRootOverride || null
+  const { options } = strategy.entry
+
+  const appRootOverride = (options && options.appRootOverride) || null
   const entryFileName = strategy.entry.fileName || 'index'
-  const customScriptTags = strategy.entry.customScriptTags || []
-  const customLinkTags = strategy.entry.customLinkTags || []
+  const customScriptTags = (options && options.customScriptTags) || []
+  const customLinkTags = (options && options.customLinkTags) || []
   const chunks = chunkGenerationFunction(uidl, {
     assetsPrefix,
     appRootOverride,

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -119,6 +119,31 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
     addChildNode(headNode, titleTag)
   }
 
+  // For frameworks that need to inject and point out the generated build files
+  if (customScriptTags.length > 0) {
+    customScriptTags.forEach((tag: CustomScriptTag) => {
+      const { type, path } = tag
+      const scriptTag = createHTMLNode('script')
+      if (type === 'module') {
+        addAttributeToNode(scriptTag, 'type', type)
+      } else {
+        addAttributeToNode(scriptTag, 'nomodule', '')
+      }
+      addAttributeToNode(scriptTag, 'src', path)
+      addChildNode(headNode, scriptTag)
+    })
+  }
+
+  if (customLinkTags.length > 0) {
+    customLinkTags.forEach((tag: CustomLinkTag) => {
+      const { path, type } = tag
+      const linkTag = createHTMLNode('link')
+      addAttributeToNode(linkTag, 'href', path)
+      addAttributeToNode(linkTag, 'rel', type)
+      addChildNode(headNode, linkTag)
+    })
+  }
+
   if (manifest) {
     const linkTag = createHTMLNode('link') // , { selfClosing: true })
     addAttributeToNode(linkTag, 'rel', 'manifest')
@@ -192,31 +217,6 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
       addChildNode(headNode, iconTag)
     }
   })
-
-  // For frameworks that need to inject and point out the generated build files
-  if (customScriptTags.length > 0) {
-    customScriptTags.forEach((tag: CustomScriptTag) => {
-      const { type, path } = tag
-      const scriptTag = createHTMLNode('script')
-      if (type === 'module') {
-        addAttributeToNode(scriptTag, 'type', type)
-      } else {
-        addAttributeToNode(scriptTag, 'nomodule', '')
-      }
-      addAttributeToNode(scriptTag, 'src', path)
-      addChildNode(headNode, scriptTag)
-    })
-  }
-
-  if (customLinkTags.length > 0) {
-    customLinkTags.forEach((tag: CustomLinkTag) => {
-      const { path, type } = tag
-      const linkTag = createHTMLNode('link')
-      addAttributeToNode(linkTag, 'href', path)
-      addAttributeToNode(linkTag, 'rel', type)
-      addChildNode(headNode, linkTag)
-    })
-  }
 
   const chunks: Record<string, ChunkDefinition[]> = {
     [FILE_TYPE.HTML]: [

--- a/packages/teleport-project-packer-test/package.json
+++ b/packages/teleport-project-packer-test/package.json
@@ -22,15 +22,15 @@
     "start": "TS_NODE_FILES=true ts-node --project tsconfig.json ./src/index.ts"
   },
   "dependencies": {
-    "@teleporthq/teleport-project-generator-react": "^0.8.1",
-    "@teleporthq/teleport-project-generator-next": "^0.8.1",
-    "@teleporthq/teleport-project-generator-vue": "^0.8.1",
-    "@teleporthq/teleport-project-generator-nuxt": "^0.8.1",
-    "@teleporthq/teleport-project-generator-preact": "^0.8.1",
-    "@teleporthq/teleport-project-generator-stencil": "^0.8.1",
-    "@teleporthq/teleport-project-packer": "^0.8.1",
-    "@teleporthq/teleport-publisher-disk": "^0.8.1",
-    "@teleporthq/teleport-types": "^0.8.1"
+    "@teleporthq/teleport-project-generator-react": "^0.9.0",
+    "@teleporthq/teleport-project-generator-next": "^0.9.0",
+    "@teleporthq/teleport-project-generator-vue": "^0.9.0",
+    "@teleporthq/teleport-project-generator-nuxt": "^0.9.0",
+    "@teleporthq/teleport-project-generator-preact": "^0.9.0",
+    "@teleporthq/teleport-project-generator-stencil": "^0.9.0",
+    "@teleporthq/teleport-project-packer": "^0.9.0",
+    "@teleporthq/teleport-publisher-disk": "^0.9.0",
+    "@teleporthq/teleport-types": "^0.9.0"
   },
   "devDependencies": {
     "ts-node": "^8.1.0",

--- a/packages/teleport-project-packer-test/package.json
+++ b/packages/teleport-project-packer-test/package.json
@@ -22,14 +22,15 @@
     "start": "TS_NODE_FILES=true ts-node --project tsconfig.json ./src/index.ts"
   },
   "dependencies": {
-    "@teleporthq/teleport-project-generator-next": "^0.9.0",
-    "@teleporthq/teleport-project-generator-nuxt": "^0.9.0",
-    "@teleporthq/teleport-project-generator-preact": "^0.9.0",
-    "@teleporthq/teleport-project-generator-react": "^0.9.0",
-    "@teleporthq/teleport-project-generator-vue": "^0.9.0",
-    "@teleporthq/teleport-project-packer": "^0.9.0",
-    "@teleporthq/teleport-publisher-disk": "^0.9.0",
-    "@teleporthq/teleport-types": "^0.9.0"
+    "@teleporthq/teleport-project-generator-react": "^0.8.1",
+    "@teleporthq/teleport-project-generator-next": "^0.8.1",
+    "@teleporthq/teleport-project-generator-vue": "^0.8.1",
+    "@teleporthq/teleport-project-generator-nuxt": "^0.8.1",
+    "@teleporthq/teleport-project-generator-preact": "^0.8.1",
+    "@teleporthq/teleport-project-generator-stencil": "^0.8.1",
+    "@teleporthq/teleport-project-packer": "^0.8.1",
+    "@teleporthq/teleport-publisher-disk": "^0.8.1",
+    "@teleporthq/teleport-types": "^0.8.1"
   },
   "devDependencies": {
     "ts-node": "^8.1.0",

--- a/packages/teleport-project-packer-test/src/constants.ts
+++ b/packages/teleport-project-packer-test/src/constants.ts
@@ -9,3 +9,7 @@ export const VUE_GITHUB_PROJECT = 'teleport-project-template-vue'
 export const NUXT_GITHUB_PROJECT = 'teleport-project-template-nuxt'
 
 export const PREACT_GITHUB_PROJECT = 'teleport-project-template-preact'
+
+export const STENCIL_AUTHOR = 'JayaKrishnaNamburu'
+
+export const STENCIL_GITHUB_PROJECT = 'teleport-project-template-stencil'

--- a/packages/teleport-project-packer-test/src/constants.ts
+++ b/packages/teleport-project-packer-test/src/constants.ts
@@ -10,6 +10,4 @@ export const NUXT_GITHUB_PROJECT = 'teleport-project-template-nuxt'
 
 export const PREACT_GITHUB_PROJECT = 'teleport-project-template-preact'
 
-export const STENCIL_AUTHOR = 'JayaKrishnaNamburu'
-
 export const STENCIL_GITHUB_PROJECT = 'teleport-project-template-stencil'

--- a/packages/teleport-project-packer-test/src/index.ts
+++ b/packages/teleport-project-packer-test/src/index.ts
@@ -5,6 +5,7 @@ import nextGenerator from '@teleporthq/teleport-project-generator-next'
 import vueGenerator from '@teleporthq/teleport-project-generator-vue'
 import nuxtGenerator from '@teleporthq/teleport-project-generator-nuxt'
 import preactGenerator from '@teleporthq/teleport-project-generator-preact'
+import stencilGenerator from '@teleporthq/teleport-project-generator-stencil'
 
 import { createDiskPublisher } from '@teleporthq/teleport-publisher-disk'
 import { RemoteTemplateDefinition } from '@teleporthq/teleport-types'
@@ -18,6 +19,8 @@ import {
   VUE_GITHUB_PROJECT,
   NUXT_GITHUB_PROJECT,
   PREACT_GITHUB_PROJECT,
+  STENCIL_AUTHOR,
+  STENCIL_GITHUB_PROJECT,
 } from './constants'
 
 import projectUIDL from '../../../examples/uidl-samples/project.json'
@@ -28,6 +31,7 @@ const generators = {
   vue: vueGenerator,
   nuxt: nuxtGenerator,
   preact: preactGenerator,
+  stencil: stencilGenerator,
 }
 
 const getGithubRemoteDefinition = (username: string, repo: string): RemoteTemplateDefinition => {
@@ -40,6 +44,7 @@ const templates = {
   vue: getGithubRemoteDefinition(GITHUB_TEMPLATE_OWNER, VUE_GITHUB_PROJECT),
   nuxt: getGithubRemoteDefinition(GITHUB_TEMPLATE_OWNER, NUXT_GITHUB_PROJECT),
   preact: getGithubRemoteDefinition(GITHUB_TEMPLATE_OWNER, PREACT_GITHUB_PROJECT),
+  stencil: getGithubRemoteDefinition(STENCIL_AUTHOR, STENCIL_GITHUB_PROJECT),
 }
 
 const publisher = createDiskPublisher({
@@ -65,10 +70,11 @@ const packProject = async (projectType: string) => {
 const run = async () => {
   try {
     await packProject('react')
-    await packProject('next')
-    await packProject('vue')
-    await packProject('nuxt')
-    await packProject('preact')
+    // await packProject('next')
+    // await packProject('vue')
+    // await packProject('nuxt')
+    // await packProject('preact')
+    await packProject('stencil')
   } catch (e) {
     console.info(e)
   }

--- a/packages/teleport-project-packer-test/src/index.ts
+++ b/packages/teleport-project-packer-test/src/index.ts
@@ -68,11 +68,11 @@ const packProject = async (projectType: string) => {
 
 const run = async () => {
   try {
-    await packProject('react')
-    await packProject('next')
-    await packProject('vue')
-    await packProject('nuxt')
-    await packProject('preact')
+    // await packProject('react')
+    // await packProject('next')
+    // await packProject('vue')
+    // await packProject('nuxt')
+    // await packProject('preact')
     await packProject('stencil')
   } catch (e) {
     console.info(e)

--- a/packages/teleport-project-packer-test/src/index.ts
+++ b/packages/teleport-project-packer-test/src/index.ts
@@ -68,11 +68,11 @@ const packProject = async (projectType: string) => {
 
 const run = async () => {
   try {
-    // await packProject('react')
-    // await packProject('next')
-    // await packProject('vue')
-    // await packProject('nuxt')
-    // await packProject('preact')
+    await packProject('react')
+    await packProject('next')
+    await packProject('vue')
+    await packProject('nuxt')
+    await packProject('preact')
     await packProject('stencil')
   } catch (e) {
     console.info(e)

--- a/packages/teleport-project-packer-test/src/index.ts
+++ b/packages/teleport-project-packer-test/src/index.ts
@@ -19,7 +19,6 @@ import {
   VUE_GITHUB_PROJECT,
   NUXT_GITHUB_PROJECT,
   PREACT_GITHUB_PROJECT,
-  STENCIL_AUTHOR,
   STENCIL_GITHUB_PROJECT,
 } from './constants'
 
@@ -44,7 +43,7 @@ const templates = {
   vue: getGithubRemoteDefinition(GITHUB_TEMPLATE_OWNER, VUE_GITHUB_PROJECT),
   nuxt: getGithubRemoteDefinition(GITHUB_TEMPLATE_OWNER, NUXT_GITHUB_PROJECT),
   preact: getGithubRemoteDefinition(GITHUB_TEMPLATE_OWNER, PREACT_GITHUB_PROJECT),
-  stencil: getGithubRemoteDefinition(STENCIL_AUTHOR, STENCIL_GITHUB_PROJECT),
+  stencil: getGithubRemoteDefinition(GITHUB_TEMPLATE_OWNER, STENCIL_GITHUB_PROJECT),
 }
 
 const publisher = createDiskPublisher({
@@ -70,10 +69,10 @@ const packProject = async (projectType: string) => {
 const run = async () => {
   try {
     await packProject('react')
-    // await packProject('next')
-    // await packProject('vue')
-    // await packProject('nuxt')
-    // await packProject('preact')
+    await packProject('next')
+    await packProject('vue')
+    await packProject('nuxt')
+    await packProject('preact')
     await packProject('stencil')
   } catch (e) {
     console.info(e)

--- a/packages/teleport-shared/src/node-handlers/node-to-jsx/index.ts
+++ b/packages/teleport-shared/src/node-handlers/node-to-jsx/index.ts
@@ -26,10 +26,8 @@ import {
   addChildJSXTag,
   addAttributeToJSXTag,
   addDynamicAttributeToJSXTag,
-  renameJSXTag,
 } from '../../utils/ast-jsx-utils'
 import { createJSXTag, createSelfClosingJSXTag } from '../../builders/ast-builders'
-import { camelCaseToDashCase } from '../../utils/string-utils'
 import { DEFAULT_JSX_OPTIONS } from './constants'
 
 const generateElementNode: NodeToJSX<UIDLElementNode, types.JSXElement> = (
@@ -40,13 +38,12 @@ const generateElementNode: NodeToJSX<UIDLElementNode, types.JSXElement> = (
   const options = { ...DEFAULT_JSX_OPTIONS, ...jsxOptions }
   const { dependencies, nodesLookup } = params
   const { elementType, children, key, attrs, dependency, events } = node.content
-  // Append app for only local dependencies
-  const elementTag =
+
+  const elementName =
     dependency && dependency.type === 'local' && options.customElementTag
-      ? createJSXTag(options.customElementTag(elementType))
-      : children
-      ? createJSXTag(elementType)
-      : createSelfClosingJSXTag(elementType)
+      ? options.customElementTag(elementType)
+      : elementType
+  const elementTag = children ? createJSXTag(elementName) : createSelfClosingJSXTag(elementName)
 
   if (attrs) {
     Object.keys(attrs).forEach((attrKey) => {
@@ -77,11 +74,6 @@ const generateElementNode: NodeToJSX<UIDLElementNode, types.JSXElement> = (
     if (options.dependencyHandling === 'import') {
       // Make a copy to avoid reference leaking
       dependencies[elementType] = { ...dependency }
-    } else {
-      // Convert
-      const rootElementIdentifier = elementTag.openingElement.name as types.JSXIdentifier
-      const webComponentName = camelCaseToDashCase(rootElementIdentifier.name)
-      renameJSXTag(elementTag, webComponentName)
     }
   }
 

--- a/packages/teleport-shared/src/node-handlers/node-to-jsx/index.ts
+++ b/packages/teleport-shared/src/node-handlers/node-to-jsx/index.ts
@@ -40,7 +40,13 @@ const generateElementNode: NodeToJSX<UIDLElementNode, types.JSXElement> = (
   const options = { ...DEFAULT_JSX_OPTIONS, ...jsxOptions }
   const { dependencies, nodesLookup } = params
   const { elementType, children, key, attrs, dependency, events } = node.content
-  const elementTag = children ? createJSXTag(elementType) : createSelfClosingJSXTag(elementType)
+  // Append app for only local dependencies
+  const elementTag =
+    dependency && dependency.type === 'local' && options.customElementTag
+      ? createJSXTag(options.customElementTag(elementType))
+      : children
+      ? createJSXTag(elementType)
+      : createSelfClosingJSXTag(elementType)
 
   if (attrs) {
     Object.keys(attrs).forEach((attrKey) => {

--- a/packages/teleport-shared/src/node-handlers/node-to-jsx/types.ts
+++ b/packages/teleport-shared/src/node-handlers/node-to-jsx/types.ts
@@ -46,6 +46,7 @@ export interface JSXGenerationOptions {
     - 'props' will render a `props.children` node and needs some workarounds for multiple slots per component
   */
   slotHandling?: 'native' | 'props'
+  customElementTag?: (name: string) => string
 }
 
 export type NodeToJSX<NodeType, ReturnType> = (

--- a/packages/teleport-shared/src/utils/ast-jsx-utils.ts
+++ b/packages/teleport-shared/src/utils/ast-jsx-utils.ts
@@ -1,6 +1,5 @@
 import * as types from '@babel/types'
 import { convertValueToLiteral, objectToObjectExpression } from './ast-js-utils'
-import { camelCaseToDashCase } from './string-utils'
 
 /**
  * Adds a class definition string to an existing string of classes
@@ -148,15 +147,8 @@ export const renameJSXTag = (jsxTag: types.JSXElement, newName: string, t = type
   }
 }
 
-export const createComponentDecorator = (name: string, t = types) => {
-  /* Stencil/ WebComponents follows a dash-cased convention for naming. Adding a 
-   dash by default, so we won'r into edge cases where comp having only a single word as name */
+export const createComponentDecorator = (params, t = types) => {
   return t.decorator(
-    t.callExpression(t.identifier('Component'), [
-      objectToObjectExpression({
-        tag: `app-${camelCaseToDashCase(name)}`,
-        shadow: true,
-      }),
-    ])
+    t.callExpression(t.identifier('Component'), [objectToObjectExpression(params)])
   )
 }

--- a/packages/teleport-shared/src/utils/ast-jsx-utils.ts
+++ b/packages/teleport-shared/src/utils/ast-jsx-utils.ts
@@ -1,5 +1,6 @@
 import * as types from '@babel/types'
-import { convertValueToLiteral } from './ast-js-utils'
+import { convertValueToLiteral, objectToObjectExpression } from './ast-js-utils'
+import { camelCaseToDashCase } from './string-utils'
 
 /**
  * Adds a class definition string to an existing string of classes
@@ -145,4 +146,15 @@ export const renameJSXTag = (jsxTag: types.JSXElement, newName: string, t = type
   if (jsxTag.closingElement) {
     jsxTag.closingElement.name = t.jsxIdentifier(newName)
   }
+}
+
+export const createComponentDecorator = (name: string, t = types) => {
+  return t.decorator(
+    t.callExpression(t.identifier('Component'), [
+      objectToObjectExpression({
+        tag: camelCaseToDashCase(name),
+        shadow: true,
+      }),
+    ])
+  )
 }

--- a/packages/teleport-shared/src/utils/ast-jsx-utils.ts
+++ b/packages/teleport-shared/src/utils/ast-jsx-utils.ts
@@ -149,10 +149,12 @@ export const renameJSXTag = (jsxTag: types.JSXElement, newName: string, t = type
 }
 
 export const createComponentDecorator = (name: string, t = types) => {
+  /* Stencil/ WebComponents follows a dash-cased convention for naming. Adding a 
+   dash by default, so we won'r into edge cases where comp having only a single word as name */
   return t.decorator(
     t.callExpression(t.identifier('Component'), [
       objectToObjectExpression({
-        tag: camelCaseToDashCase(name),
+        tag: `app-${camelCaseToDashCase(name)}`,
         shadow: true,
       }),
     ])

--- a/packages/teleport-types/src/generators.ts
+++ b/packages/teleport-types/src/generators.ts
@@ -142,6 +142,8 @@ export interface ProjectStrategy {
       options: EntryFileOptions
     ) => Record<string, ChunkDefinition[]>
     appRootOverride?: string
+    customScriptTags?: CustomScriptTag[]
+    customLinkTags?: CustomLinkTag[]
   }
   static: {
     prefix?: string
@@ -149,9 +151,21 @@ export interface ProjectStrategy {
   }
 }
 
+export interface CustomLinkTag {
+  type: string
+  path: string[]
+}
+
+export interface CustomScriptTag {
+  type: string
+  path: string[]
+}
+
 export interface EntryFileOptions {
   assetsPrefix?: string
   appRootOverride?: string
+  customScriptTags?: CustomScriptTag[]
+  customLinkTags?: CustomLinkTag[]
 }
 
 export interface GeneratedFolder {

--- a/packages/teleport-types/src/generators.ts
+++ b/packages/teleport-types/src/generators.ts
@@ -141,9 +141,11 @@ export interface ProjectStrategy {
       uidl: ProjectUIDL,
       options: EntryFileOptions
     ) => Record<string, ChunkDefinition[]>
-    appRootOverride?: string
-    customScriptTags?: CustomScriptTag[]
-    customLinkTags?: CustomLinkTag[]
+    options?: {
+      appRootOverride?: string
+      customScriptTags?: CustomScriptTag[]
+      customLinkTags?: CustomLinkTag[]
+    }
   }
   static: {
     prefix?: string

--- a/packages/teleport-types/src/generators.ts
+++ b/packages/teleport-types/src/generators.ts
@@ -153,12 +153,12 @@ export interface ProjectStrategy {
 
 export interface CustomLinkTag {
   type: string
-  path: string[]
+  path: string
 }
 
 export interface CustomScriptTag {
   type: string
-  path: string[]
+  path: string
 }
 
 export interface EntryFileOptions {


### PR DESCRIPTION
*Stencil Generator* is almost completed, but here are the two limitations that we need to look into

- There are few reserve keywords in Stencil like `title`. we need to make a list and cross-check when the UIDL contains such declarations
- We add attributes directly to the `jsx` tags like 
```
<textaread rows="8" cols="50" />
```
Since we have type-checking enabled in the stencil, binding numeric characters like above is not supported. Instead, it should be

```
<textarea rows={8} cols={50}
```