### PR TITLE
refactor(teleport-types): refactored checkes and validators for UIDLDependency

### DIFF
--- a/packages/teleport-component-generator/src/assembly-line/utils.ts
+++ b/packages/teleport-component-generator/src/assembly-line/utils.ts
@@ -7,7 +7,7 @@ export const extractExternalDependencies = (dependencies: Record<string, UIDLDep
     })
     .reduce((acc: Record<string, string>, key) => {
       const depInfo = dependencies[key]
-      if (depInfo.path) {
+      if (depInfo.path && (depInfo.type === 'library' || depInfo.type === 'package')) {
         acc[depInfo.path] = depInfo.version
       }
 

--- a/packages/teleport-plugin-jsx-head-config/src/index.ts
+++ b/packages/teleport-plugin-jsx-head-config/src/index.ts
@@ -6,6 +6,7 @@ interface JSXHeadPluginConfig {
   componentChunkName?: string
   configTagIdentifier?: string
   configTagDependencyPath?: string
+  configTagDependencyVersion?: string
 }
 
 export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConfig> = (config) => {
@@ -13,6 +14,7 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
     componentChunkName = 'jsx-component',
     configTagIdentifier = 'Helmet',
     configTagDependencyPath = 'react-helmet',
+    configTagDependencyVersion = '^5.2.1',
   } = config || {}
 
   const jsxHeadConfigPlugin: ComponentPlugin = async (structure) => {
@@ -72,6 +74,7 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
       dependencies[configTagIdentifier] = {
         type: 'library',
         path: configTagDependencyPath,
+        version: configTagDependencyVersion,
       }
     }
 

--- a/packages/teleport-plugin-reactnative-app-routing/src/index.ts
+++ b/packages/teleport-plugin-reactnative-app-routing/src/index.ts
@@ -26,7 +26,8 @@ export const createReactAppRoutingComponentPlugin: ComponentPluginFactory<AppRou
 
     const navigatorDependency: UIDLDependency = {
       type: 'library',
-      path: 'react-navigator',
+      path: 'react-navigaton',
+      version: '^4.4.0',
       meta: {
         namedImport: true,
       },

--- a/packages/teleport-plugin-vue-app-routing/src/index.ts
+++ b/packages/teleport-plugin-vue-app-routing/src/index.ts
@@ -22,14 +22,17 @@ export const createVueAppRoutingPlugin: ComponentPluginFactory<VueRouterConfig> 
     dependencies.Vue = {
       type: 'library',
       path: 'vue',
+      version: '^2.6.7',
     }
     dependencies.Router = {
       type: 'library',
       path: 'vue-router',
+      version: '^3.0.2',
     }
     dependencies.Meta = {
       type: 'library',
       path: 'vue-meta',
+      version: '^2.2.1',
     }
 
     const routerDeclaration = t.expressionStatement(

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -249,10 +249,22 @@ export interface UIDLEventHandlerStatement {
   args?: Array<string | number | boolean>
 }
 
-export interface UIDLDependency {
-  type: 'library' | 'package' | 'local'
+export type UIDLDependency = UIDLLocalDependency | UIDLExternalDependency
+
+export interface UIDLLocalDependency {
+  type: 'local'
   path?: string
-  version?: string
+  meta?: {
+    namedImport?: boolean
+    originalName?: string
+    importJustPath?: boolean
+  }
+}
+
+export interface UIDLExternalDependency {
+  type: 'library' | 'package'
+  path: string
+  version: string
   meta?: {
     namedImport?: boolean
     originalName?: string

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -36,6 +36,8 @@ import {
   UIDLElementNodeProjectReferencedStyle,
   UIDLComponentSEO,
   UIDLGlobalAsset,
+  UIDLExternalDependency,
+  UIDLLocalDependency,
 } from '@teleporthq/teleport-types'
 import {
   VUIDLStyleSetDefnition,
@@ -200,17 +202,35 @@ export const outputOptionsDecoder: Decoder<UIDLComponentOutputOptions> = object(
   folderPath: optional(array((isValidFileName() as unknown) as Decoder<string>)),
 })
 
-export const dependencyDecoder: Decoder<UIDLDependency> = object({
-  type: union(constant('library'), constant('package'), constant('local')),
-  path: optional(string()),
-  version: optional(string()),
+export const externaldependencyDecoder: Decoder<UIDLExternalDependency> = object({
+  type: union(constant('library'), constant('package')),
+  path: string(),
+  version: string(),
   meta: optional(
     object({
       namedImport: optional(boolean()),
       originalName: optional(string()),
+      importJustPath: optional(boolean()),
     })
   ),
 })
+
+export const localDependencyDecoder: Decoder<UIDLLocalDependency> = object({
+  type: constant('local'),
+  path: optional(string()),
+  meta: optional(
+    object({
+      namedImport: optional(boolean()),
+      originalName: optional(string()),
+      importJustPath: optional(boolean()),
+    })
+  ),
+})
+
+export const dependencyDecoder: Decoder<UIDLDependency> = union(
+  localDependencyDecoder,
+  externaldependencyDecoder
+)
 
 export const attributeValueDecoder: Decoder<UIDLAttributeValue> = union(
   dynamicValueDecoder,


### PR DESCRIPTION
fixes #470 

Currently the type of UIDLDependency has `version` as optional. But when we are using a `package` or `library` the `version` is mandatory. Right now it's passing the checks since it's an optional field. Just refactored the checkes.