### PR TITLE
feat(proj-styles): adding support for conditions for project-styles

### DIFF
--- a/packages/teleport-plugin-common/src/builders/style-builders.ts
+++ b/packages/teleport-plugin-common/src/builders/style-builders.ts
@@ -72,3 +72,20 @@ export const createDynamicStyleExpression = (
       )
   }
 }
+
+export const generateMediaStyle = (mediaStylesMap: Record<string, Record<string, unknown>>) => {
+  const styles: string[] = []
+  Object.keys(mediaStylesMap)
+    .sort((a: string, b: string) => Number(a) - Number(b))
+    .reverse()
+    .forEach((mediaOffset: string) => {
+      styles.push(
+        createCSSClassWithMediaQuery(
+          `max-width: ${mediaOffset}px`,
+          // @ts-ignore
+          mediaStylesMap[mediaOffset]
+        )
+      )
+    })
+  return styles
+}

--- a/packages/teleport-plugin-css-modules/__tests__/style-sheet.ts
+++ b/packages/teleport-plugin-css-modules/__tests__/style-sheet.ts
@@ -25,6 +25,31 @@ describe('plugin-css-modules-style-sheet', () => {
           color: staticNode('blue'),
         },
       },
+      '5ecfa1233b8e50f60ea2b64c': {
+        id: '5ecfa1233b8e50f60ea2b64c',
+        name: 'conditionalButton',
+        type: 'reusable-project-style-map',
+        conditions: [
+          {
+            type: 'screen-size',
+            meta: { maxWidth: 991 },
+            content: {
+              backgrouns: staticNode('purple'),
+            },
+          },
+          {
+            type: 'element-state',
+            meta: { state: 'hover' },
+            content: {
+              background: staticNode('yellow'),
+            },
+          },
+        ],
+        content: {
+          background: staticNode('red'),
+          color: staticNode('blue'),
+        },
+      },
     }
 
     const { chunks } = await plugin(structure)
@@ -33,6 +58,8 @@ describe('plugin-css-modules-style-sheet', () => {
     expect(cssFile).toBeDefined()
     expect(cssFile.content).toContain('.primaryButton')
     expect(cssFile.content).toContain('secondaryButton')
+    expect(cssFile.content).toContain('.conditionalButton:hover')
+    expect(cssFile.content).toContain('@media(max-width: 991px)')
     expect(cssFile.content).not.toContain('5ecfa1233b8e50f60ea2b64b')
   })
 

--- a/packages/teleport-plugin-css-modules/src/style-sheet.ts
+++ b/packages/teleport-plugin-css-modules/src/style-sheet.ts
@@ -5,7 +5,6 @@ import {
   ChunkType,
   FileType,
 } from '@teleporthq/teleport-types'
-
 interface StyleSheetPlugin {
   fileName?: string
   omitModuleextension?: boolean
@@ -25,8 +24,10 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
     }
 
     const cssMap: string[] = []
+    const mediaStylesMap: Record<string, Record<string, unknown>> = {}
+
     Object.values(styleSetDefinitions).forEach((style) => {
-      const { name, content } = style
+      const { name, content, conditions = [] } = style
       cssMap.push(
         StyleBuilders.createCSSClass(
           name,
@@ -34,7 +35,32 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
           StyleUtils.getContentOfStyleObject(content)
         )
       )
+
+      if (conditions.length === 0) {
+        return
+      }
+      conditions.forEach((styleRef) => {
+        if (styleRef.type === 'element-state') {
+          cssMap.push(
+            StyleBuilders.createCSSClassWithSelector(
+              name,
+              `&:${styleRef.meta.state}`,
+              // @ts-ignore
+              StyleUtils.getContentOfStyleObject(styleRef.content)
+            )
+          )
+        }
+
+        if (styleRef.type === 'screen-size') {
+          mediaStylesMap[styleRef.meta.maxWidth] = {
+            ...mediaStylesMap[styleRef.meta.maxWidth],
+            [name]: StyleUtils.getContentOfStyleObject(styleRef.content),
+          }
+        }
+      })
     })
+
+    cssMap.push(...StyleBuilders.generateMediaStyle(mediaStylesMap))
 
     const sheeName = omitModuleextension ? fileName : `${fileName}.module`
 

--- a/packages/teleport-plugin-css/__tests__/style-sheet.ts
+++ b/packages/teleport-plugin-css/__tests__/style-sheet.ts
@@ -25,6 +25,31 @@ describe('plugin-css-modules-style-sheet', () => {
           color: staticNode('blue'),
         },
       },
+      '5ecfa1233b8e50f60ea2b64c': {
+        id: '5ecfa1233b8e50f60ea2b64c',
+        name: 'conditionalButton',
+        type: 'reusable-project-style-map',
+        conditions: [
+          {
+            type: 'screen-size',
+            meta: { maxWidth: 991 },
+            content: {
+              backgrouns: staticNode('purple'),
+            },
+          },
+          {
+            type: 'element-state',
+            meta: { state: 'hover' },
+            content: {
+              background: staticNode('yellow'),
+            },
+          },
+        ],
+        content: {
+          background: staticNode('red'),
+          color: staticNode('blue'),
+        },
+      },
     }
 
     const { chunks } = await plugin(structure)
@@ -33,6 +58,8 @@ describe('plugin-css-modules-style-sheet', () => {
     expect(cssFile).toBeDefined()
     expect(cssFile.content).toContain('.primaryButton')
     expect(cssFile.content).toContain('secondaryButton')
+    expect(cssFile.content).toContain('.conditionalButton:hover')
+    expect(cssFile.content).toContain('@media(max-width: 991px)')
     expect(cssFile.content).not.toContain('5ecfa1233b8e50f60ea2b64b')
   })
 

--- a/packages/teleport-plugin-css/src/index.ts
+++ b/packages/teleport-plugin-css/src/index.ts
@@ -133,6 +133,11 @@ export const createCSSPlugin: ComponentPluginFactory<CSSPluginConfig> = (config)
               const { staticStyles } = UIDLUtils.splitDynamicAndStaticStyles(
                 styleRef.content.styles
               )
+
+              if (staticStyles && Object.keys(staticStyles).length === 0) {
+                return
+              }
+
               if (Object.keys(staticStyles).length > 0) {
                 const condition = styleRef.content.conditions[0]
                 const { conditionType } = condition
@@ -206,18 +211,7 @@ export const createCSSPlugin: ComponentPluginFactory<CSSPluginConfig> = (config)
     })
 
     if (Object.keys(mediaStylesMap).length > 0) {
-      Object.keys(mediaStylesMap)
-        .sort((a: string, b: string) => Number(a) - Number(b))
-        .reverse()
-        .forEach((mediaOffset: string) => {
-          jssStylesArray.push(
-            StyleBuilders.createCSSClassWithMediaQuery(
-              `max-width: ${mediaOffset}px`,
-              // @ts-ignore
-              mediaStylesMap[mediaOffset]
-            )
-          )
-        })
+      jssStylesArray.push(...StyleBuilders.generateMediaStyle(mediaStylesMap))
     }
 
     if (isProjectStyleReferred && projectStyleSet?.importFile) {

--- a/packages/teleport-plugin-react-jss/__tests__/style-sheet.ts
+++ b/packages/teleport-plugin-react-jss/__tests__/style-sheet.ts
@@ -59,10 +59,36 @@ describe('Style Sheet from styled components', () => {
           color: staticNode('blue'),
         },
       },
+      '5ecfa1233b8e50f60ea2b64c': {
+        id: '5ecfa1233b8e50f60ea2b64c',
+        name: 'conditionalButton',
+        type: 'reusable-project-style-map',
+        conditions: [
+          {
+            type: 'screen-size',
+            meta: { maxWidth: 991 },
+            content: {
+              backgrouns: staticNode('purple'),
+            },
+          },
+          {
+            type: 'element-state',
+            meta: { state: 'hover' },
+            content: {
+              background: staticNode('yellow'),
+            },
+          },
+        ],
+        content: {
+          background: staticNode('red'),
+          color: staticNode('blue'),
+        },
+      },
     }
 
     const result = await plugin(structure)
     const { chunks, dependencies } = result
+
     expect(chunks.length).toBe(2)
     expect(dependencies.createUseStyles.path).toBe('react-jss')
   })

--- a/packages/teleport-plugin-react-jss/src/index.ts
+++ b/packages/teleport-plugin-react-jss/src/index.ts
@@ -64,6 +64,11 @@ export const createReactJSSPlugin: ComponentPluginFactory<JSSConfig> = (config) 
             case 'inlined': {
               const { conditions } = styleRef.content
               const [condition] = conditions
+
+              if (styleRef.content?.styles && Object.keys(styleRef.content.styles).length === 0) {
+                return
+              }
+
               if (condition.conditionType === 'screen-size') {
                 jssStyleMap[className] = {
                   ...(jssStyleMap[className] as Record<string, string>),

--- a/packages/teleport-plugin-react-jss/src/index.ts
+++ b/packages/teleport-plugin-react-jss/src/index.ts
@@ -65,7 +65,7 @@ export const createReactJSSPlugin: ComponentPluginFactory<JSSConfig> = (config) 
               const { conditions } = styleRef.content
               const [condition] = conditions
 
-              if (styleRef.content?.styles && Object.keys(styleRef.content.styles).length === 0) {
+              if (!styleRef.content?.styles || Object.keys(styleRef.content.styles).length === 0) {
                 return
               }
 

--- a/packages/teleport-plugin-react-jss/src/style-sheet.ts
+++ b/packages/teleport-plugin-react-jss/src/style-sheet.ts
@@ -26,9 +26,40 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
 
     if (styleSetDefinitions && Object.keys(styleSetDefinitions)) {
       Object.values(styleSetDefinitions).forEach((style) => {
-        styleSet[StringUtils.dashCaseToCamelCase(style.name)] = StyleUtils.getContentOfStyleObject(
-          style.content
-        )
+        const { conditions = [] } = style
+        let styles = StyleUtils.getContentOfStyleObject(style.content)
+
+        if (conditions.length > 0) {
+          conditions.forEach((styleRef) => {
+            if (Object.keys(styleRef.content).length === 0) {
+              return
+            }
+
+            if (styleRef.type === 'screen-size') {
+              styles = {
+                ...styles,
+                ...{
+                  [`@media(max-width: ${styleRef.meta.maxWidth}px)`]: StyleUtils.getContentOfStyleObject(
+                    styleRef.content
+                  ),
+                },
+              }
+            }
+
+            if (styleRef.type === 'element-state') {
+              styles = {
+                ...styles,
+                ...{
+                  [`&:${styleRef.meta.state}`]: StyleUtils.getContentOfStyleObject(
+                    styleRef.content
+                  ),
+                },
+              }
+            }
+          })
+        }
+
+        styleSet[StringUtils.dashCaseToCamelCase(style.name)] = styles
       })
     }
 

--- a/packages/teleport-plugin-react-styled-components/__tests__/style-sheet.ts
+++ b/packages/teleport-plugin-react-styled-components/__tests__/style-sheet.ts
@@ -58,13 +58,38 @@ describe('Style Sheet from styled components', () => {
           color: staticNode('blue'),
         },
       },
+      '5ecfa1233b8e50f60ea2b64c': {
+        id: '5ecfa1233b8e50f60ea2b64c',
+        name: 'conditionalButton',
+        type: 'reusable-project-style-map',
+        conditions: [
+          {
+            type: 'screen-size',
+            meta: { maxWidth: 991 },
+            content: {
+              backgrouns: staticNode('purple'),
+            },
+          },
+          {
+            type: 'element-state',
+            meta: { state: 'hover' },
+            content: {
+              background: staticNode('yellow'),
+            },
+          },
+        ],
+        content: {
+          background: staticNode('red'),
+          color: staticNode('blue'),
+        },
+      },
     }
 
     const result = await plugin(structure)
     const { chunks, dependencies } = result
     const styleChunks = chunks.filter((chunk) => chunk.name === 'style')
 
-    expect(styleChunks.length).toBe(2)
+    expect(styleChunks.length).toBe(3)
     expect(dependencies.css.path).toBe('styled-components')
   })
 

--- a/packages/teleport-plugin-react-styled-components/src/index.ts
+++ b/packages/teleport-plugin-react-styled-components/src/index.ts
@@ -107,6 +107,11 @@ export const createReactStyledComponentsPlugin: ComponentPluginFactory<StyledCom
             case 'inlined': {
               const { conditions } = styleRef.content
               const [condition] = conditions
+
+              if (styleRef.content?.styles && Object.keys(styleRef.content.styles).length === 0) {
+                return
+              }
+
               if (condition.conditionType === 'screen-size') {
                 jssStyleMap[className] = {
                   ...(jssStyleMap[className] as Record<string, string>),

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { packProject } from '@teleporthq/teleport-code-generator'
 import { ProjectUIDL, PackerOptions, ProjectType, PublisherType } from '@teleporthq/teleport-types'
 
-import projectJSON from '../../../examples/uidl-samples/test.json'
+import projectJSON from '../../../examples/uidl-samples/project.json'
 
 const projectUIDL = (projectJSON as unknown) as ProjectUIDL
 const assetFile = readFileSync(join(__dirname, 'asset.png'))

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { packProject } from '@teleporthq/teleport-code-generator'
 import { ProjectUIDL, PackerOptions, ProjectType, PublisherType } from '@teleporthq/teleport-types'
 
-import projectJSON from '../../../examples/uidl-samples/project.json'
+import projectJSON from '../../../examples/uidl-samples/test.json'
 
 const projectUIDL = (projectJSON as unknown) as ProjectUIDL
 const assetFile = readFileSync(join(__dirname, 'asset.png'))
@@ -38,22 +38,22 @@ const run = async () => {
     // console.info(ProjectType.REACTNATIVE, '-', result.payload)
     result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.REACT })
     console.info(ProjectType.REACT, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NEXT })
-    console.info(ProjectType.NEXT, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
-    console.info(ProjectType.NUXT, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.VUE })
-    console.info(ProjectType.VUE, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.STENCIL })
-    console.info(ProjectType.STENCIL, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.PREACT })
-    console.info(ProjectType.PREACT, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.ANGULAR })
-    console.info(ProjectType.ANGULAR, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GRIDSOME })
-    console.info(ProjectType.GRIDSOME, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GATSBY })
-    console.info(ProjectType.GATSBY, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NEXT })
+    // console.info(ProjectType.NEXT, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
+    // console.info(ProjectType.NUXT, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.VUE })
+    // console.info(ProjectType.VUE, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.STENCIL })
+    // console.info(ProjectType.STENCIL, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.PREACT })
+    // console.info(ProjectType.PREACT, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.ANGULAR })
+    // console.info(ProjectType.ANGULAR, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GRIDSOME })
+    // console.info(ProjectType.GRIDSOME, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GATSBY })
+    // console.info(ProjectType.GATSBY, '-', result.payload)
   } catch (e) {
     console.info(e)
   }

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -9,7 +9,7 @@ const projectUIDL = (projectJSON as unknown) as ProjectUIDL
 const assetFile = readFileSync(join(__dirname, 'asset.png'))
 const base64File = new Buffer(assetFile).toString('base64')
 const packerOptions: PackerOptions = {
-  publisher: PublisherType.DISK,
+  publisher: PublisherType.CODESANDBOX,
   projectType: ProjectType.REACT,
   publishOptions: {
     outputPath: 'dist',
@@ -38,22 +38,22 @@ const run = async () => {
     // console.info(ProjectType.REACTNATIVE, '-', result.payload)
     result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.REACT })
     console.info(ProjectType.REACT, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NEXT })
-    // console.info(ProjectType.NEXT, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
-    // console.info(ProjectType.NUXT, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.VUE })
-    // console.info(ProjectType.VUE, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.STENCIL })
-    // console.info(ProjectType.STENCIL, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.PREACT })
-    // console.info(ProjectType.PREACT, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.ANGULAR })
-    // console.info(ProjectType.ANGULAR, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GRIDSOME })
-    // console.info(ProjectType.GRIDSOME, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GATSBY })
-    // console.info(ProjectType.GATSBY, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NEXT })
+    console.info(ProjectType.NEXT, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
+    console.info(ProjectType.NUXT, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.VUE })
+    console.info(ProjectType.VUE, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.STENCIL })
+    console.info(ProjectType.STENCIL, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.PREACT })
+    console.info(ProjectType.PREACT, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.ANGULAR })
+    console.info(ProjectType.ANGULAR, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GRIDSOME })
+    console.info(ProjectType.GRIDSOME, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GATSBY })
+    console.info(ProjectType.GATSBY, '-', result.payload)
   } catch (e) {
     console.info(e)
   }

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -9,7 +9,7 @@ const projectUIDL = (projectJSON as unknown) as ProjectUIDL
 const assetFile = readFileSync(join(__dirname, 'asset.png'))
 const base64File = new Buffer(assetFile).toString('base64')
 const packerOptions: PackerOptions = {
-  publisher: PublisherType.CODESANDBOX,
+  publisher: PublisherType.DISK,
   projectType: ProjectType.REACT,
   publishOptions: {
     outputPath: 'dist',

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -72,6 +72,7 @@ export interface UIDLStyleSetDefinition {
   id: string
   name: string
   type: 'reusable-project-style-map'
+  conditions?: UIDLStyleSetConditions[]
   content: Record<string, UIDLStaticValue>
 }
 
@@ -321,3 +322,24 @@ export interface UIDLStyleStateCondition {
 }
 
 export type UIDLElementStyleStates = 'hover' | 'active' | 'focus' | 'disabled'
+
+export type UIDLStyleSetConditions = UIDLStyleSetMediaCondition | UIDLStyleSetStateCondition
+
+export interface UIDLStyleSetMediaCondition {
+  type: 'screen-size'
+  content: Record<string, UIDLStaticValue>
+  meta: {
+    maxWidth: number
+    minWidth?: number
+    maxHeight?: number
+    minHeight?: number
+  }
+}
+
+export interface UIDLStyleSetStateCondition {
+  type: 'element-state'
+  meta: {
+    state: UIDLElementStyleStates
+  }
+  content: Record<string, UIDLStaticValue>
+}

--- a/packages/teleport-uidl-resolver/src/resolver.ts
+++ b/packages/teleport-uidl-resolver/src/resolver.ts
@@ -3,6 +3,7 @@ import { UIDLUtils } from '@teleporthq/teleport-shared'
 import { ComponentUIDL, UIDLElement, Mapping, GeneratorOptions } from '@teleporthq/teleport-types'
 import { resolveAbilities } from './resolvers/abilities'
 import { resolveReferencedStyle } from './resolvers/referenced-styles'
+import { resolveStyleSetDefinitions } from './resolvers/style-set-definitions'
 
 /**
  * The resolver takes the input UIDL and converts all the abstract node types into
@@ -41,6 +42,8 @@ export default class Resolver {
     UIDLUtils.setFriendlyOutputOptions(uidl)
 
     utils.checkForIllegalNames(uidl, mapping)
+
+    resolveStyleSetDefinitions(uidl)
 
     resolveAbilities(uidl, newOptions)
 

--- a/packages/teleport-uidl-resolver/src/resolvers/abilities/utils.ts
+++ b/packages/teleport-uidl-resolver/src/resolvers/abilities/utils.ts
@@ -43,8 +43,21 @@ export const insertLinks = (
       return node
     }
 
-    // a text node (span) on which we added a link gets transformed into an <a>
-    // the rest of the text elements get wrapped with an <a> tag
+    /* We repalce buttons with link to use <a> tag's, to make the generated
+    code to be semantically correct. */
+    if (elementType === 'button') {
+      node.content.elementType = getLinkElementType(abilities.link)
+      node.content.semanticType = ''
+      node.content.attrs = createLinkAttributes(abilities.link, options)
+      node.content.style = {
+        ...node.content.style,
+        textDecoration: { type: 'static', content: 'none' },
+      }
+      return node
+    }
+
+    /* a text node (span) on which we added a link gets transformed into an <a>
+     the rest of the text elements get wrapped with an <a> tag */
     if (elementType === 'text' && semanticType === 'span') {
       node.content.elementType = getLinkElementType(abilities.link)
       node.content.semanticType = ''

--- a/packages/teleport-uidl-resolver/src/resolvers/abilities/utils.ts
+++ b/packages/teleport-uidl-resolver/src/resolvers/abilities/utils.ts
@@ -49,10 +49,6 @@ export const insertLinks = (
       node.content.elementType = getLinkElementType(abilities.link)
       node.content.semanticType = ''
       node.content.attrs = createLinkAttributes(abilities.link, options)
-      node.content.style = {
-        ...node.content.style,
-        textDecoration: { type: 'static', content: 'none' },
-      }
       return node
     }
 

--- a/packages/teleport-uidl-resolver/src/resolvers/style-set-definitions/index.ts
+++ b/packages/teleport-uidl-resolver/src/resolvers/style-set-definitions/index.ts
@@ -1,0 +1,52 @@
+/* 
+    Styleset-Definitions have conditions which helps in applying media styles
+    and pseudo styles on them. These need to be sorted as we do for referenced-Styles
+*/
+
+import {
+  ComponentUIDL,
+  UIDLStyleSetDefinition,
+  UIDLStyleSetMediaCondition,
+} from '@teleporthq/teleport-types'
+
+export const resolveStyleSetDefinitions = (input: ComponentUIDL) => {
+  if (!input?.styleSetDefinitions) {
+    return
+  }
+  input.styleSetDefinitions = sortStyleSetDefinitions(input.styleSetDefinitions)
+}
+
+const sortStyleSetDefinitions = (styleSets: Record<string, UIDLStyleSetDefinition>) => {
+  return Object.values(styleSets).reduce(
+    (acc: Record<string, UIDLStyleSetDefinition>, styleRef) => {
+      const { conditions = [] } = styleRef
+
+      if (conditions.length === 0) {
+        return (acc = {
+          ...acc,
+          [styleRef.id]: {
+            ...styleRef,
+          },
+        })
+      }
+
+      const mediaConditions = conditions
+        .filter((item) => item.type === 'screen-size')
+        .sort(
+          (a: UIDLStyleSetMediaCondition, b: UIDLStyleSetMediaCondition) =>
+            a.meta.maxWidth - b.meta.maxWidth
+        )
+        .reverse()
+      const elementStateConditions = conditions.filter((item) => item.type === 'element-state')
+
+      return (acc = {
+        ...acc,
+        [styleRef.id]: {
+          ...styleRef,
+          conditions: [...elementStateConditions, ...mediaConditions],
+        },
+      })
+    },
+    {}
+  )
+}

--- a/packages/teleport-uidl-validator/src/decoders/types.ts
+++ b/packages/teleport-uidl-validator/src/decoders/types.ts
@@ -21,6 +21,8 @@ import {
   UIDLNavLinkNode,
   UIDLMailLinkNode,
   UIDLPhoneLinkNode,
+  UIDLStyleSetMediaCondition,
+  UIDLStyleSetStateCondition,
 } from '@teleporthq/teleport-types'
 
 type Modify<T, R> = Omit<T, keyof R> & R
@@ -94,6 +96,7 @@ export interface VUIDLStyleSetDefnition
   extends Modify<
     UIDLStyleSetDefinition,
     {
+      conditions?: VUIDLStyleSetConditions[]
       content: Record<string, UIDLStaticValue | string | number>
     }
   > {}
@@ -144,6 +147,24 @@ export interface VUIDLURLLinkNode
       }
     }
   > {}
+
+export interface VUIDLStyleSetMediaCondition
+  extends Modify<
+    UIDLStyleSetMediaCondition,
+    {
+      content: Record<string, UIDLStaticValue | string | number>
+    }
+  > {}
+
+export interface VUIDLStyleSetStateCondition
+  extends Modify<
+    UIDLStyleSetStateCondition,
+    {
+      content: Record<string, UIDLStaticValue | string | number>
+    }
+  > {}
+
+export type VUIDLStyleSetConditions = VUIDLStyleSetMediaCondition | VUIDLStyleSetStateCondition
 
 export type VUIDLLinkNode =
   | VUIDLURLLinkNode

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -49,6 +49,9 @@ import {
   VUIDLSectionLinkNode,
   VUIDLLinkNode,
   VUIDLURLLinkNode,
+  VUIDLStyleSetConditions,
+  VUIDLStyleSetMediaCondition,
+  VUIDLStyleSetStateCondition,
 } from './types'
 import { CustomCombinators } from './custom-combinators'
 
@@ -80,10 +83,35 @@ export const staticValueDecoder: Decoder<UIDLStaticValue> = object({
   content: union(string(), number(), boolean(), array()),
 })
 
+export const styleSetMediaConditionDecoder: Decoder<VUIDLStyleSetMediaCondition> = object({
+  type: constant('screen-size'),
+  meta: object({
+    maxWidth: number(),
+    maxHeight: optional(number()),
+    minHeight: optional(number()),
+    minWidth: optional(number()),
+  }),
+  content: dict(union(staticValueDecoder, string(), number())),
+})
+
+export const styleSetStateConditionDecoder: Decoder<VUIDLStyleSetStateCondition> = object({
+  type: constant('element-state'),
+  meta: object({
+    state: lazy(() => elementStateDecoder),
+  }),
+  content: dict(union(staticValueDecoder, string(), number())),
+})
+
+export const projectStyleConditionsDecoder: Decoder<VUIDLStyleSetConditions> = union(
+  styleSetMediaConditionDecoder,
+  styleSetStateConditionDecoder
+)
+
 export const styleSetDefinitionDecoder: Decoder<VUIDLStyleSetDefnition> = object({
   id: string(),
   name: string(),
   type: constant('reusable-project-style-map'),
+  conditions: optional(array(projectStyleConditionsDecoder)),
   content: dict(union(staticValueDecoder, string(), number())),
 })
 

--- a/packages/teleport-uidl-validator/src/parser/index.ts
+++ b/packages/teleport-uidl-validator/src/parser/index.ts
@@ -10,6 +10,7 @@ import {
   UIDLSlotNode,
   UIDLElementNode,
   UIDLStaticValue,
+  UIDLStyleSetConditions,
 } from '@teleporthq/teleport-types'
 
 interface ParseComponentJSONParams {
@@ -53,7 +54,16 @@ export const parseProjectJSON = (
   if (result.root?.styleSetDefinitions) {
     const { styleSetDefinitions } = root
     Object.values(styleSetDefinitions).forEach((styleRef) => {
+      const { conditions = [] } = styleRef
       styleRef.content = UIDLUtils.transformStylesAssignmentsToJson(styleRef.content)
+      if (conditions.length > 0) {
+        conditions.forEach((style: UIDLStyleSetConditions) => {
+          style.content = UIDLUtils.transformStylesAssignmentsToJson(style.content) as Record<
+            string,
+            UIDLStaticValue
+          >
+        })
+      }
     })
   }
 


### PR DESCRIPTION
## Enhancements 
We are now allowing to add conditions for the project styles. In previous release, we allowed support for project-styles and made them available to be added to any nodes.
Now, we are allowing conditions on top of project-style. Which allows the user to design the style once in all the conditions like, **default**, **media**, **pseudo-state**. So when a node is referred with the style, it inherits the behaviour in all the conditions.

## Refactors

- Adding links to elements like button's is a commonly used practice but **semantically-incorrect**. So, by default we are converting them to use `a` tags with `button-styles` from the themes.
- By default Project theme is not added to head anymore, we just convert them as `project-styles` from playground. So we could refer them on elements as styles directly.

