### PR TITLE
 fix(angular-base): ignore imports for frameworks like angular which are imported directly in modules

### DIFF
--- a/examples/test-samples/project-sample-with-dependency.json
+++ b/examples/test-samples/project-sample-with-dependency.json
@@ -1,0 +1,586 @@
+{
+    "name": "myVueProject",
+    "globals": {
+      "settings": {
+        "language": "en",
+        "title": "teleportHQ"
+      },
+      "meta" : [
+        { "name": "description", "content": "Free Web tutorials" },
+        { "name": "keywords", "content": "prea bun, prea ca la tara" },
+        { "name": "viewport", "content": "width=device-width, initial-scale=1.0" },
+        { "property": "og:title", "content": "Free Web tutorials" },
+        { "property": "og:url", "content": "/playground_assets/asdasd.png" }
+      ],
+      "manifest": {
+        "icons": [
+          {
+            "src": "/playground_assets/icons-192.png",
+            "type": "image/png",
+            "sizes": "192x192"
+          },
+          {
+            "src": "/playground_assets/icons-512.png",
+            "type": "image/png",
+            "sizes": "512x512"
+          }
+        ],
+        "theme_color": "#822CEC",
+        "background_color": "#822CEC"
+      },
+      "assets": [
+        {
+          "type": "style",
+          "path": "https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css",
+          "options": {
+            "target": "body"
+          }
+        }, 
+        {
+          "type": "script",
+          "path": "https://www.googletagmanager.com/gtm.js",
+          "options": {
+            "defer": true
+          }
+        },
+        {
+          "type": "script",
+          "content": "console.log(\"inline script\")",
+          "options": {
+            "target": "body"
+          }
+        },
+        {
+          "type": "font",
+          "path": "https://fonts.googleapis.com/css?family=Roboto"
+        },
+        {
+          "type": "style",
+          "content": "body{font-family: 'Roboto', sans-serif;}"
+        },
+        {
+          "type": "icon",
+          "path": "/playground_assets/favicon-32x32.png",
+          "options": {
+            "iconType": "image/png",
+            "iconSizes": "32x32"
+          }
+        }
+      ],
+      "variables": {
+        "primaryColor": "#822CEC",
+        "secondaryColor": "#414141",
+        "spacing": "10px"
+      }
+    },
+    "root": {
+      "name": "App",
+      "importDefinitions": {
+        "antdCSS": {
+          "type": "package",
+          "path": "antd/dist/antd.css",
+          "version": "^4.5.1",
+          "meta": {
+            "importJustPath": true
+          }
+        }
+      },
+      "stateDefinitions": {
+        "route": {
+          "type": "string",
+          "defaultValue": "index",
+          "values": [
+            {
+              "value": "index",
+              "pageOptions": {
+                "navLink": "/",
+                "fileName": "index",
+                "componentName": "Home"
+              }
+            },
+            {
+              "value": "about",
+              "pageOptions": {
+                "navLink": "/about",
+                "fileName": "about",
+                "componentName": "About"
+              }
+            },
+            {
+              "value": "contact-us",
+              "pageOptions": {
+                "navLink": "/here-we-are",
+                "fileName": "contact-us",
+                "componentName": "Us"
+              }
+            }
+          ]
+        }
+      },
+      "node": {
+        "type": "element",
+        "content": {
+          "elementType": "Router",
+          "children": [
+            {
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "children": [
+                      {
+                        "type": "static",
+                        "content": "Page 1"
+                      },
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "Modal",
+                          "dependency": {
+                            "type": "local"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "value": "index",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            },
+            {
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "children": [
+                      {
+                        "type": "static",
+                        "content": "Page 2"
+                      }
+                    ]
+                  }
+                },
+                "value": "about",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            },{
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "children": [
+                      {
+                        "type": "static",
+                        "content": "Page 3"
+                      }
+                    ]
+                  }
+                },
+                "value": "contact-us",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "components": {
+      "OneComponent": {
+        "name": "OneComponent",
+        "propDefinitions": {
+          "titleValue": {
+            "type": "string",
+            "defaultValue": "Hello"
+          },
+          "items": {
+            "type": "array",
+            "defaultValue": []
+          }
+        },
+        "stateDefinitions": {
+          "isVisible": {
+            "type": "boolean",
+            "defaultValue": true
+          }
+        },
+        "node": {
+          "type": "element",
+          "content": {
+            "elementType": "container",
+            "attrs": {
+              "data-static-attr": {
+                "type": "static",
+                "content": "test"
+              },
+              "data-dynamic-attr": {
+                "type": "dynamic",
+                "content": {
+                  "referenceType": "prop",
+                  "id": "titleValue"
+                }
+              }
+            },
+            "children": [
+              {
+                "type": "element",
+                "content": {
+                  "elementType": "text",
+                  "children": [
+                    {
+                      "type": "static",
+                      "content": "Hello World!"
+                    },
+                    {
+                      "type": "dynamic",
+                      "content": {
+                        "referenceType": "prop",
+                        "id": "titleValue"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "repeat",
+                "content": {
+                  "node": {
+                    "type": "element",
+                    "content": {
+                      "elementType": "text",
+                      "children": [
+                        {
+                          "type": "dynamic",
+                          "content": {
+                            "referenceType": "local",
+                            "id": "item"
+                          }
+                        },
+                        {
+                          "type": "element",
+                          "content": {
+                            "elementType": "list",
+                            "attrs": {
+                              "items": {
+                                "type": "static",
+                                "content": ["angular", "react", "vue"]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "dataSource": {
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "prop",
+                      "id": "items"
+                    }
+                  },
+                  "meta": {
+                    "useIndex": true,
+                    "iteratorName": "item"
+                  }
+                }
+              },
+              {
+                "type": "conditional",
+                "content": {
+                  "reference": {
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "state",
+                      "id": "isVisible"
+                    }
+                  },
+                  "value": true,
+                  "node": {
+                    "type": "element",
+                    "content": {
+                      "elementType": "text",
+                      "children": [{
+                        "type": "static",
+                        "content": "Now you see me!"
+                      }]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "ExpandableArea": {
+        "name": "ExpandableArea",
+        "propDefinitions": {
+          "titleValue": {
+            "type": "string",
+            "defaultValue": "Hello"
+          },
+          "text": {
+            "type": "string",
+            "defaultValue": "Is it me you're looking for?"
+          }
+        },
+        "stateDefinitions": {
+          "isExpanded": {
+            "type": "boolean",
+            "defaultValue": false
+          }
+        },
+        "node": {
+          "type": "element",
+          "content": {
+            "elementType": "container",
+            "style": {
+              "margin": "10px"
+            },
+            "children": [
+              {
+                "type": "element",
+                "content": {
+                  "elementType": "text",
+                  "children": [{
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "prop",
+                      "id": "titleValue"
+                    }
+                  }]
+                }
+              },
+              {
+                "type": "element",
+                "content": {
+                  "elementType": "button",
+                  "children": [{
+                    "type": "conditional",
+                    "content": {
+                      "node": {
+                        "type": "static",
+                        "content": "Hide me"
+                      },
+                      "value": true,
+                      "reference": {
+                        "type": "dynamic",
+                        "content": {
+                          "referenceType": "state",
+                          "id": "isExpanded"
+                        }
+                      }
+                    }
+                  },{
+                    "type": "conditional",
+                    "content": {
+                      "node": {
+                        "type": "static",
+                        "content": "Show me"
+                      },
+                      "value": false,
+                      "reference": {
+                        "type": "dynamic",
+                        "content": {
+                          "referenceType": "state",
+                          "id": "isExpanded"
+                        }
+                      }
+                    }
+                  }],
+                  "events": {
+                    "click": [
+                      {
+                        "type": "stateChange",
+                        "modifies": "isExpanded",
+                        "newState": "$toggle"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "conditional",
+                "content": {
+                  "node": {
+                    "type": "element",
+                    "content": {
+                      "elementType": "text",
+                      "children": [{
+                        "type": "dynamic",
+                        "content": {
+                          "referenceType": "prop",
+                          "id": "text"
+                        }
+                      }]
+                    }
+                  },
+                  "value": true,
+                  "reference": {
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "state",
+                      "id": "isExpanded"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "Modal": {
+        "name": "Modal",
+        "stateDefinitions": {
+          "isOpen": {
+            "type": "boolean",
+            "defaultValue": false
+          }
+        },
+        "node": {
+          "type": "element",
+          "content": {
+            "elementType": "group",
+            "children": [
+              {
+                "type": "element",
+                "content": {
+                  "semanticType": "Button",
+                  "elementType": "component",
+                  "attrs": {
+                    "type": "primary"
+                  },
+                  "name": "openmodal",
+                  "events": {
+                    "click": [{
+                      "type": "stateChange",
+                      "modifies": "isOpen",
+                      "newState": true
+                    }]
+                  },
+                  "children": [{
+                    "type": "static",
+                    "content": "Show Popup"
+                  }],
+                  "dependency": {
+                    "type": "package",
+                    "path": "antd",
+                    "version": "4.5.4",
+                    "meta": {
+                      "namedImport": true
+                    }
+                  }
+                }
+              },
+              {
+                "type": "conditional",
+                "content": {
+                  "node": {
+                    "type": "element",
+                    "content": {
+                      "elementType": "ModalWindow",
+                      "name": "window",
+                      "dependency": {
+                        "type": "local"
+                      },
+                      "events": {
+                        "onClose": [{
+                          "type": "stateChange",
+                          "modifies": "isOpen",
+                          "newState": false
+                        }]
+                      }
+                    }
+                  },
+                  "value": true,
+                  "reference": {
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "state",
+                      "id": "isOpen"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "ModalWindow": {
+        "name": "ModalWindow",
+        "propDefinitions": {
+          "message": {
+            "type": "string",
+            "defaultValue": "Hello"
+          },
+          "onClose": {
+            "type": "func",
+            "defaultValue": "() => {}"
+          }
+        },
+        "stateDefinitions": {
+          "fakeState": {
+            "type": "boolean",
+            "defaultValue": false
+          }
+        },
+        "node": {
+          "type": "element",
+          "content": {
+            "elementType": "container",
+            "children": [{
+              "type": "dynamic",
+              "content": {
+                "referenceType": "prop",
+                "id": "message"
+              }
+            },{
+              "type": "element",
+              "content": {
+                "elementType": "button",
+                "name": "close",
+                "children": [{
+                  "type": "static",
+                  "content": "Close me"
+                }],
+                "events": {
+                  "click": [{
+                    "type": "propCall",
+                    "calls": "onClose"
+                  },{
+                    "type": "stateChange",
+                    "modifies": "fakeState",
+                    "newState": false
+                  }]
+                }
+              }
+            }]
+          }
+        }
+      }
+    }
+  }

--- a/examples/test-samples/project-with-import-global-styles.json
+++ b/examples/test-samples/project-with-import-global-styles.json
@@ -1,0 +1,607 @@
+{
+    "name": "myVueProject",
+    "globals": {
+      "settings": {
+        "language": "en",
+        "title": "teleportHQ"
+      },
+      "meta" : [
+        { "name": "description", "content": "Free Web tutorials" },
+        { "name": "keywords", "content": "prea bun, prea ca la tara" },
+        { "name": "viewport", "content": "width=device-width, initial-scale=1.0" },
+        { "property": "og:title", "content": "Free Web tutorials" },
+        { "property": "og:url", "content": "/playground_assets/asdasd.png" }
+      ],
+      "manifest": {
+        "icons": [
+          {
+            "src": "/playground_assets/icons-192.png",
+            "type": "image/png",
+            "sizes": "192x192"
+          },
+          {
+            "src": "/playground_assets/icons-512.png",
+            "type": "image/png",
+            "sizes": "512x512"
+          }
+        ],
+        "theme_color": "#822CEC",
+        "background_color": "#822CEC"
+      },
+      "assets": [
+        {
+          "type": "style",
+          "path": "https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css",
+          "options": {
+            "target": "body"
+          }
+        }, 
+        {
+          "type": "script",
+          "path": "https://www.googletagmanager.com/gtm.js",
+          "options": {
+            "defer": true
+          }
+        },
+        {
+          "type": "script",
+          "content": "console.log(\"inline script\")",
+          "options": {
+            "target": "body"
+          }
+        },
+        {
+          "type": "font",
+          "path": "https://fonts.googleapis.com/css?family=Roboto"
+        },
+        {
+          "type": "style",
+          "content": "body{font-family: 'Roboto', sans-serif;}"
+        },
+        {
+          "type": "icon",
+          "path": "/playground_assets/favicon-32x32.png",
+          "options": {
+            "iconType": "image/png",
+            "iconSizes": "32x32"
+          }
+        }
+      ],
+      "variables": {
+        "primaryColor": "#822CEC",
+        "secondaryColor": "#414141",
+        "spacing": "10px"
+      }
+    },
+    "root": {
+      "name": "App",
+      "styleSetDefinitions": {
+        "5ed0d05baa77d97673711820": {
+          "id": "5ed0d05baa77d97673711820",
+          "name": "primaryButton",
+          "type": "reusable-project-style-map",
+          "content": {
+            "background": "blue",
+            "width": "auto",
+            "color": "#fff",
+            "border": "1px solid #fff"
+          }
+        },
+        "5ed0d4923de727e93cb4efa2": {
+          "id": "5ed0d4923de727e93cb4efa2",
+          "name": "secondaryButton",
+          "type": "reusable-project-style-map",
+          "content": {
+            "background": "red",
+            "width": "auto",
+            "color": "#fff",
+            "border": "1px solid #fff"
+          }
+        }
+      },
+      "stateDefinitions": {
+        "route": {
+          "type": "string",
+          "defaultValue": "index",
+          "values": [
+            {
+              "value": "index",
+              "pageOptions": {
+                "navLink": "/",
+                "fileName": "index",
+                "componentName": "Home"
+              }
+            },
+            {
+              "value": "about",
+              "pageOptions": {
+                "navLink": "/about",
+                "fileName": "about",
+                "componentName": "About"
+              }
+            },
+            {
+              "value": "contact-us",
+              "pageOptions": {
+                "navLink": "/here-we-are",
+                "fileName": "contact-us",
+                "componentName": "Us"
+              }
+            }
+          ]
+        }
+      },
+      "node": {
+        "type": "element",
+        "content": {
+          "elementType": "Router",
+          "children": [
+            {
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "children": [
+                      {
+                        "type": "static",
+                        "content": "Page 1",
+                        "referencedStyles": {
+                          "5ed0d3daf36df4da926078ee": {
+                            "id": "5ed0d3daf36df4da926078ee",
+                            "type": "style-map",
+                            "content": {
+                              "mapType": "project-referenced",
+                              "referenceId": "5ed0d05baa77d97673711820"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "value": "index",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            },
+            {
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "children": [
+                      {
+                        "type": "static",
+                        "content": "Page 2"
+                      }
+                    ]
+                  }
+                },
+                "value": "about",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            },{
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "children": [
+                      {
+                        "type": "static",
+                        "content": "Page 3"
+                      }
+                    ]
+                  }
+                },
+                "value": "contact-us",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "components": {
+      "OneComponent": {
+        "name": "OneComponent",
+        "propDefinitions": {
+          "titleValue": {
+            "type": "string",
+            "defaultValue": "Hello"
+          },
+          "items": {
+            "type": "array",
+            "defaultValue": []
+          }
+        },
+        "stateDefinitions": {
+          "isVisible": {
+            "type": "boolean",
+            "defaultValue": true
+          }
+        },
+        "node": {
+          "type": "element",
+          "content": {
+            "elementType": "container",
+            "attrs": {
+              "data-static-attr": {
+                "type": "static",
+                "content": "test"
+              },
+              "data-dynamic-attr": {
+                "type": "dynamic",
+                "content": {
+                  "referenceType": "prop",
+                  "id": "titleValue"
+                }
+              }
+            },
+            "children": [
+                {
+                    "type": "element",
+                    "content": {
+                      "semanticType": "Button",
+                      "elementType": "component",
+                      "attrs": {
+                        "type": "danger"
+                      },
+                      "dependency": {
+                        "type": "package",
+                        "version": "^4.5.1",
+                        "path": "antd",
+                        "meta": {
+                          "namedImport": true
+                        }
+                      },
+                      "children": ["Button from Antd"]
+                    }
+                  },
+              {
+                "type": "element",
+                "content": {
+                  "elementType": "text",
+                  "children": [
+                    {
+                      "type": "static",
+                      "content": "Hello World!"
+                    },
+                    {
+                      "type": "dynamic",
+                      "content": {
+                        "referenceType": "prop",
+                        "id": "titleValue"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "repeat",
+                "content": {
+                  "node": {
+                    "type": "element",
+                    "content": {
+                      "elementType": "text",
+                      "children": [
+                        {
+                          "type": "dynamic",
+                          "content": {
+                            "referenceType": "local",
+                            "id": "item"
+                          }
+                        },
+                        {
+                          "type": "element",
+                          "content": {
+                            "elementType": "list",
+                            "attrs": {
+                              "items": {
+                                "type": "static",
+                                "content": ["angular", "react", "vue"]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "dataSource": {
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "prop",
+                      "id": "items"
+                    }
+                  },
+                  "meta": {
+                    "useIndex": true,
+                    "iteratorName": "item"
+                  }
+                }
+              },
+              {
+                "type": "conditional",
+                "content": {
+                  "reference": {
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "state",
+                      "id": "isVisible"
+                    }
+                  },
+                  "value": true,
+                  "node": {
+                    "type": "element",
+                    "content": {
+                      "elementType": "text",
+                      "children": [{
+                        "type": "static",
+                        "content": "Now you see me!"
+                      }]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "ExpandableArea": {
+        "name": "ExpandableArea",
+        "propDefinitions": {
+          "titleValue": {
+            "type": "string",
+            "defaultValue": "Hello"
+          },
+          "text": {
+            "type": "string",
+            "defaultValue": "Is it me you're looking for?"
+          }
+        },
+        "stateDefinitions": {
+          "isExpanded": {
+            "type": "boolean",
+            "defaultValue": false
+          }
+        },
+        "node": {
+          "type": "element",
+          "content": {
+            "elementType": "container",
+            "style": {
+              "margin": "10px"
+            },
+            "children": [
+              {
+                "type": "element",
+                "content": {
+                  "elementType": "text",
+                  "children": [{
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "prop",
+                      "id": "titleValue"
+                    }
+                  }]
+                }
+              },
+              {
+                "type": "element",
+                "content": {
+                  "elementType": "button",
+                  "children": [{
+                    "type": "conditional",
+                    "content": {
+                      "node": {
+                        "type": "static",
+                        "content": "Hide me"
+                      },
+                      "value": true,
+                      "reference": {
+                        "type": "dynamic",
+                        "content": {
+                          "referenceType": "state",
+                          "id": "isExpanded"
+                        }
+                      }
+                    }
+                  },{
+                    "type": "conditional",
+                    "content": {
+                      "node": {
+                        "type": "static",
+                        "content": "Show me"
+                      },
+                      "value": false,
+                      "reference": {
+                        "type": "dynamic",
+                        "content": {
+                          "referenceType": "state",
+                          "id": "isExpanded"
+                        }
+                      }
+                    }
+                  }],
+                  "events": {
+                    "click": [
+                      {
+                        "type": "stateChange",
+                        "modifies": "isExpanded",
+                        "newState": "$toggle"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "conditional",
+                "content": {
+                  "node": {
+                    "type": "element",
+                    "content": {
+                      "elementType": "text",
+                      "children": [{
+                        "type": "dynamic",
+                        "content": {
+                          "referenceType": "prop",
+                          "id": "text"
+                        }
+                      }]
+                    }
+                  },
+                  "value": true,
+                  "reference": {
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "state",
+                      "id": "isExpanded"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "Modal": {
+        "name": "Modal",
+        "stateDefinitions": {
+          "isOpen": {
+            "type": "boolean",
+            "defaultValue": false
+          }
+        },
+        "node": {
+          "type": "element",
+          "content": {
+            "elementType": "group",
+            "children": [
+              {
+                "type": "element",
+                "content": {
+                  "elementType": "button",
+                  "name": "openmodal",
+                  "children": [{
+                    "type": "static",
+                    "content": "Show Popup"
+                  }],
+                  "events": {
+                    "click": [{
+                      "type": "stateChange",
+                      "modifies": "isOpen",
+                      "newState": true
+                    }]
+                  }
+                }
+              },
+              {
+                "type": "conditional",
+                "content": {
+                  "node": {
+                    "type": "element",
+                    "content": {
+                      "elementType": "ModalWindow",
+                      "name": "window",
+                      "dependency": {
+                        "type": "local"
+                      },
+                      "events": {
+                        "onClose": [{
+                          "type": "stateChange",
+                          "modifies": "isOpen",
+                          "newState": false
+                        }]
+                      }
+                    }
+                  },
+                  "value": true,
+                  "reference": {
+                    "type": "dynamic",
+                    "content": {
+                      "referenceType": "state",
+                      "id": "isOpen"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "ModalWindow": {
+        "name": "ModalWindow",
+        "propDefinitions": {
+          "message": {
+            "type": "string",
+            "defaultValue": "Hello"
+          },
+          "onClose": {
+            "type": "func",
+            "defaultValue": "() => {}"
+          }
+        },
+        "stateDefinitions": {
+          "fakeState": {
+            "type": "boolean",
+            "defaultValue": false
+          }
+        },
+        "node": {
+          "type": "element",
+          "content": {
+            "elementType": "container",
+            "children": [{
+              "type": "dynamic",
+              "content": {
+                "referenceType": "prop",
+                "id": "message"
+              }
+            },{
+              "type": "element",
+              "content": {
+                "elementType": "button",
+                "name": "close",
+                "children": [{
+                  "type": "static",
+                  "content": "Close me"
+                }],
+                "events": {
+                  "click": [{
+                    "type": "propCall",
+                    "calls": "onClose"
+                  },{
+                    "type": "stateChange",
+                    "modifies": "fakeState",
+                    "newState": false
+                  }]
+                }
+              }
+            }]
+          }
+        }
+      }
+    }
+  }

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-html/index.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-html/index.ts
@@ -27,14 +27,16 @@ const generateElementNode: NodeToHTML<UIDLElementNode, HastNode> = (node, params
 
   if (dependency) {
     const existingDependency = dependencies[tagName]
-    safeTagName =
-      existingDependency && existingDependency?.path !== dependency?.path
-        ? `${StringUtils.dashCaseToUpperCamelCase(
-            StringUtils.removeIllegalCharacters(dependency.path)
-          )}${tagName}`
-        : tagName
+    if (templateSyntax.dependencyHandling === 'import') {
+      safeTagName =
+        existingDependency && existingDependency?.path !== dependency?.path
+          ? `${StringUtils.dashCaseToUpperCamelCase(
+              StringUtils.removeIllegalCharacters(dependency.path)
+            )}${tagName}`
+          : tagName
+    }
 
-    if (templateSyntax.dependencyHandling === 'import' && dependency.type !== 'local') {
+    if (dependency.type !== 'local') {
       dependencies[safeTagName] = { ...dependency }
 
       if (existingDependency && existingDependency?.path !== dependency?.path) {
@@ -46,7 +48,7 @@ const generateElementNode: NodeToHTML<UIDLElementNode, HastNode> = (node, params
           },
         }
       }
-    } else if (dependency.type === 'local') {
+    } else if (dependency.type === 'local' && templateSyntax.dependencyHandling === 'import') {
       // local dependencies can be renamed based on their safety (eg: Header/header, Form/form)
       const safeImportName = StringUtils.dashCaseToUpperCamelCase(safeTagName)
       dependencies[safeImportName] = { ...dependency }

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-html/index.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-html/index.ts
@@ -27,16 +27,14 @@ const generateElementNode: NodeToHTML<UIDLElementNode, HastNode> = (node, params
 
   if (dependency) {
     const existingDependency = dependencies[tagName]
-    if (templateSyntax.dependencyHandling === 'import') {
+    if (templateSyntax.dependencyHandling === 'import' && dependency.type !== 'local') {
       safeTagName =
         existingDependency && existingDependency?.path !== dependency?.path
           ? `${StringUtils.dashCaseToUpperCamelCase(
               StringUtils.removeIllegalCharacters(dependency.path)
             )}${tagName}`
           : tagName
-    }
 
-    if (dependency.type !== 'local') {
       dependencies[safeTagName] = { ...dependency }
 
       if (existingDependency && existingDependency?.path !== dependency?.path) {

--- a/packages/teleport-project-generator-angular/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-angular/__tests__/end2end/index.ts
@@ -1,8 +1,5 @@
-// @ts-ignore
-import uidlSample from '../../../../examples/test-samples/project-sample.json'
-// @ts-ignore
+import uidlSample from '../../../../examples/test-samples/project-sample-with-dependency.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
-// @ts-ignore
 import template from './template-definition.json'
 import { createAngularProjectGenerator } from '../../src'
 import { FileType } from '@teleporthq/teleport-types'
@@ -14,26 +11,58 @@ describe('Angular Project Generator', () => {
     const outputFolder = await generator.generateProject(uidlSample, template)
     const assetsPath = generator.getAssetsPath()
 
-    expect(assetsPath).toBeDefined()
-    expect(outputFolder.name).toBe(template.name)
-    expect(outputFolder.files[0].name).toBe('package')
-
+    const packageJSON = outputFolder.files[0]
     const srcFolder = outputFolder.subFolders[0]
     const appFolder = srcFolder.subFolders[0]
     const pagesFolder = appFolder.subFolders[0]
     const componentsFolder = appFolder.subFolders[1]
+    const modalComponent = componentsFolder.subFolders[2]
+    const componentsModule = componentsFolder.files[0]
 
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(outputFolder.files[0].name).toBe('package')
     expect(srcFolder.files[0].fileType).toBe(FileType.HTML)
     expect(srcFolder.files[0].content).toBeDefined()
     expect(appFolder.files[0].name).toBe('app.module')
     expect(appFolder.files[0].fileType).toBe(FileType.TS)
     expect(appFolder.files[0].content).toBeDefined()
     expect(componentsFolder.name).toBe('components')
-    expect(componentsFolder.files[0].name).toBe('components.module')
+    expect(componentsModule.name).toBe('components.module')
     expect(componentsFolder.files[0].content).toBeDefined()
     expect(componentsFolder.subFolders.length).toBeGreaterThan(0)
     expect(pagesFolder.name).toBe('pages')
     expect(pagesFolder.subFolders.length).toBeGreaterThan(0)
+
+    /*
+     * For angular by default we are adding all the external dependencies only in components module
+     * Since we can import once in module and use in all places for angular unlike
+     * other frameworks. External dependnecies don't have first class support in Angular yet in
+     * code-generators
+     *
+     * Any local dependency is also imported only once in the components module and direclty
+     * used in any other component
+     *
+     * Refer --> https://github.com/teleporthq/teleport-code-generators/pull/478
+     */
+
+    expect(componentsModule.content).toContain(`import { Button } from 'antd'`)
+    expect(componentsModule.content)
+      .toContain(`import { OneComponent } from './one-component/one-component.component'
+import { ExpandableArea } from './expandable-area/expandable-area.component'
+import { Modal } from './modal/modal.component'
+import { ModalWindow } from './modal-window/modal-window.component'`)
+    expect(modalComponent.files[0].content).toContain(
+      `<modal-window (onClose)="isOpen = false" *ngIf="isOpen"></modal-window>`
+    )
+    expect(pagesFolder.subFolders[0].files[0].content).toContain(`<app-modal></app-modal>`)
+    /*
+     * Modal is used in home page but don't need to import since all components are packed
+     * together as components module and imported at once in root module
+     */
+    expect(pagesFolder.subFolders[0].files[1].content).not.toContain(`import Modal`)
+    expect(modalComponent.files[1].content).not.toContain(`import Modal`)
+    expect(packageJSON.content).toContain(`"antd": "4.5.4"`)
   })
 
   it('throws error when invalid UIDL sample is used', async () => {

--- a/packages/teleport-project-generator-gatsby/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-gatsby/__tests__/end2end/index.ts
@@ -1,5 +1,5 @@
-// @ts-ignore
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
+import uidlSampleWithExternalDependencies from '../../../../examples/test-samples/project-sample-with-dependency.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
 import template from './mocks'
 import { createGatsbyProjectGenerator } from '../../src'
@@ -26,6 +26,36 @@ describe('Gatsby Project Generator', () => {
     expect(pagesFolder.files.length).toBeGreaterThan(0)
     expect(componentsFolder.files.length).toBeGreaterThan(0)
     expect(componentsFolder.name).toBe('components')
+  })
+
+  it('runs without crashing with external dependencies', async () => {
+    const outputFolder = await generator.generateProject(
+      uidlSampleWithExternalDependencies,
+      template
+    )
+    const assetsPath = generator.getAssetsPath()
+
+    const srcFolder = outputFolder.subFolders[0]
+    const pagesFolder = srcFolder.subFolders[1]
+    const componentsFolder = srcFolder.subFolders[2]
+
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(outputFolder.files[0].name).toBe('package')
+    expect(outputFolder.files[0].content).toContain(`"antd": "4.5.4"`)
+    expect(srcFolder.files[0].name).toBe('html')
+    expect(srcFolder.files[0].fileType).toBe(FileType.JS)
+    expect(srcFolder.files[0].content).toBeDefined()
+    expect(pagesFolder.name).toBe('pages')
+    expect(pagesFolder.files.length).toBeGreaterThan(0)
+    expect(componentsFolder.files.length).toBeGreaterThan(0)
+    expect(componentsFolder.name).toBe('components')
+
+    /*
+     * Imports like css imports / or imports which are just inserted,
+     * are added in index file in pages
+     */
+    expect(pagesFolder.files[0].content).toContain(`import 'antd/dist/antd.css'`)
   })
 
   it('throws error when invalid UIDL sample is used', async () => {

--- a/packages/teleport-project-generator-gridsome/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-gridsome/__tests__/end2end/index.ts
@@ -1,8 +1,7 @@
-// @ts-ignore
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
-// @ts-ignore
+import uidlSampleWithExternalDependency from '../../../../examples/test-samples/project-sample-with-dependency.json'
+import uidlWithProjectStyleSheet from '../../../../examples/test-samples/project-with-import-global-styles.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
-// @ts-ignore
 import template from './template-definition.json'
 import { createGridsomeProjectGenerator } from '../../src'
 
@@ -14,12 +13,59 @@ describe('Gridsome Project Generator', () => {
     const assetsPath = generator.getAssetsPath()
 
     const srcFolder = outputFolder.subFolders[0]
+    const mainFile = srcFolder.files[0]
+
+    expect(assetsPath).toBeDefined()
+    expect(mainFile.content).not.toContain(`import '~/assets/style.css'`)
+    expect(outputFolder.name).toBe(template.name)
+    expect(srcFolder.files[0].name).toBe('main')
+    expect(srcFolder.files[0].fileType).toBe('js')
+  })
+
+  it('runs without crashing with project style sheets', async () => {
+    const outputFolder = await generator.generateProject(uidlWithProjectStyleSheet, template)
+    const assetsPath = generator.getAssetsPath()
+
+    const srcFolder = outputFolder.subFolders[0]
+    const mainFile = srcFolder.files[0]
+    const assetsFoler = srcFolder.subFolders[0]
 
     expect(assetsPath).toBeDefined()
     expect(outputFolder.name).toBe(template.name)
     expect(srcFolder.files[0].name).toBe('main')
     expect(srcFolder.files[0].fileType).toBe('js')
+    expect(mainFile.content).toContain(`import '~/assets/style.css'`)
+    expect(assetsFoler.files.length).toBe(1)
+    expect(assetsFoler.files[0].name).toBe('style')
+    expect(assetsFoler.files[0].content).toContain(`.primaryButton`)
   })
+
+  it('runs without crashing with external dependencies with supported syntaxes', async () => {
+    const outputFolder = await generator.generateProject(uidlSampleWithExternalDependency, template)
+    const assetsPath = generator.getAssetsPath()
+
+    const packageJSON = outputFolder.files[0]
+    const pages = outputFolder.subFolders[0].subFolders[0]
+    const components = outputFolder.subFolders[0].subFolders[1]
+
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(packageJSON).toBeDefined()
+    expect(pages.files.length).toBe(3)
+    expect(components.files.length).toBe(4)
+
+    /*
+     * Support for external dependencies for Nuxt is same as Vue
+     * For further details, refer --> https://github.com/teleporthq/teleport-code-generators/pull/478
+     */
+
+    expect(components.files[2].content).toContain(`import { Button } from 'antd'`)
+    expect(packageJSON.content).toContain(`"antd": "4.5.4"`)
+
+    /** For Nuxt based projects, just imports are injected in index file of the routes */
+    expect(pages.files[0].content).toContain(`import 'antd/dist/antd.css'`)
+  })
+
   it('throws error when invalid UIDL sample is used', async () => {
     const result = generator.generateProject(invalidUidlSample, template)
 

--- a/packages/teleport-project-generator-next/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-next/__tests__/end2end/index.ts
@@ -1,10 +1,7 @@
-// @ts-ignore
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
-// @ts-ignore
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
-// @ts-ignore
 import uidlSampleWithoutProjectStyleesButImports from './project-with-import-without-global-styles.json'
-// @ts-ignore
+import uidlSampleWithProjectStyleSheet from '../../../../examples/test-samples/project-with-import-global-styles.json'
 import template from './template-definition.json'
 import { createNextProjectGenerator } from '../../src'
 
@@ -27,6 +24,21 @@ describe('React Next Project Generator', () => {
     expect(appFile).toBeDefined()
     expect(appFile.content).toContain(`import "antd/dist/antd.css`)
     expect(appFile.content).not.toContain(`import './style.css'`)
+  })
+
+  it('runs without crashing and adding style sheet to _app.js file', async () => {
+    const outputFolder = await generator.generateProject(uidlSampleWithProjectStyleSheet, template)
+    const assetsPath = generator.getAssetsPath()
+
+    const publicFolder = outputFolder.subFolders.find((folder) => folder.name === 'pages')
+    const appFile = publicFolder.files.find((file) => file.name === '_app')
+
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(outputFolder.files[0].name).toBe('package')
+    expect(appFile).toBeDefined()
+    expect(appFile.content).not.toContain(`import "antd/dist/antd.css`)
+    expect(appFile.content).toContain(`import './style.css'`)
   })
 
   it('runs without crashing', async () => {

--- a/packages/teleport-project-generator-nuxt/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-nuxt/__tests__/end2end/index.ts
@@ -1,8 +1,6 @@
-// @ts-ignore
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
-// @ts-ignore
+import uidlSampleWithDependencies from '../../../../examples/test-samples/project-sample-with-dependency.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
-// @ts-ignore
 import template from './template-definition.json'
 import { createNuxtProjectGenerator } from '../../src'
 
@@ -13,8 +11,37 @@ describe('Vue Nuxt Project Generator', () => {
     const outputFolder = await generator.generateProject(uidlSample, template)
     const assetsPath = generator.getAssetsPath()
 
+    const packageJSON = outputFolder.files[1]
+
     expect(assetsPath).toBeDefined()
     expect(outputFolder.name).toBe(template.name)
+    expect(packageJSON).toBeDefined()
+  })
+
+  it('runs without crashing with external dependencies with supported syntaxes', async () => {
+    const outputFolder = await generator.generateProject(uidlSampleWithDependencies, template)
+    const assetsPath = generator.getAssetsPath()
+
+    const packageJSON = outputFolder.files[1]
+    const pages = outputFolder.subFolders[1]
+    const components = outputFolder.subFolders[0]
+
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(packageJSON).toBeDefined()
+    expect(pages.files.length).toBe(3)
+    expect(components.files.length).toBe(4)
+
+    /*
+     * Support for external dependencies for Nuxt is same as Vue
+     * For further details, refer --> https://github.com/teleporthq/teleport-code-generators/pull/478
+     */
+
+    expect(components.files[2].content).toContain(`import { Button } from 'antd'`)
+    expect(packageJSON.content).toContain(`"antd": "4.5.4"`)
+
+    /* For Nuxt based projects, just imports are injected in index file of the routes */
+    expect(pages.files[0].content).toContain(`import 'antd/dist/antd.css'`)
   })
 
   it('throws error when invalid UIDL sample is used', async () => {

--- a/packages/teleport-project-generator-preact/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-preact/__tests__/end2end/index.ts
@@ -1,34 +1,73 @@
-// @ts-ignore
+import uidlSampleWithDependencies from '../../../../examples/test-samples/project-sample-with-dependency.json'
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
-// @ts-ignore
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
-// @ts-ignore
 import template from './template-definition.json'
 import { createPreactProjectGenerator } from '../../src'
-import { ProjectUIDL } from '@teleporthq/teleport-types'
-
-const projectUIDL = uidlSample as ProjectUIDL
 
 describe('Preact Project Generator', () => {
   const generator = createPreactProjectGenerator()
 
-  it('runs without crashing', async () => {
-    const outputFolder = await generator.generateProject(projectUIDL, template)
+  it('runs without crashing with external dependencies', async () => {
+    const outputFolder = await generator.generateProject(uidlSample, template)
     const assetsPath = generator.getAssetsPath()
-
-    expect(assetsPath).toBeDefined()
-    expect(outputFolder.name).toBe(template.name)
-    expect(outputFolder.files[0].name).toBe('package')
 
     const srcFolder = outputFolder.subFolders[0]
     const componentFiles = srcFolder.subFolders[0].files
+    const packageJSON = outputFolder.files[0]
 
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(packageJSON).toBeDefined()
+    expect(packageJSON.name).toBe('package')
     expect(srcFolder.files[0].name).toBe('index')
     expect(srcFolder.files[0].fileType).toBe('html')
     expect(srcFolder.subFolders[0].name).toBe('components')
     expect(srcFolder.subFolders[1].name).toBe('routes')
+    expect(componentFiles.length).toBe(6)
     expect(componentFiles[componentFiles.length - 1].fileType).toBe('js')
     expect(componentFiles[componentFiles.length - 1].name).toBe('app')
+  })
+
+  it('runs without crashing with external dependencies', async () => {
+    const outputFolder = await generator.generateProject(uidlSampleWithDependencies, template)
+    const assetsPath = generator.getAssetsPath()
+
+    const srcFolder = outputFolder.subFolders[0]
+    const componentFiles = srcFolder.subFolders[0].files
+    const packageJSON = outputFolder.files[0]
+    const modalComponent = componentFiles[3]
+
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(packageJSON).toBeDefined()
+    expect(packageJSON.name).toBe('package')
+    expect(packageJSON.content).toContain(`{
+  "name": "myvueproject",
+  "version": "1.0.0",
+  "description": "Project generated based on a UIDL document",
+  "dependencies": {
+    "react-helmet": "^6.1.0",
+    "prop-types": "15.7.2",
+    "antd": "4.5.4"
+  }
+}`)
+    expect(srcFolder.files[0].name).toBe('index')
+    expect(srcFolder.files[0].fileType).toBe('html')
+    expect(srcFolder.subFolders[0].name).toBe('components')
+    expect(srcFolder.subFolders[1].name).toBe('routes')
+    expect(componentFiles.length).toBe(6)
+    expect(componentFiles[componentFiles.length - 1].fileType).toBe('js')
+    expect(componentFiles[componentFiles.length - 1].name).toBe('app')
+    expect(modalComponent.content).toContain(
+      `<Button type="primary" onClick={() => setIsOpen(true)}>
+        Show Popup
+      </Button>`
+    )
+    expect(modalComponent.content).toContain(`import { Button } from 'antd'`)
+    /** Imports which are just inserted and left like css one's are added directly in app.js file */
+    expect(componentFiles[componentFiles.length - 1].content).toContain(
+      `import 'antd/dist/antd.css'`
+    )
   })
 
   it('throws error when invalid UIDL sample is used', async () => {

--- a/packages/teleport-project-generator-stencil/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-stencil/__tests__/end2end/index.ts
@@ -1,18 +1,14 @@
-// @ts-ignore
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
-// @ts-ignore
+import uidlSampleWithGlobalStyleSheet from '../../../../examples/test-samples/project-with-import-global-styles.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
 import template from './mocks'
 import { createStencilProjectGenerator } from '../../src'
-import { ProjectUIDL } from '@teleporthq/teleport-types'
-
-const projectUIDL = uidlSample as ProjectUIDL
 
 describe('Preact Project Generator', () => {
   const generator = createStencilProjectGenerator()
 
   it('runs without crashing', async () => {
-    const outputFolder = await generator.generateProject(projectUIDL, template)
+    const outputFolder = await generator.generateProject(uidlSample, template)
     const assetsPath = generator.getAssetsPath()
 
     expect(assetsPath).toBeDefined()
@@ -23,9 +19,36 @@ describe('Preact Project Generator', () => {
     const srcFolder = outputFolder.subFolders[0]
     const rootFiles = srcFolder.subFolders[0].files
 
+    expect(outputFolder.files.length).toBe(2)
     expect(srcFolder.files[0].name).toBe('index')
     expect(srcFolder.files[0].fileType).toBe('html')
     expect(srcFolder.files[0].content).toContain('<script type="module" src="/build/app.esm.js">')
+    expect(rootFiles[0].name).toBe('app-root')
+    expect(rootFiles[0].fileType).toBe('tsx')
+    expect(srcFolder.subFolders[0].name).toBe('components')
+  })
+
+  it('runs without crashing with global style sheet and added to stencil config', async () => {
+    const outputFolder = await generator.generateProject(uidlSampleWithGlobalStyleSheet, template)
+    const assetsPath = generator.getAssetsPath()
+
+    const srcFolder = outputFolder.subFolders[0]
+    const rootFiles = srcFolder.subFolders[0].files
+    const stencilConfig = outputFolder.files[0]
+
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.files.length).toBe(2)
+    expect(outputFolder.name).toBe(template.name)
+    expect(outputFolder.name).toBe('stencil')
+    expect(outputFolder.files[1].name).toBe('package')
+    expect(stencilConfig.name).toBe('stencil.config')
+    expect(stencilConfig.fileType).toBe('ts')
+
+    expect(srcFolder.files[0].name).toBe('style')
+    expect(srcFolder.files[0].fileType).toBe('css')
+    expect(srcFolder.files[1].name).toBe('index')
+    expect(srcFolder.files[1].fileType).toBe('html')
+    expect(srcFolder.files[1].content).toContain('<script type="module" src="/build/app.esm.js">')
     expect(rootFiles[0].name).toBe('app-root')
     expect(rootFiles[0].fileType).toBe('tsx')
     expect(srcFolder.subFolders[0].name).toBe('components')

--- a/packages/teleport-project-generator-vue/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-vue/__tests__/end2end/index.ts
@@ -1,8 +1,6 @@
-// @ts-ignore
+import uidlSampleWithDependencies from '../../../../examples/test-samples/project-sample-with-dependency.json'
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
-// @ts-ignore
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
-// @ts-ignore
 import template from './template-definition.json'
 import { createVueProjectGenerator } from '../../src'
 
@@ -12,10 +10,62 @@ describe('Vue Project Generator', () => {
   it('runs without crashing', async () => {
     const outputFolder = await generator.generateProject(uidlSample, template)
     const assetsPath = generator.getAssetsPath()
+    const srcFolder = outputFolder.subFolders[0]
+    const viewsFolder = srcFolder.subFolders[1]
+    const packageJSON = outputFolder.files[0]
+    const componentsFolder = srcFolder.subFolders[0]
+    const modalComponent = componentsFolder.files[2]
 
     expect(assetsPath).toBeDefined()
     expect(outputFolder.name).toBe(template.name)
+    expect(viewsFolder.files.length).toBe(3)
+    expect(packageJSON).toBeDefined()
+    expect(packageJSON.name).toBe('package')
+    expect(modalComponent.name).toBe('modal')
+    expect(componentsFolder.files.length).toBe(4)
   })
+
+  it('runs without crashing with supported syntax for external dependencies', async () => {
+    const outputFolder = await generator.generateProject(uidlSampleWithDependencies, template)
+    const assetsPath = generator.getAssetsPath()
+    const srcFolder = outputFolder.subFolders[0]
+    const viewsFolder = srcFolder.subFolders[1]
+    const packageJSON = outputFolder.files[0]
+    const componentsFolder = srcFolder.subFolders[0]
+    const modalComponent = componentsFolder.files[2]
+
+    expect(assetsPath).toBeDefined()
+    expect(outputFolder.name).toBe(template.name)
+    expect(viewsFolder.files.length).toBe(3)
+    expect(packageJSON).toBeDefined()
+    expect(packageJSON.name).toBe('package')
+
+    /*
+     * All external dependencies are imported whenver they are used,
+     * but we don't have a first class support for vue external dependencies
+     * Since we need to make some config changes whenever a external component
+     * is used from vue and the generators are not there yet.
+     *
+     * For further details refer --> https://github.com/teleporthq/teleport-code-generators/pull/478
+     */
+
+    expect(packageJSON.content).toContain(`{
+  "name": "myvueproject",
+  "version": "1.0.0",
+  "description": "Project generated based on a UIDL document",
+  "dependencies": {
+    "antd": "4.5.4"
+  }
+}`)
+    expect(modalComponent.name).toBe('modal')
+    expect(componentsFolder.files.length).toBe(4)
+    expect(modalComponent.content).toContain(`import { Button } from 'antd'`)
+    expect(viewsFolder.files[0].content).toContain(`<app-modal></app-modal>`)
+    expect(viewsFolder.files[0].content).toContain(`import AppModal from '../components/modal'`)
+    /** Imports that are just inserted like css are added to router file by default  */
+    expect(srcFolder.files[0].content).toContain(`import 'antd/dist/antd.css'`)
+  })
+
   it('throws error when invalid UIDL sample is used', async () => {
     const result = generator.generateProject(invalidUidlSample, template)
 


### PR DESCRIPTION
I was doing a round of local testing and noticed that angular-projects are breaking. There is a small bug which is causing a problem with imports and breaking them. 