### PR TITLE
fix(css-modules): importing project styles at first than local styles

### DIFF
--- a/packages/teleport-plugin-css-modules/src/index.ts
+++ b/packages/teleport-plugin-css-modules/src/index.ts
@@ -217,13 +217,8 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
       uidl.outputOptions.styleFileName = cssFileName
     }
 
-    if (cssClasses.length > 0) {
-      dependencies[styleObjectImportName] = {
-        type: 'local',
-        path: `./${cssFileName}.${FileType.CSS}`,
-      }
-    }
-
+    /* Order of imports play a important role on initial load sequence
+    So, project styles should always be loaded before component styles */
     if (isProjectStyleReferred) {
       const fileName = moduleExtension
         ? `${options.projectStyleSet.fileName}.module`
@@ -231,6 +226,13 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
       dependencies[projectStylesReferenceOffset] = {
         type: 'local',
         path: `${options.projectStyleSet.path}/${fileName}.${FileType.CSS}`,
+      }
+    }
+
+    if (cssClasses.length > 0) {
+      dependencies[styleObjectImportName] = {
+        type: 'local',
+        path: `./${cssFileName}.${FileType.CSS}`,
       }
     }
 


### PR DESCRIPTION
## Issue

Import order effects the way in which styles are being applied. 

Example, if we have something like this.
```jsx
<button className={` ${projectStyles.primaryButton} ${styles.button} `}>
   Primary Button
</button>
```

If the `projectStyles` are added before the local styles but imported before them like this 
```js
import styles from './home.module.css'
import projectStyles from '../style.module.css'
```

Only project styles are rendered first and it is causing some unwanted behaviour.

## Solution

They should always be loaded in this sequence
```js
import projectStyles from '../style.module.css'
import styles from './home.module.css'
```