### PR TITLE
Bug: Generate projects, even if project don't have any components. Improved UIDL validations for root and component UIDL

### DIFF
--- a/packages/teleport-component-generator/src/index.ts
+++ b/packages/teleport-component-generator/src/index.ts
@@ -39,7 +39,11 @@ const createComponentGenerator = ({
   ): Promise<CompiledComponent> => {
     let cleanedUIDL = input
     if (!options.skipValidation) {
-      const schemaValidationResult = validator.validateComponentSchema(input)
+      const schemaValidator = options?.isRootComponent
+        ? validator.validateRootComponentSchema
+        : validator.validateComponentSchema
+
+      const schemaValidationResult = schemaValidator(input)
       const { componentUIDL, valid } = schemaValidationResult
       if (valid && componentUIDL) {
         cleanedUIDL = (componentUIDL as unknown) as Record<string, unknown>

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -77,9 +77,10 @@ export const createRouterFile = async (root: ComponentUIDL, strategy: ProjectStr
     strategy.pages.path
   )
 
-  const options = {
+  const options: GeneratorOptions = {
     localDependenciesPrefix: routerLocalDependenciesPrefix,
     strategy,
+    isRootComponent: true,
   }
 
   root.outputOptions = root.outputOptions || {}

--- a/packages/teleport-project-generator/src/index.ts
+++ b/packages/teleport-project-generator/src/index.ts
@@ -149,11 +149,12 @@ export class ProjectGenerator {
     // Based on the routing roles, separate pages into distict UIDLs with their own file names and paths
     const pageUIDLs = createPageUIDLs(uidl, this.strategy)
 
-    // Set the filename and folder path for each component based on the strategy
-    prepareComponentOutputOptions(components, this.strategy)
-
-    // Set the local dependency paths based on the relative paths between files
-    resolveLocalDependencies(pageUIDLs, components, this.strategy)
+    if (Object.keys(components).length > 0) {
+      // Set the filename and folder path for each component based on the strategy
+      prepareComponentOutputOptions(components, this.strategy)
+      // Set the local dependency paths based on the relative paths between files
+      resolveLocalDependencies(pageUIDLs, components, this.strategy)
+    }
 
     // Initialize output folder and other reusable structures
     const rootFolder = UIDLUtils.cloneObject(template || DEFAULT_TEMPLATE)

--- a/packages/teleport-project-generator/src/index.ts
+++ b/packages/teleport-project-generator/src/index.ts
@@ -143,8 +143,8 @@ export class ProjectGenerator {
       throw new Error(contentValidationResult.errorMsg)
     }
 
-    const { components = {}, root } = uidl
-    const { styleSetDefinitions = {} } = root
+    const { components = {} } = uidl
+    const { styleSetDefinitions = {} } = uidl.root
 
     // Based on the routing roles, separate pages into distict UIDLs with their own file names and paths
     const pageUIDLs = createPageUIDLs(uidl, this.strategy)
@@ -166,7 +166,7 @@ export class ProjectGenerator {
         : '/' + this.getAssetsPath().join('/')
     const options: GeneratorOptions = {
       assetsPrefix,
-      projectRouteDefinition: root.stateDefinitions.route,
+      projectRouteDefinition: uidl.root.stateDefinitions.route,
       mapping,
       skipValidation: true,
     }
@@ -174,7 +174,9 @@ export class ProjectGenerator {
     // Handling project style sheet
     if (this.strategy.projectStyleSheet?.generator && Object.keys(styleSetDefinitions).length > 0) {
       const { generator, path } = this.strategy.projectStyleSheet
-      const { files, dependencies } = await generator.generateComponent(uidl.root)
+      const { files, dependencies } = await generator.generateComponent(uidl.root, {
+        isRootComponent: true,
+      })
 
       inMemoryFilesMap.set('projectStyleSheet', {
         rootFolder,
@@ -375,7 +377,7 @@ export class ProjectGenerator {
 
     // Create the routing component in case the project generator has a strategy for that
     if (this.strategy.router) {
-      const { routerFile, dependencies } = await createRouterFile(root, this.strategy)
+      const { routerFile, dependencies } = await createRouterFile(uidl.root, this.strategy)
 
       inMemoryFilesMap.set('router', {
         rootFolder,

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -9,7 +9,7 @@ import projectJSON from '../../../examples/uidl-samples/project.json'
 const projectUIDL = (projectJSON as unknown) as ProjectUIDL
 const reactProjectUIDL = (reactProjectJSON as unknown) as ProjectUIDL
 const assetFile = readFileSync(join(__dirname, 'asset.png'))
-const base64File = new Buffer(assetFile).toString('base64')
+const base64File = Buffer.from(assetFile).toString('base64')
 const packerOptions: PackerOptions = {
   publisher: PublisherType.DISK,
   projectType: ProjectType.REACT,

--- a/packages/teleport-types/src/generators.ts
+++ b/packages/teleport-types/src/generators.ts
@@ -85,6 +85,7 @@ export interface GeneratorOptions {
   assetsPrefix?: string
   mapping?: Mapping
   skipValidation?: boolean
+  isRootComponent?: boolean
   skipNavlinkResolver?: boolean
   projectRouteDefinition?: UIDLStateDefinition
   strategy?: ProjectStrategy

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -34,7 +34,6 @@ export interface UIDLGlobalAsset {
 }
 
 export interface ComponentUIDL {
-  $schema?: string
   name: string
   node: UIDLElementNode
   styleSetDefinitions?: Record<string, UIDLStyleSetDefinition>

--- a/packages/teleport-uidl-validator/src/decoders/component-decoder.ts
+++ b/packages/teleport-uidl-validator/src/decoders/component-decoder.ts
@@ -19,17 +19,16 @@ import {
 } from './utils'
 
 const componentUIDLValidator: Decoder<VComponentUIDL> = object({
-  id: optional(string()),
   name: withDefault('MyComponent', string()),
   node: elementNodeDecoder,
   stateDefinitions: optional(dict(stateDefinitionsDecoder)),
   propDefinitions: optional(dict(propDefinitionsDecoder)),
   importDefinitions: optional(dict(externaldependencyDecoder)),
   outputOptions: optional(outputOptionsDecoder),
+  seo: optional(componentSeoDecoder),
 })
 
 const rootComponentUIDLValidator: Decoder<VRootComponentUIDL> = object({
-  id: optional(string()),
   name: withDefault('App', string()),
   node: elementNodeDecoder,
   stateDefinitions: dict(stateDefinitionsDecoder),

--- a/packages/teleport-uidl-validator/src/decoders/component-decoder.ts
+++ b/packages/teleport-uidl-validator/src/decoders/component-decoder.ts
@@ -6,7 +6,7 @@ import {
   Decoder,
   optional,
 } from '@mojotech/json-type-validation'
-import { VComponentUIDL } from './types'
+import { VComponentUIDL, VRootComponentUIDL } from './types'
 import {
   styleSetDefinitionDecoder,
   propDefinitionsDecoder,
@@ -18,18 +18,29 @@ import {
   peerDependencyDecoder,
 } from './utils'
 
-const componentUIDLValudator: Decoder<VComponentUIDL> = object({
-  $schema: optional(string()),
+const componentUIDLValidator: Decoder<VComponentUIDL> = object({
   id: optional(string()),
   name: withDefault('MyComponent', string()),
   node: elementNodeDecoder,
   stateDefinitions: optional(dict(stateDefinitionsDecoder)),
-  styleSetDefinitions: optional(dict(styleSetDefinitionDecoder)),
   propDefinitions: optional(dict(propDefinitionsDecoder)),
-  peerDefinitions: optional(dict(peerDependencyDecoder)),
   importDefinitions: optional(dict(externaldependencyDecoder)),
+  outputOptions: optional(outputOptionsDecoder),
+})
+
+const rootComponentUIDLValidator: Decoder<VRootComponentUIDL> = object({
+  id: optional(string()),
+  name: withDefault('App', string()),
+  node: elementNodeDecoder,
+  stateDefinitions: dict(stateDefinitionsDecoder),
+  propDefinitions: optional(dict(propDefinitionsDecoder)),
+  importDefinitions: optional(dict(externaldependencyDecoder)),
+  peerDefinitions: optional(dict(peerDependencyDecoder)),
+  styleSetDefinitions: optional(dict(styleSetDefinitionDecoder)),
   outputOptions: optional(outputOptionsDecoder),
   seo: optional(componentSeoDecoder),
 })
 
-export default componentUIDLValudator
+export { rootComponentUIDLValidator }
+
+export default componentUIDLValidator

--- a/packages/teleport-uidl-validator/src/decoders/index.ts
+++ b/packages/teleport-uidl-validator/src/decoders/index.ts
@@ -1,4 +1,4 @@
-import componentUIDLValidator from './component-decoder'
+import componentUIDLValidator, { rootComponentUIDLValidator } from './component-decoder'
 import projectUIDLValidator from './project-decoder'
 
-export { componentUIDLValidator, projectUIDLValidator }
+export { componentUIDLValidator, projectUIDLValidator, rootComponentUIDLValidator }

--- a/packages/teleport-uidl-validator/src/decoders/project-decoder.ts
+++ b/packages/teleport-uidl-validator/src/decoders/project-decoder.ts
@@ -1,7 +1,7 @@
 import { Decoder, object, optional, string, dict, array } from '@mojotech/json-type-validation'
 import { UIDLGlobalProjectValues, WebManifest } from '@teleporthq/teleport-types'
 import { globalAssetsValidator } from './utils'
-import componentUIDLValudator from './component-decoder'
+import componentUIDLValudator, { rootComponentUIDLValidator } from './component-decoder'
 import { VProjectUIDL } from './types'
 
 export const webManifestDecoder: Decoder<WebManifest> = object({
@@ -37,7 +37,7 @@ const projectUIDLValidator: Decoder<VProjectUIDL> = object({
   $schema: optional(string()),
   name: string(),
   globals: globalProjectValuesDecoder,
-  root: componentUIDLValudator,
+  root: rootComponentUIDLValidator,
   components: optional(dict(componentUIDLValudator)),
 })
 

--- a/packages/teleport-uidl-validator/src/decoders/types.ts
+++ b/packages/teleport-uidl-validator/src/decoders/types.ts
@@ -29,30 +29,28 @@ type Modify<T, R> = Omit<T, keyof R> & R
 
 export interface VUIDLElementNode extends Modify<UIDLElementNode, { content: VUIDLElement }> {}
 
-export interface VUIDLConditionalNode
-  extends Modify<
-    UIDLConditionalNode,
-    {
-      content: {
-        node: VUIDLNode
-        reference: UIDLDynamicReference
-        value?: string | number | boolean
-        condition?: UIDLConditionalExpression
-      }
+export type VUIDLConditionalNode = Modify<
+  UIDLConditionalNode,
+  {
+    content: {
+      node: VUIDLNode
+      reference: UIDLDynamicReference
+      value?: string | number | boolean
+      condition?: UIDLConditionalExpression
     }
-  > {}
+  }
+>
 
-export interface VUIDLRepeatNode
-  extends Modify<
-    UIDLRepeatNode,
-    {
-      content: {
-        node: VUIDLElementNode
-        dataSource?: UIDLAttributeValue
-        meta?: UIDLRepeatMeta
-      }
+export type VUIDLRepeatNode = Modify<
+  UIDLRepeatNode,
+  {
+    content: {
+      node: VUIDLElementNode
+      dataSource?: UIDLAttributeValue
+      meta?: UIDLRepeatMeta
     }
-  > {}
+  }
+>
 
 export type VUIDLNode =
   | UIDLDynamicReference
@@ -63,106 +61,104 @@ export type VUIDLNode =
   | VUIDLConditionalNode
   | VUIDLSlotNode
   | string
-export interface VUIDLElement
-  extends Modify<
-    UIDLElement,
-    {
-      abilities?: {
-        link?: VUIDLLinkNode
-      }
-      children?: VUIDLNode[]
-      style?: Record<string, UIDLAttributeValue | string | number>
-      attrs?: Record<string, UIDLAttributeValue | string | number>
-      referencedStyles: Record<
-        string,
-        UIDLElementNodeProjectReferencedStyle | VUIDLElementNodeInlineReferencedStyle
-      >
-    }
-  > {}
 
-export interface VUIDLElementNodeInlineReferencedStyle
-  extends Modify<
-    UIDLElementNodeInlineReferencedStyle,
-    {
-      content: {
-        mapType: 'inlined'
-        conditions: UIDLStyleConditions[]
-        styles: Record<string, UIDLAttributeValue | string | number>
-      }
+export type VUIDLElement = Modify<
+  UIDLElement,
+  {
+    abilities?: {
+      link?: VUIDLLinkNode
     }
-  > {}
+    children?: VUIDLNode[]
+    style?: Record<string, UIDLAttributeValue | string | number>
+    attrs?: Record<string, UIDLAttributeValue | string | number>
+    referencedStyles: Record<
+      string,
+      UIDLElementNodeProjectReferencedStyle | VUIDLElementNodeInlineReferencedStyle
+    >
+  }
+>
 
-export interface VUIDLStyleSetDefnition
-  extends Modify<
-    UIDLStyleSetDefinition,
-    {
-      conditions?: VUIDLStyleSetConditions[]
-      content: Record<string, UIDLStaticValue | string | number>
+export type VUIDLElementNodeInlineReferencedStyle = Modify<
+  UIDLElementNodeInlineReferencedStyle,
+  {
+    content: {
+      mapType: 'inlined'
+      conditions: UIDLStyleConditions[]
+      styles: Record<string, UIDLAttributeValue | string | number>
     }
-  > {}
+  }
+>
 
-export interface VComponentUIDL
-  extends Modify<
-    ComponentUIDL,
-    { styleSetDefinitions: Record<string, VUIDLStyleSetDefnition>; node: VUIDLElementNode }
-  > {}
+export type VUIDLStyleSetDefnition = Modify<
+  UIDLStyleSetDefinition,
+  {
+    conditions?: VUIDLStyleSetConditions[]
+    content: Record<string, UIDLStaticValue | string | number>
+  }
+>
 
-export interface VProjectUIDL
-  extends Modify<
-    ProjectUIDL,
-    {
-      root: VComponentUIDL
-      components?: Record<string, VComponentUIDL>
+type ModifiedComponentUIDL = Modify<
+  ComponentUIDL,
+  { styleSetDefinitions: Record<string, VUIDLStyleSetDefnition>; node: VUIDLElementNode }
+>
+
+export type VComponentUIDL = Omit<
+  ModifiedComponentUIDL,
+  'peerDefinitions' | 'seo' | 'styleSetDefinitions'
+>
+
+export type VRootComponentUIDL = ModifiedComponentUIDL
+
+export type VProjectUIDL = Modify<
+  ProjectUIDL,
+  {
+    root: VRootComponentUIDL
+    components?: Record<string, VComponentUIDL>
+  }
+>
+
+export type VUIDLSlotNode = Modify<
+  UIDLSlotNode,
+  {
+    content:
+      | {
+          name?: string
+          fallback?: VUIDLElementNode | UIDLStaticValue | UIDLDynamicReference
+        }
+      | {}
+  }
+>
+
+export type VUIDLSectionLinkNode = Modify<
+  UIDLSectionLinkNode,
+  {
+    content: Record<string, string>
+  }
+>
+
+export type VUIDLURLLinkNode = Modify<
+  UIDLURLLinkNode,
+  {
+    content: {
+      url: UIDLAttributeValue | string
+      newTab: boolean
     }
-  > {}
+  }
+>
 
-export interface VUIDLSlotNode
-  extends Modify<
-    UIDLSlotNode,
-    {
-      content:
-        | {
-            name?: string
-            fallback?: VUIDLElementNode | UIDLStaticValue | UIDLDynamicReference
-          }
-        | {}
-    }
-  > {}
+export type VUIDLStyleSetMediaCondition = Modify<
+  UIDLStyleSetMediaCondition,
+  {
+    content: Record<string, UIDLStaticValue | string | number>
+  }
+>
 
-export interface VUIDLSectionLinkNode
-  extends Modify<
-    UIDLSectionLinkNode,
-    {
-      content: Record<string, string>
-    }
-  > {}
-
-export interface VUIDLURLLinkNode
-  extends Modify<
-    UIDLURLLinkNode,
-    {
-      content: {
-        url: UIDLAttributeValue | string
-        newTab: boolean
-      }
-    }
-  > {}
-
-export interface VUIDLStyleSetMediaCondition
-  extends Modify<
-    UIDLStyleSetMediaCondition,
-    {
-      content: Record<string, UIDLStaticValue | string | number>
-    }
-  > {}
-
-export interface VUIDLStyleSetStateCondition
-  extends Modify<
-    UIDLStyleSetStateCondition,
-    {
-      content: Record<string, UIDLStaticValue | string | number>
-    }
-  > {}
+export type VUIDLStyleSetStateCondition = Modify<
+  UIDLStyleSetStateCondition,
+  {
+    content: Record<string, UIDLStaticValue | string | number>
+  }
+>
 
 export type VUIDLStyleSetConditions = VUIDLStyleSetMediaCondition | VUIDLStyleSetStateCondition
 

--- a/packages/teleport-uidl-validator/src/decoders/types.ts
+++ b/packages/teleport-uidl-validator/src/decoders/types.ts
@@ -102,10 +102,7 @@ type ModifiedComponentUIDL = Modify<
   { styleSetDefinitions: Record<string, VUIDLStyleSetDefnition>; node: VUIDLElementNode }
 >
 
-export type VComponentUIDL = Omit<
-  ModifiedComponentUIDL,
-  'peerDefinitions' | 'seo' | 'styleSetDefinitions'
->
+export type VComponentUIDL = Omit<ModifiedComponentUIDL, 'peerDefinitions' | 'styleSetDefinitions'>
 
 export type VRootComponentUIDL = ModifiedComponentUIDL
 

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -279,7 +279,7 @@ export const urlLinkNodeDecoder: Decoder<VUIDLURLLinkNode> = object({
 
 export const sectionLinkNodeDecoder: Decoder<VUIDLSectionLinkNode> = object({
   type: constant('section'),
-  content: optional(dict(string())),
+  content: dict(string()),
 })
 
 export const navLinkNodeDecoder: Decoder<UIDLNavLinkNode> = object({

--- a/packages/teleport-uidl-validator/src/index.ts
+++ b/packages/teleport-uidl-validator/src/index.ts
@@ -1,6 +1,16 @@
 import * as Parser from './parser'
 import * as Decoders from './decoders/utils'
-import { componentUIDLValidator, projectUIDLValidator } from './decoders'
+import {
+  componentUIDLValidator,
+  projectUIDLValidator,
+  rootComponentUIDLValidator,
+} from './decoders'
 
 export { default as Validator } from './validator'
-export { Parser, Decoders, componentUIDLValidator, projectUIDLValidator }
+export {
+  Parser,
+  Decoders,
+  componentUIDLValidator,
+  projectUIDLValidator,
+  rootComponentUIDLValidator,
+}

--- a/packages/teleport-uidl-validator/src/validator/index.ts
+++ b/packages/teleport-uidl-validator/src/validator/index.ts
@@ -4,7 +4,11 @@ import {
   ProjectValidationError,
   ComponentValidationError,
 } from '@teleporthq/teleport-types'
-import { componentUIDLValidator, projectUIDLValidator } from '../decoders'
+import {
+  componentUIDLValidator,
+  projectUIDLValidator,
+  rootComponentUIDLValidator,
+} from '../decoders'
 import { VComponentUIDL, VProjectUIDL } from '../decoders/types'
 import * as utils from './utils'
 
@@ -19,6 +23,16 @@ export default class Validator {
   public validateComponentSchema(input: unknown): ValidationResult {
     try {
       const cleanedUIDL = componentUIDLValidator.runWithException(input)
+      return { valid: true, errorMsg: '', componentUIDL: cleanedUIDL }
+    } catch (e) {
+      const errorMsg = utils.formatErrors([{ kind: e.kind, message: e.message, at: e.at }])
+      throw new ComponentValidationError(errorMsg)
+    }
+  }
+
+  public validateRootComponentSchema(input: unknown): ValidationResult {
+    try {
+      const cleanedUIDL = rootComponentUIDLValidator.runWithException(input)
       return { valid: true, errorMsg: '', componentUIDL: cleanedUIDL }
     } catch (e) {
       const errorMsg = utils.formatErrors([{ kind: e.kind, message: e.message, at: e.at }])

--- a/packages/teleport-uidl-validator/src/validator/utils.ts
+++ b/packages/teleport-uidl-validator/src/validator/utils.ts
@@ -179,7 +179,7 @@ export const checkRouteDefinition = (input: ProjectUIDL) => {
 // in the component section
 export const checkComponentExistence = (input: ProjectUIDL) => {
   const errors: string[] = []
-  const components = Object.keys(input.components)
+  const components = Object.keys(input.components || {})
 
   UIDLUtils.traverseElements(input.root.node, (element) => {
     if (
@@ -203,8 +203,8 @@ export const checkComponentExistence = (input: ProjectUIDL) => {
 //      }
 //    }
 export const checkComponentNaming = (input: ProjectUIDL) => {
-  const errors = []
-  const namesUsed = Object.keys(input.components)
+  const errors: string[] = []
+  const namesUsed = Object.keys(input.components || {})
 
   const diffs = namesUsed.filter((name) => input.components[name].name !== name)
 


### PR DESCRIPTION
#487 

We use `ComponentUIDL` to carry out all operations needs for generating components. But we use the ComponentUIDL for maintaining `root` in `ProjectUIDL`. But there are slight changes needed in order to validate.

### Root Component UIDL
- name
- node
- propDefinitions
- stateDefinitions
- importDefinitions
- peerDefinitions
- styleSetDefinitions
- outputOptions
- seo

## Component UIDL

- name
- node
- propDefinitions
- stateDefinitions
- importDefinitions
- outputOptions
- seo

In `root` the `stateDefinitions` are not optional but in component they are optional. Since in root we need them to construct routes. So, ti handle this unique validations  no we have two diff validators for components. `componentUIDLValidator` and `rootComponentUIDLValidator`. 

By default the `@teleporthq/teleport-component-generator` uses `componentUIDLValidator` unless a flag is explicitly passed to use `rootComponentValidator`. 

Like this 

```js 
const result = await generator.generateProject(uidl, { isRootComponent: true})
```

When this flag is passed, it starts to validate the component using `rootComponentValidator`. This is automatically handled by our project generators while validating a project.


* A small bug-fix to generate projects even when components are not used and defined in the `projectUIDL`