### PR TITLE
feat(gatsby-proj): support for custom manifest in gatsby

### DIFF
--- a/packages/teleport-project-generator-gatsby/src/index.ts
+++ b/packages/teleport-project-generator-gatsby/src/index.ts
@@ -53,7 +53,7 @@ const createGatsbyProjectGenerator = () => {
     },
     static: {
       prefix: '',
-      path: ['src', 'images'],
+      path: ['static'],
     },
   })
 

--- a/packages/teleport-project-generator-gatsby/src/project-template.ts
+++ b/packages/teleport-project-generator-gatsby/src/project-template.ts
@@ -14,7 +14,6 @@ export default {
   "dependencies": {
     "gatsby": "^2.15.36",
     "gatsby-image": "^2.2.27",
-    "gatsby-plugin-manifest": "^2.2.21",
     "gatsby-plugin-offline": "^3.0.14",
     "gatsby-plugin-react-helmet": "^3.1.11",
     "gatsby-plugin-sharp": "^2.2.29",
@@ -63,26 +62,12 @@ export default {
       resolve: 'gatsby-source-filesystem',
       options: {
         name: 'images',
-        path: ${String('`${__dirname}/src/images`')}
+        path: ${String('`${__dirname}/static/playground_assets`')}
       },
     },
     'gatsby-transformer-sharp',
-    'gatsby-plugin-sharp',
-    {
-      resolve: 'gatsby-plugin-manifest',
-      options: {
-        name: 'gatsby-starter-default',
-        short_name: 'starter',
-        start_url: '/',
-        background_color: '#663399',
-        theme_color: '#663399',
-        display: 'minimal-ui',
-      },
-    },
-    // this (optional) plugin enables Progressive Web App + Offline functionality
-    // To learn more, visit: https://gatsby.dev/offline
-    // 'gatsby-plugin-offline',
-  ],
+    'gatsby-plugin-sharp'
+    ],
 }`,
     },
     {

--- a/packages/teleport-project-generator-gatsby/src/utils.ts
+++ b/packages/teleport-project-generator-gatsby/src/utils.ts
@@ -69,11 +69,13 @@ const generateHTMLNode = (uidl: ProjectUIDL, options: EntryFileOptions, t = type
   const headNode = ASTBuilders.createJSXTag('head')
   const bodyNode = ASTBuilders.createJSXTag('body')
   const noScriptNode = ASTBuilders.createJSXTag('noscript')
-  const manifestTag = ASTBuilders.createJSXTag('link')
 
-  ASTUtils.addAttributeToJSXTag(manifestTag, 'rel', 'manifest')
-  ASTUtils.addAttributeToJSXTag(manifestTag, 'href', '/manifest.json')
-  ASTUtils.addChildJSXTag(headNode, manifestTag)
+  if (uidl.globals.manifest) {
+    const manifestTag = ASTBuilders.createJSXTag('link')
+    ASTUtils.addAttributeToJSXTag(manifestTag, 'rel', 'manifest')
+    ASTUtils.addAttributeToJSXTag(manifestTag, 'href', '/manifest.json')
+    ASTUtils.addChildJSXTag(headNode, manifestTag)
+  }
 
   const charSetMetaTag = ASTBuilders.createSelfClosingJSXTag('meta')
   ASTUtils.addAttributeToJSXTag(charSetMetaTag, 'charSet', 'utf-8')

--- a/packages/teleport-project-generator-gatsby/src/utils.ts
+++ b/packages/teleport-project-generator-gatsby/src/utils.ts
@@ -69,6 +69,11 @@ const generateHTMLNode = (uidl: ProjectUIDL, options: EntryFileOptions, t = type
   const headNode = ASTBuilders.createJSXTag('head')
   const bodyNode = ASTBuilders.createJSXTag('body')
   const noScriptNode = ASTBuilders.createJSXTag('noscript')
+  const manifestTag = ASTBuilders.createJSXTag('link')
+
+  ASTUtils.addAttributeToJSXTag(manifestTag, 'rel', 'manifest')
+  ASTUtils.addAttributeToJSXTag(manifestTag, 'href', '/manifest.json')
+  ASTUtils.addChildJSXTag(headNode, manifestTag)
 
   const charSetMetaTag = ASTBuilders.createSelfClosingJSXTag('meta')
   ASTUtils.addAttributeToJSXTag(charSetMetaTag, 'charSet', 'utf-8')


### PR DESCRIPTION
fixes #397 

I cross-checked and we don't need to make changes for gridsome.