### PR TITLE
Rename packer.loadTemplate to packer.loadRemoteTemplate

### DIFF
--- a/packages/teleport-project-packer/__tests__/index.ts
+++ b/packages/teleport-project-packer/__tests__/index.ts
@@ -34,7 +34,7 @@ const assetsData = {
 describe('teleport generic project packer', () => {
   it('creates a new instance of generic packer', () => {
     const packer = createProjectPacker()
-    expect(packer.loadTemplate).toBeDefined()
+    expect(packer.loadRemoteTemplate).toBeDefined()
     expect(packer.pack).toBeDefined()
     expect(packer.setAssets).toBeDefined()
     expect(packer.setGenerator).toBeDefined()

--- a/packages/teleport-project-packer/src/index.ts
+++ b/packages/teleport-project-packer/src/index.ts
@@ -23,7 +23,7 @@ export type PackerFactory = (
   params?: PackerFactoryParams
 ) => {
   pack: (projectUIDL?: ProjectUIDL, params?: PackerFactoryParams) => Promise<PublisherResponse<any>>
-  loadTemplate: (remoteTemplateDefinition: RemoteTemplateDefinition) => Promise<void>
+  loadRemoteTemplate: (remoteTemplateDefinition: RemoteTemplateDefinition) => Promise<void>
   setPublisher: <T, U>(publisher: Publisher<T, U>) => void
   setGenerator: (generator: ProjectGenerator) => void
   setAssets: (assets: AssetsDefinition) => void
@@ -51,7 +51,7 @@ export const createProjectPacker: PackerFactory = (params: PackerFactoryParams =
     template = templateFolder
   }
 
-  const loadTemplate = async (remoteDefinition: RemoteTemplateDefinition): Promise<void> => {
+  const loadRemoteTemplate = async (remoteDefinition: RemoteTemplateDefinition): Promise<void> => {
     template = await fetchTemplate(remoteDefinition)
   }
 
@@ -90,7 +90,7 @@ export const createProjectPacker: PackerFactory = (params: PackerFactoryParams =
     setGenerator,
     setAssets,
     setTemplate,
-    loadTemplate,
+    loadRemoteTemplate,
     pack,
   }
 }

--- a/packages/teleport-test/src/packer.ts
+++ b/packages/teleport-test/src/packer.ts
@@ -63,7 +63,7 @@ const packProject = async (projectType: string) => {
 
   projectPacker.setPublisher(publisher)
   projectPacker.setGenerator(generators[projectType])
-  await projectPacker.loadTemplate(remoteTemplate)
+  await projectPacker.loadRemoteTemplate(remoteTemplate)
 
   const result = await projectPacker.pack((projectUIDL as unknown) as ProjectUIDL)
 


### PR DESCRIPTION
Hello 👋,

This PR renames the `loadTemplate` method of the packer to `loadRemoteTemplate` as requested [here](https://github.com/teleporthq/teleport-code-generators/issues/377).

EDIT: closes #377 