### PR TITLE
fix(resolver): prioritizing semantic type only if the elm don't have a dependency

### DIFF
--- a/packages/teleport-uidl-resolver/src/utils.ts
+++ b/packages/teleport-uidl-resolver/src/utils.ts
@@ -99,7 +99,10 @@ export const resolveElement = (element: UIDLElement, options: GeneratorOptions) 
 
   // Mapping the type from the semantic type of the mapping
   // Semantic type has precedence as it is dictated by the user
-  originalElement.elementType = originalElement.semanticType || mappedElement.elementType
+  originalElement.elementType =
+    originalElement.semanticType && !originalElement.dependency
+      ? originalElement.semanticType
+      : mappedElement.elementType
 
   if (mappedElement.ignore) {
     originalElement.ignore = mappedElement.ignore


### PR DESCRIPTION
Looks like, from our previous PR. We got a edge case creeped inside --> https://github.com/teleporthq/teleport-code-generators/pull/445

Prioritising `semanticType` only if the `element` doesn't have a `dependency`.

I am sharing the UIDL link, which i came across while working today. Looks, like it's taking `semanticType` all the time even when we are importing components.

The `PersonList` component get's imported as `AppComponent`. Since in actual projects developed in playground. The components always follows the *default imports* we did not observe this issue. Since they just work with the componentName.

https://teleport-repl-git-feature-preview-component.teleport-team.vercel.app/?uidlLink=pjzlffgqaqhecigmnty41s

