### PR TITLE
fix(styles): Fix for importing and handling project-stylesheet if only tokens are used. 

### DIFF
--- a/examples/test-samples/project-with-only-tokens.json
+++ b/examples/test-samples/project-with-only-tokens.json
@@ -1,0 +1,766 @@
+{
+    "name": "dsffdsf",
+    "globals": {
+      "settings": {
+        "title": "dsffdsf",
+        "language": "en"
+      },
+      "assets": [
+        {
+          "type": "style",
+          "content": "html {  line-height: 1.15;}body {  margin: 0;}* {  box-sizing: border-box;  border-width: 0;  border-style: solid;}p,li,ul,pre,div,h1,h2,h3,h4,h5,h6 {  margin: 0;  padding: 0;}button,input,optgroup,select,textarea {  font-family: inherit;  font-size: 100%;  line-height: 1.15;  margin: 0;}button,select {  text-transform: none;}button,[type=\"button\"],[type=\"reset\"],[type=\"submit\"] {  -webkit-appearance: button;}button::-moz-focus-inner,[type=\"button\"]::-moz-focus-inner,[type=\"reset\"]::-moz-focus-inner,[type=\"submit\"]::-moz-focus-inner {  border-style: none;  padding: 0;}button:-moz-focus,[type=\"button\"]:-moz-focus,[type=\"reset\"]:-moz-focus,[type=\"submit\"]:-moz-focus {  outline: 1px dotted ButtonText;}a {  color: inherit;  text-decoration: inherit;}input {  padding: 2px 4px;}img {  display: block;}"
+        }
+      ],
+      "meta": [
+        {
+          "name": "viewport",
+          "content": "width=device-width, initial-scale=1.0"
+        },
+        {
+          "charSet": "utf-8"
+        },
+        {
+          "property": "twitter:card",
+          "content": "summary_large_image"
+        }
+      ],
+      "customCode": {}
+    },
+    "root": {
+      "name": "App",
+      "designLanguage": {
+        "tokens": {
+          "Primary-900": {
+            "type": "static",
+            "content": "#E6FAFF"
+          },
+          "Space-Unit": {
+            "type": "static",
+            "content": "1rem"
+          },
+          "Space-TripleUnit": {
+            "type": "static",
+            "content": "3rem"
+          },
+          "Greys-White": {
+            "type": "static",
+            "content": "#FFFFFF"
+          },
+          "Radius-Round": {
+            "type": "static",
+            "content": "50%"
+          },
+          "Greys-700": {
+            "type": "static",
+            "content": "#999999"
+          },
+          "Danger-300": {
+            "type": "static",
+            "content": "#A22020"
+          },
+          "Primary-500": {
+            "type": "static",
+            "content": "#14A9FF"
+          },
+          "Success-300": {
+            "type": "static",
+            "content": "#199033"
+          },
+          "Success-700": {
+            "type": "static",
+            "content": "#4CC366"
+          },
+          "Size-HalfUnit": {
+            "type": "static",
+            "content": "0.5rem"
+          },
+          "Primary-700": {
+            "type": "static",
+            "content": "#85DCFF"
+          },
+          "Greys-Black": {
+            "type": "static",
+            "content": "#000000"
+          },
+          "Success-500": {
+            "type": "static",
+            "content": "#32A94C"
+          },
+          "Primary-300": {
+            "type": "static",
+            "content": "#0074F0"
+          },
+          "Space-DoubleUnit": {
+            "type": "static",
+            "content": "2rem"
+          },
+          "Radius-Square": {
+            "type": "static",
+            "content": "0"
+          },
+          "Danger-500": {
+            "type": "static",
+            "content": "#BF2626"
+          },
+          "Size-Unit": {
+            "type": "static",
+            "content": "1rem"
+          },
+          "Space-HalfUnit": {
+            "type": "static",
+            "content": "0.5rem"
+          },
+          "Size-DoubleUnit": {
+            "type": "static",
+            "content": "2rem"
+          },
+          "Greys-500": {
+            "type": "static",
+            "content": "#595959"
+          },
+          "Size-TripleUnit": {
+            "type": "static",
+            "content": "3rem"
+          },
+          "Danger-700": {
+            "type": "static",
+            "content": "#E14747"
+          },
+          "Primary-100": {
+            "type": "static",
+            "content": "#003EB3"
+          }
+        }
+      },
+      "stateDefinitions": {
+        "route": {
+          "type": "string",
+          "defaultValue": "Home",
+          "values": [
+            {
+              "value": "Abolut",
+              "seo": {
+                "title": "Abolut - dsffdsf",
+                "metaTags": [
+                  {
+                    "property": "og:title",
+                    "content": "Abolut - dsffdsf"
+                  }
+                ]
+              }
+            },
+            {
+              "value": "Home",
+              "seo": {
+                "title": "dsffdsf",
+                "metaTags": [
+                  {
+                    "property": "og:title",
+                    "content": "dsffdsf"
+                  }
+                ]
+              }
+            },
+            {
+              "value": "Contact",
+              "seo": {
+                "title": "Contact - dsffdsf",
+                "metaTags": [
+                  {
+                    "property": "og:title",
+                    "content": "Contact - dsffdsf"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "node": {
+        "type": "element",
+        "content": {
+          "elementType": "Router",
+          "children": [
+            {
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "semanticType": "div",
+                    "referencedStyles": {},
+                    "attrs": {},
+                    "abilities": {},
+                    "style": {
+                      "height": {
+                        "type": "static",
+                        "content": "auto"
+                      },
+                      "display": {
+                        "type": "static",
+                        "content": "flex"
+                      },
+                      "minHeight": {
+                        "type": "static",
+                        "content": "100vh"
+                      },
+                      "alignItems": {
+                        "type": "static",
+                        "content": "flex-start"
+                      },
+                      "flexDirection": {
+                        "type": "static",
+                        "content": "column"
+                      }
+                    },
+                    "children": []
+                  }
+                },
+                "value": "Abolut",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            },
+            {
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "semanticType": "div",
+                    "referencedStyles": {},
+                    "attrs": {},
+                    "abilities": {},
+                    "style": {
+                      "height": {
+                        "type": "static",
+                        "content": "auto"
+                      },
+                      "display": {
+                        "type": "static",
+                        "content": "flex"
+                      },
+                      "minHeight": {
+                        "type": "static",
+                        "content": "100vh"
+                      },
+                      "alignItems": {
+                        "type": "static",
+                        "content": "flex-start"
+                      },
+                      "flexDirection": {
+                        "type": "static",
+                        "content": "column"
+                      },
+                      "justifyContent": {
+                        "type": "static",
+                        "content": "flex-start"
+                      }
+                    },
+                    "children": [
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "dynamic",
+                              "content": {
+                                "referenceType": "token",
+                                "id": "Primary-100"
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "type": "element",
+                              "content": {
+                                "elementType": "text",
+                                "semanticType": "h1",
+                                "attrs": {},
+                                "abilities": {},
+                                "style": {
+                                  "backgroundColor": {
+                                    "type": "dynamic",
+                                    "content": {
+                                      "referenceType": "token",
+                                      "id": "Primary-900"
+                                    }
+                                  }
+                                },
+                                "children": [
+                                  {
+                                    "type": "static",
+                                    "content": "Heading"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "value": "Home",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            },
+            {
+              "type": "conditional",
+              "content": {
+                "node": {
+                  "type": "element",
+                  "content": {
+                    "elementType": "container",
+                    "semanticType": "div",
+                    "referencedStyles": {},
+                    "attrs": {},
+                    "abilities": {},
+                    "style": {
+                      "height": {
+                        "type": "static",
+                        "content": "auto"
+                      },
+                      "display": {
+                        "type": "static",
+                        "content": "flex"
+                      },
+                      "minHeight": {
+                        "type": "static",
+                        "content": "100vh"
+                      },
+                      "alignItems": {
+                        "type": "static",
+                        "content": "flex-start"
+                      },
+                      "flexDirection": {
+                        "type": "static",
+                        "content": "column"
+                      }
+                    },
+                    "children": [
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "static",
+                              "content": "rgba(120, 120, 120, 0.4)"
+                            }
+                          },
+                          "children": []
+                        }
+                      },
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "static",
+                              "content": "rgba(120, 120, 120, 0.4)"
+                            }
+                          },
+                          "children": []
+                        }
+                      },
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "static",
+                              "content": "rgba(120, 120, 120, 0.4)"
+                            }
+                          },
+                          "children": []
+                        }
+                      },
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "static",
+                              "content": "rgba(120, 120, 120, 0.4)"
+                            }
+                          },
+                          "children": []
+                        }
+                      },
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "static",
+                              "content": "rgba(120, 120, 120, 0.4)"
+                            }
+                          },
+                          "children": []
+                        }
+                      },
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "static",
+                              "content": "rgba(120, 120, 120, 0.4)"
+                            }
+                          },
+                          "children": []
+                        }
+                      },
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "static",
+                              "content": "rgba(120, 120, 120, 0.4)"
+                            }
+                          },
+                          "children": []
+                        }
+                      },
+                      {
+                        "type": "element",
+                        "content": {
+                          "elementType": "container",
+                          "semanticType": "div",
+                          "referencedStyles": {},
+                          "attrs": {},
+                          "abilities": {},
+                          "style": {
+                            "width": {
+                              "type": "static",
+                              "content": "100%"
+                            },
+                            "height": {
+                              "type": "static",
+                              "content": "100px"
+                            },
+                            "display": {
+                              "type": "static",
+                              "content": "flex"
+                            },
+                            "flexWrap": {
+                              "type": "static",
+                              "content": "wrap"
+                            },
+                            "alignItems": {
+                              "type": "static",
+                              "content": "center"
+                            },
+                            "flexDirection": {
+                              "type": "static",
+                              "content": "row"
+                            },
+                            "justifyContent": {
+                              "type": "static",
+                              "content": "flex-start"
+                            },
+                            "backgroundColor": {
+                              "type": "static",
+                              "content": "rgba(120, 120, 120, 0.4)"
+                            }
+                          },
+                          "children": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                "value": "Contact",
+                "reference": {
+                  "type": "dynamic",
+                  "content": {
+                    "referenceType": "state",
+                    "id": "route"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "components": {}
+  }

--- a/packages/teleport-component-generator-react/__tests__/integration/component-referenced-styles.ts
+++ b/packages/teleport-component-generator-react/__tests__/integration/component-referenced-styles.ts
@@ -278,9 +278,15 @@ describe('Referes from project style and adds it to the node, without any styles
 
   it('CSS-Modules', async () => {
     const generator = createReactComponentGenerator(ReactStyleVariation.CSSModules)
-    const { files } = await generator.generateComponent(uidl, options)
-    const jsFile = findFileByType(files, FileType.JS)
+    const cssOptions: GeneratorOptions = {
+      projectStyleSet: {
+        ...options.projectStyleSet,
+        importFile: true,
+      },
+    }
 
+    const { files } = await generator.generateComponent(uidl, cssOptions)
+    const jsFile = findFileByType(files, FileType.JS)
     expect(jsFile.content).toContain('className={projectStyles.primaryButton}')
     expect(jsFile.content).toContain(`import projectStyles from '../style.module.css'`)
     expect(jsFile.content).not.toContain(`import styles from './my-component.module.css'`)

--- a/packages/teleport-component-generator/src/assembly-line/index.ts
+++ b/packages/teleport-component-generator/src/assembly-line/index.ts
@@ -35,7 +35,7 @@ export default class AssemblyLine {
     )
 
     const externalDependencies = {
-      ...UIDLUtils.extractExternalDependencies(finalStructure.dependencies),
+      ...UIDLUtils.extractExternalDependencies(finalStructure?.dependencies || {}),
       ...UIDLUtils.extractExternalDependencies(finalStructure.uidl?.peerDefinitions || {}),
     }
     const chunks = groupChunksByFileType(finalStructure.chunks)

--- a/packages/teleport-plugin-css-modules/src/index.ts
+++ b/packages/teleport-plugin-css-modules/src/index.ts
@@ -46,17 +46,11 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
 
   const cssModulesPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks, dependencies, options } = structure
-    const {
-      projectStyleSet: {
-        styleSetDefinitions = {},
-        fileName: projectStyleSheetName,
-        path,
-        importFile = false,
-      },
-      designLanguage: { tokens = {} } = {},
-      isRootComponent,
-    } = options
+    const { projectStyleSet, designLanguage: { tokens = {} } = {}, isRootComponent } = options || {}
     const componentChunk = chunks.filter((chunk) => chunk.name === componentChunkName)[0]
+
+    const { styleSetDefinitions = {}, fileName: projectStyleSheetName, path, importFile = false } =
+      projectStyleSet || {}
 
     if (isRootComponent) {
       if (Object.keys(tokens).length > 0 && Object.keys(styleSetDefinitions).length === 0) {

--- a/packages/teleport-plugin-css-modules/src/index.ts
+++ b/packages/teleport-plugin-css-modules/src/index.ts
@@ -27,6 +27,7 @@ const defaultConfigProps = {
   camelCaseClassNames: false,
   moduleExtension: false,
   classAttributeName: 'className',
+  projectStylesReferenceOffset: 'projectStyles',
 }
 
 export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = (config = {}) => {
@@ -37,6 +38,7 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
     camelCaseClassNames,
     moduleExtension,
     classAttributeName,
+    projectStylesReferenceOffset,
   } = {
     ...defaultConfigProps,
     ...config,
@@ -44,8 +46,32 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
 
   const cssModulesPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks, dependencies, options } = structure
-    const { projectStyleSet } = options
+    const {
+      projectStyleSet: {
+        styleSetDefinitions = {},
+        fileName: projectStyleSheetName,
+        path,
+        importFile = false,
+      },
+      designLanguage: { tokens = {} } = {},
+      isRootComponent,
+    } = options
     const componentChunk = chunks.filter((chunk) => chunk.name === componentChunkName)[0]
+
+    if (isRootComponent) {
+      if (Object.keys(tokens).length > 0 && Object.keys(styleSetDefinitions).length === 0) {
+        const fileName = moduleExtension ? `${projectStyleSheetName}.module` : projectStyleSheetName
+        dependencies[projectStylesReferenceOffset] = {
+          type: 'local',
+          path: `${path}/${fileName}.${FileType.CSS}`,
+          meta: {
+            importJustPath: true,
+          },
+        }
+      }
+
+      return structure
+    }
 
     if (!componentChunk) {
       throw new Error(
@@ -56,7 +82,6 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
     const cssClasses: string[] = []
     let isProjectStyleReferred: boolean = false
     const mediaStylesMap: Record<string, Record<string, unknown>> = {}
-    const projectStylesReferenceOffset = `projectStyles`
     const astNodesLookup = (componentChunk.meta.nodesLookup || {}) as Record<string, unknown>
     // @ts-ignore
     const propsPrefix = componentChunk.meta.dynamicRefPrefix.prop
@@ -80,7 +105,7 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
           : `styles['${className}']`
       const root = astNodesLookup[key]
 
-      if (style) {
+      if (Object.keys(style || {}).length > 0) {
         const { staticStyles, dynamicStyles, tokenStyles } = UIDLUtils.splitDynamicAndStaticStyles(
           style
         )
@@ -110,7 +135,7 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
         }
       }
 
-      if (referencedStyles && Object.keys(referencedStyles).length > 0) {
+      if (Object.keys(referencedStyles || {}).length > 0) {
         Object.values(referencedStyles).forEach((styleRef: UIDLElementNodeReferenceStyles) => {
           switch (styleRef.content.mapType) {
             case 'inlined': {
@@ -147,16 +172,10 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
               return
             }
             case 'project-referenced': {
-              if (!projectStyleSet) {
-                throw new Error(
-                  `Project Style Sheet is missing, but the node is referring to it ${element}`
-                )
-              }
-
               const { content } = styleRef
               if (content.referenceId && !content?.conditions) {
                 isProjectStyleReferred = true
-                const referedStyle = projectStyleSet.styleSetDefinitions[content.referenceId]
+                const referedStyle = styleSetDefinitions[content.referenceId]
                 if (!referedStyle) {
                   throw new Error(
                     `Style that is being used for reference is missing - ${content.referenceId}`
@@ -222,13 +241,11 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
 
     /* Order of imports play a important role on initial load sequence
     So, project styles should always be loaded before component styles */
-    if (isProjectStyleReferred) {
-      const fileName = moduleExtension
-        ? `${options.projectStyleSet.fileName}.module`
-        : options.projectStyleSet.fileName
+    if (isProjectStyleReferred && importFile) {
+      const fileName = moduleExtension ? `${projectStyleSheetName}.module` : projectStyleSheetName
       dependencies[projectStylesReferenceOffset] = {
         type: 'local',
-        path: `${options.projectStyleSet.path}/${fileName}.${FileType.CSS}`,
+        path: `${path}/${fileName}.${FileType.CSS}`,
       }
     }
 

--- a/packages/teleport-plugin-css-modules/src/style-sheet.ts
+++ b/packages/teleport-plugin-css-modules/src/style-sheet.ts
@@ -18,10 +18,9 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
   }
   const styleSheetPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks } = structure
-    const { styleSetDefinitions, designLanguage = {} } = uidl
-    const { tokens = {} } = designLanguage
+    const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
 
-    if (!styleSetDefinitions || Object.keys(styleSetDefinitions).length === 0) {
+    if (!styleSetDefinitions && !tokens) {
       return
     }
 
@@ -83,8 +82,11 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
 
     cssMap.push(...StyleBuilders.generateMediaStyle(mediaStylesMap))
 
-    const sheeName = omitModuleextension ? fileName : `${fileName}.module`
+    if (cssMap.length === 0) {
+      return structure
+    }
 
+    const sheeName = omitModuleextension ? fileName : `${fileName}.module`
     uidl.outputOptions = uidl.outputOptions || {}
     uidl.outputOptions.styleFileName = sheeName
 

--- a/packages/teleport-plugin-css-modules/src/style-sheet.ts
+++ b/packages/teleport-plugin-css-modules/src/style-sheet.ts
@@ -20,7 +20,10 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
     const { uidl, chunks } = structure
     const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
 
-    if (!styleSetDefinitions && !tokens) {
+    if (
+      (!styleSetDefinitions && !tokens) ||
+      (Object.keys(styleSetDefinitions).length === 0 && Object.keys(tokens).length === 0)
+    ) {
       return
     }
 
@@ -37,48 +40,50 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
       )
     }
 
-    Object.values(styleSetDefinitions).forEach((style) => {
-      const { name, content, conditions = [] } = style
-      const { staticStyles, tokenStyles } = UIDLUtils.splitDynamicAndStaticStyles(content)
+    if (Object.keys(styleSetDefinitions).length > 0) {
+      Object.values(styleSetDefinitions).forEach((style) => {
+        const { name, content, conditions = [] } = style
+        const { staticStyles, tokenStyles } = UIDLUtils.splitDynamicAndStaticStyles(content)
 
-      const collectedStyles = {
-        ...StyleUtils.getContentOfStyleObject(staticStyles),
-        ...StyleUtils.getCSSVariablesContentFromTokenStyles(tokenStyles),
-      } as Record<string, string | number>
-
-      cssMap.push(StyleBuilders.createCSSClass(name, collectedStyles))
-
-      if (conditions.length === 0) {
-        return
-      }
-      conditions.forEach((styleRef) => {
-        const {
-          staticStyles: staticValues,
-          tokenStyles: tokenValues,
-        } = UIDLUtils.splitDynamicAndStaticStyles(styleRef.content)
-        const collectedMediaStyles = {
-          ...StyleUtils.getContentOfStyleObject(staticValues),
-          ...StyleUtils.getCSSVariablesContentFromTokenStyles(tokenValues),
+        const collectedStyles = {
+          ...StyleUtils.getContentOfStyleObject(staticStyles),
+          ...StyleUtils.getCSSVariablesContentFromTokenStyles(tokenStyles),
         } as Record<string, string | number>
 
-        if (styleRef.type === 'element-state') {
-          cssMap.push(
-            StyleBuilders.createCSSClassWithSelector(
-              name,
-              `&:${styleRef.meta.state}`,
-              collectedMediaStyles
-            )
-          )
-        }
+        cssMap.push(StyleBuilders.createCSSClass(name, collectedStyles))
 
-        if (styleRef.type === 'screen-size') {
-          mediaStylesMap[styleRef.meta.maxWidth] = {
-            ...mediaStylesMap[styleRef.meta.maxWidth],
-            [name]: collectedMediaStyles,
-          }
+        if (conditions.length === 0) {
+          return
         }
+        conditions.forEach((styleRef) => {
+          const {
+            staticStyles: staticValues,
+            tokenStyles: tokenValues,
+          } = UIDLUtils.splitDynamicAndStaticStyles(styleRef.content)
+          const collectedMediaStyles = {
+            ...StyleUtils.getContentOfStyleObject(staticValues),
+            ...StyleUtils.getCSSVariablesContentFromTokenStyles(tokenValues),
+          } as Record<string, string | number>
+
+          if (styleRef.type === 'element-state') {
+            cssMap.push(
+              StyleBuilders.createCSSClassWithSelector(
+                name,
+                `&:${styleRef.meta.state}`,
+                collectedMediaStyles
+              )
+            )
+          }
+
+          if (styleRef.type === 'screen-size') {
+            mediaStylesMap[styleRef.meta.maxWidth] = {
+              ...mediaStylesMap[styleRef.meta.maxWidth],
+              [name]: collectedMediaStyles,
+            }
+          }
+        })
       })
-    })
+    }
 
     cssMap.push(...StyleBuilders.generateMediaStyle(mediaStylesMap))
 

--- a/packages/teleport-plugin-css-modules/src/style-sheet.ts
+++ b/packages/teleport-plugin-css-modules/src/style-sheet.ts
@@ -8,13 +8,18 @@ import {
 } from '@teleporthq/teleport-types'
 interface StyleSheetPlugin {
   fileName?: string
-  omitModuleextension?: boolean
+  moduleExtension?: boolean
+}
+
+const defaultConfig = {
+  fileName: 'style',
+  moduleExtension: false,
 }
 
 export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = (config) => {
-  const { fileName, omitModuleextension } = config || {
-    fileName: 'style',
-    omitModuleextension: false,
+  const { fileName, moduleExtension } = {
+    ...defaultConfig,
+    ...config,
   }
   const styleSheetPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks } = structure
@@ -91,9 +96,8 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
       return structure
     }
 
-    const sheeName = omitModuleextension ? fileName : `${fileName}.module`
     uidl.outputOptions = uidl.outputOptions || {}
-    uidl.outputOptions.styleFileName = sheeName
+    uidl.outputOptions.styleFileName = moduleExtension ? `${fileName}.module` : fileName
 
     chunks.push({
       name: fileName,

--- a/packages/teleport-plugin-css/__tests__/index.ts
+++ b/packages/teleport-plugin-css/__tests__/index.ts
@@ -5,7 +5,7 @@ import {
   ChunkType,
   FileType,
 } from '@teleporthq/teleport-types'
-import { createCSSPlugin } from '../src/index'
+import { createCSSPlugin } from '../src'
 
 describe('plugin-css', () => {
   describe('on html template based components', () => {

--- a/packages/teleport-plugin-css/src/index.ts
+++ b/packages/teleport-plugin-css/src/index.ts
@@ -39,9 +39,32 @@ export const createCSSPlugin: ComponentPluginFactory<CSSPluginConfig> = (config)
 
   const cssPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks, dependencies, options } = structure
-    const { projectStyleSet } = options
+    const {
+      projectStyleSet: {
+        styleSetDefinitions = {},
+        fileName: projectStyleSheetName,
+        path,
+        importFile = false,
+      },
+      designLanguage: { tokens = {} } = {},
+      isRootComponent,
+    } = options
 
     const { node } = uidl
+
+    if (isRootComponent) {
+      if (Object.keys(tokens).length > 0 && Object.keys(styleSetDefinitions).length === 0) {
+        dependencies[projectStyleSheetName] = {
+          type: 'local',
+          path: `${path}/${projectStyleSheetName}.${FileType.CSS}`,
+          meta: {
+            importJustPath: true,
+          },
+        }
+      }
+
+      return structure
+    }
 
     const templateChunk = chunks.find((chunk) => chunk.name === templateChunkName)
     const componentDecoratorChunk = chunks.find(
@@ -159,16 +182,10 @@ export const createCSSPlugin: ComponentPluginFactory<CSSPluginConfig> = (config)
               return
             }
             case 'project-referenced': {
-              if (!projectStyleSet) {
-                throw new Error(
-                  `Project Style Sheet is missing, but the node is referring to it ${element}`
-                )
-              }
-
               const { content } = styleRef
               if (content.referenceId && !content?.conditions) {
                 isProjectStyleReferred = true
-                const referedStyle = projectStyleSet.styleSetDefinitions[content.referenceId]
+                const referedStyle = styleSetDefinitions[content.referenceId]
                 if (!referedStyle) {
                   throw new Error(
                     `Style that is being used for reference is missing - ${content.referenceId}`
@@ -208,10 +225,10 @@ export const createCSSPlugin: ComponentPluginFactory<CSSPluginConfig> = (config)
       jssStylesArray.push(...StyleBuilders.generateMediaStyle(mediaStylesMap))
     }
 
-    if (isProjectStyleReferred && projectStyleSet?.importFile) {
-      dependencies[projectStyleSet.fileName] = {
+    if (isProjectStyleReferred && importFile) {
+      dependencies[projectStyleSheetName] = {
         type: 'local',
-        path: `${projectStyleSet.path}/${projectStyleSet.fileName}.${FileType.CSS}`,
+        path: `${path}/${projectStyleSheetName}.${FileType.CSS}`,
         meta: {
           importJustPath: true,
         },

--- a/packages/teleport-plugin-css/src/index.ts
+++ b/packages/teleport-plugin-css/src/index.ts
@@ -39,16 +39,9 @@ export const createCSSPlugin: ComponentPluginFactory<CSSPluginConfig> = (config)
 
   const cssPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks, dependencies, options } = structure
-    const {
-      projectStyleSet: {
-        styleSetDefinitions = {},
-        fileName: projectStyleSheetName,
-        path,
-        importFile = false,
-      },
-      designLanguage: { tokens = {} } = {},
-      isRootComponent,
-    } = options
+    const { projectStyleSet, designLanguage: { tokens = {} } = {}, isRootComponent } = options || {}
+    const { styleSetDefinitions = {}, fileName: projectStyleSheetName, path, importFile = false } =
+      projectStyleSet || {}
 
     const { node } = uidl
 

--- a/packages/teleport-plugin-css/src/style-sheet.ts
+++ b/packages/teleport-plugin-css/src/style-sheet.ts
@@ -17,8 +17,11 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
     const { uidl, chunks } = structure
     const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
 
-    if (!styleSetDefinitions && !tokens) {
-      return structure
+    if (
+      (!styleSetDefinitions && !tokens) ||
+      (Object.keys(styleSetDefinitions).length === 0 && Object.keys(tokens).length === 0)
+    ) {
+      return
     }
 
     const cssMap: string[] = []
@@ -34,46 +37,48 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
       )
     }
 
-    Object.values(styleSetDefinitions).forEach((style) => {
-      const { name, content, conditions = [] } = style
-      const { staticStyles, tokenStyles } = UIDLUtils.splitDynamicAndStaticStyles(content)
-      const collectedStyles = {
-        ...StyleUtils.getContentOfStyleObject(staticStyles),
-        ...StyleUtils.getCSSVariablesContentFromTokenStyles(tokenStyles),
-      } as Record<string, string | number>
-      cssMap.push(StyleBuilders.createCSSClass(name, collectedStyles))
-
-      if (conditions.length === 0) {
-        return
-      }
-      conditions.forEach((styleRef) => {
-        const {
-          staticStyles: staticValues,
-          tokenStyles: tokenValues,
-        } = UIDLUtils.splitDynamicAndStaticStyles(styleRef.content)
-        const collecedMediaStyles = {
-          ...StyleUtils.getContentOfStyleObject(staticValues),
-          ...StyleUtils.getCSSVariablesContentFromTokenStyles(tokenValues),
+    if (Object.keys(styleSetDefinitions).length > 0) {
+      Object.values(styleSetDefinitions).forEach((style) => {
+        const { name, content, conditions = [] } = style
+        const { staticStyles, tokenStyles } = UIDLUtils.splitDynamicAndStaticStyles(content)
+        const collectedStyles = {
+          ...StyleUtils.getContentOfStyleObject(staticStyles),
+          ...StyleUtils.getCSSVariablesContentFromTokenStyles(tokenStyles),
         } as Record<string, string | number>
+        cssMap.push(StyleBuilders.createCSSClass(name, collectedStyles))
 
-        if (styleRef.type === 'element-state') {
-          cssMap.push(
-            StyleBuilders.createCSSClassWithSelector(
-              name,
-              `&:${styleRef.meta.state}`,
-              collecedMediaStyles
+        if (conditions.length === 0) {
+          return
+        }
+        conditions.forEach((styleRef) => {
+          const {
+            staticStyles: staticValues,
+            tokenStyles: tokenValues,
+          } = UIDLUtils.splitDynamicAndStaticStyles(styleRef.content)
+          const collecedMediaStyles = {
+            ...StyleUtils.getContentOfStyleObject(staticValues),
+            ...StyleUtils.getCSSVariablesContentFromTokenStyles(tokenValues),
+          } as Record<string, string | number>
+
+          if (styleRef.type === 'element-state') {
+            cssMap.push(
+              StyleBuilders.createCSSClassWithSelector(
+                name,
+                `&:${styleRef.meta.state}`,
+                collecedMediaStyles
+              )
             )
-          )
-        }
-
-        if (styleRef.type === 'screen-size') {
-          mediaStylesMap[styleRef.meta.maxWidth] = {
-            ...mediaStylesMap[styleRef.meta.maxWidth],
-            [name]: collecedMediaStyles,
           }
-        }
+
+          if (styleRef.type === 'screen-size') {
+            mediaStylesMap[styleRef.meta.maxWidth] = {
+              ...mediaStylesMap[styleRef.meta.maxWidth],
+              [name]: collecedMediaStyles,
+            }
+          }
+        })
       })
-    })
+    }
 
     cssMap.push(...StyleBuilders.generateMediaStyle(mediaStylesMap))
 

--- a/packages/teleport-plugin-css/src/style-sheet.ts
+++ b/packages/teleport-plugin-css/src/style-sheet.ts
@@ -15,11 +15,10 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
   const { fileName } = config || { fileName: 'style' }
   const styleSheetPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks } = structure
-    const { styleSetDefinitions, designLanguage = {} } = uidl
-    const { tokens = {} } = designLanguage
+    const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
 
-    if (!styleSetDefinitions || Object.keys(styleSetDefinitions).length === 0) {
-      return
+    if (!styleSetDefinitions && !tokens) {
+      return structure
     }
 
     const cssMap: string[] = []
@@ -77,6 +76,10 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
     })
 
     cssMap.push(...StyleBuilders.generateMediaStyle(mediaStylesMap))
+
+    if (cssMap.length === 0) {
+      return structure
+    }
 
     uidl.outputOptions = uidl.outputOptions || {}
     uidl.outputOptions.styleFileName = fileName

--- a/packages/teleport-plugin-react-jss/__tests__/style-sheet.ts
+++ b/packages/teleport-plugin-react-jss/__tests__/style-sheet.ts
@@ -149,6 +149,7 @@ describe('Style Sheet from react-jss', () => {
 
     const result = await plugin(structure)
     const { chunks } = result
-    expect(chunks[2].name).toBe('index')
+    const styleChunk = chunks.find((chunk) => chunk.name === 'index')
+    expect(styleChunk).toBeDefined()
   })
 })

--- a/packages/teleport-plugin-react-jss/src/style-sheet.ts
+++ b/packages/teleport-plugin-react-jss/src/style-sheet.ts
@@ -19,8 +19,11 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
     const { uidl, chunks, dependencies } = structure
     const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
 
-    if (!styleSetDefinitions && !tokens) {
-      return
+    if (
+      (!styleSetDefinitions && !tokens) ||
+      (Object.keys(styleSetDefinitions).length === 0 && Object.keys(tokens).length === 0)
+    ) {
+      return structure
     }
 
     const tokensMap: Record<string, string | number> = Object.keys(tokens || {}).reduce(

--- a/packages/teleport-plugin-react-jss/src/style-sheet.ts
+++ b/packages/teleport-plugin-react-jss/src/style-sheet.ts
@@ -17,8 +17,7 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
   const { fileName } = config || { fileName: 'style' }
   const styleSheetPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks, dependencies } = structure
-    const { styleSetDefinitions = {}, designLanguage = {} } = uidl
-    const { tokens = {} } = designLanguage
+    const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
 
     if (!styleSetDefinitions && !tokens) {
       return
@@ -38,9 +37,8 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
     if (Object.keys(styleSetDefinitions).length > 0) {
       Object.values(styleSetDefinitions).forEach((style) => {
         const { conditions = [], content } = style
-        const { transformedStyles } = generatePropSyntax(content)
         let styles = {
-          ...transformedStyles,
+          ...generatePropSyntax(content),
         }
 
         if (conditions.length > 0) {
@@ -48,15 +46,13 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
             if (Object.keys(styleRef.content).length === 0) {
               return
             }
-            const { transformedStyles: transformedMediaStyles } = generatePropSyntax(
-              styleRef.content
-            )
-
             if (styleRef.type === 'screen-size') {
               styles = {
                 ...styles,
                 ...{
-                  [`@media(max-width: ${styleRef.meta.maxWidth}px)`]: transformedMediaStyles,
+                  [`@media(max-width: ${styleRef.meta.maxWidth}px)`]: generatePropSyntax(
+                    styleRef.content
+                  ),
                 },
               }
             }
@@ -65,10 +61,7 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
               styles = {
                 ...styles,
                 ...{
-                  [`&:${styleRef.meta.state}`]: transformedMediaStyles as Record<
-                    string,
-                    string | number
-                  >,
+                  [`&:${styleRef.meta.state}`]: generatePropSyntax(styleRef.content),
                 },
               }
             }
@@ -91,37 +84,41 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
       },
     }
 
-    chunks.push({
-      name: 'tokens-chunk',
-      type: ChunkType.AST,
-      fileType: FileType.JS,
-      content: t.exportNamedDeclaration(
-        t.variableDeclaration('const', [
-          t.variableDeclarator(
-            t.identifier('TOKENS'),
-            ASTUtils.objectToObjectExpression(tokensMap)
-          ),
-        ])
-      ),
-      linkAfter: ['import-local'],
-    })
+    if (Object.keys(tokens).length > 0) {
+      chunks.push({
+        name: 'tokens-chunk',
+        type: ChunkType.AST,
+        fileType: FileType.JS,
+        content: t.exportNamedDeclaration(
+          t.variableDeclaration('const', [
+            t.variableDeclarator(
+              t.identifier('TOKENS'),
+              ASTUtils.objectToObjectExpression(tokensMap)
+            ),
+          ])
+        ),
+        linkAfter: ['import-local'],
+      })
+    }
 
-    chunks.push({
-      name: fileName,
-      type: ChunkType.AST,
-      fileType: FileType.JS,
-      content: t.exportNamedDeclaration(
-        t.variableDeclaration('const', [
-          t.variableDeclarator(
-            t.identifier('useProjectStyles'),
-            t.callExpression(t.identifier('createUseStyles'), [
-              ASTUtils.objectToObjectExpression(styleSet),
-            ])
-          ),
-        ])
-      ),
-      linkAfter: ['tokens-chunk'],
-    })
+    if (Object.keys(styleSet).length > 0) {
+      chunks.push({
+        name: fileName,
+        type: ChunkType.AST,
+        fileType: FileType.JS,
+        content: t.exportNamedDeclaration(
+          t.variableDeclaration('const', [
+            t.variableDeclarator(
+              t.identifier('useProjectStyles'),
+              t.callExpression(t.identifier('createUseStyles'), [
+                ASTUtils.objectToObjectExpression(styleSet),
+              ])
+            ),
+          ])
+        ),
+        linkAfter: ['tokens-chunk'],
+      })
+    }
 
     return structure
   }

--- a/packages/teleport-plugin-react-jss/src/utils.ts
+++ b/packages/teleport-plugin-react-jss/src/utils.ts
@@ -3,36 +3,28 @@ import { StringUtils, UIDLUtils } from '@teleporthq/teleport-shared'
 import { ParsedASTNode, ASTBuilders } from '@teleporthq/teleport-plugin-common'
 import { UIDLStyleValue } from '@teleporthq/teleport-types'
 
-export const generatePropSyntax = (style: Record<string, UIDLStyleValue>) => {
-  let tokensUsed = false
-  let propsUsed = false
-  return {
-    transformedStyles: UIDLUtils.transformDynamicStyles(style, (styleValue) => {
-      switch (styleValue.content.referenceType) {
-        case 'prop':
-          propsUsed = true
-          return new ParsedASTNode(
-            ASTBuilders.createArrowFunctionWithMemberExpression('props', styleValue.content.id)
-          )
-        case 'token':
-          tokensUsed = true
-          return new ParsedASTNode(
-            t.memberExpression(
-              t.identifier('TOKENS'),
-              t.identifier(
-                StringUtils.capitalize(StringUtils.dashCaseToCamelCase(styleValue.content.id))
-              )
-            )
-          )
-        default:
-          throw new Error(
-            `Error running transformDynamicStyles in reactJSSComponentStyleChunksPlugin. Unsupported styleValue.content.referenceType value ${styleValue.content.referenceType}`
-          )
-      }
-    }),
-    tokensUsed,
-    propsUsed,
-  }
+export const generatePropSyntax = (
+  style: Record<string, UIDLStyleValue>,
+  tokensUsed?: string[],
+  propsUsed?: string[]
+) => {
+  return UIDLUtils.transformDynamicStyles(style, (styleValue) => {
+    switch (styleValue.content.referenceType) {
+      case 'prop':
+        propsUsed?.push(styleValue.content.id)
+        return new ParsedASTNode(
+          ASTBuilders.createArrowFunctionWithMemberExpression('props', styleValue.content.id)
+        )
+      case 'token':
+        const token = StringUtils.capitalize(StringUtils.dashCaseToCamelCase(styleValue.content.id))
+        tokensUsed?.push(token)
+        return new ParsedASTNode(t.memberExpression(t.identifier('TOKENS'), t.identifier(token)))
+      default:
+        throw new Error(
+          `Error running transformDynamicStyles in reactJSSComponentStyleChunksPlugin. Unsupported styleValue.content.referenceType value ${styleValue.content.referenceType}`
+        )
+    }
+  })
 }
 
 export const createStylesHookDecleration = (

--- a/packages/teleport-plugin-react-styled-components/src/style-sheet.ts
+++ b/packages/teleport-plugin-react-styled-components/src/style-sheet.ts
@@ -21,8 +21,11 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
     const { uidl, chunks, dependencies } = structure
     const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
 
-    if (!styleSetDefinitions && !tokens) {
-      return
+    if (
+      (!styleSetDefinitions && !tokens) ||
+      (Object.keys(styleSetDefinitions).length === 0 && Object.keys(tokens).length === 0)
+    ) {
+      return structure
     }
 
     const tokensMap: Record<string, string | number> = Object.keys(tokens || {}).reduce(

--- a/packages/teleport-plugin-react-styled-components/src/style-sheet.ts
+++ b/packages/teleport-plugin-react-styled-components/src/style-sheet.ts
@@ -19,8 +19,7 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
 
   const styleSheetPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks, dependencies } = structure
-    const { styleSetDefinitions, designLanguage = {} } = uidl
-    const { tokens = {} } = designLanguage
+    const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
 
     if (!styleSetDefinitions && !tokens) {
       return
@@ -41,10 +40,9 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
 
       const className = StringUtils.dashCaseToUpperCamelCase(name)
       let styles = {}
-      const { transformedStyles } = generatePropReferencesSyntax(content, 0)
       styles = {
         ...styles,
-        ...transformedStyles,
+        ...generatePropReferencesSyntax(content),
       }
 
       if (conditions.length > 0) {
@@ -52,16 +50,14 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
           if (Object.keys(styleRef.content).length === 0) {
             return
           }
-          const { transformedStyles: transformedMediaStyles } = generatePropReferencesSyntax(
-            styleRef.content,
-            0
-          )
 
           if (styleRef.type === 'screen-size') {
             styles = {
               ...styles,
               ...{
-                [`@media(max-width: ${styleRef.meta.maxWidth}px)`]: transformedMediaStyles,
+                [`@media(max-width: ${styleRef.meta.maxWidth}px)`]: generatePropReferencesSyntax(
+                  styleRef.content
+                ),
               },
             }
           }
@@ -70,15 +66,12 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
             styles = {
               ...styles,
               ...{
-                [`&:${styleRef.meta.state}`]: transformedMediaStyles,
+                [`&:${styleRef.meta.state}`]: generatePropReferencesSyntax(styleRef.content),
               },
             }
           }
         })
       }
-
-      uidl.outputOptions = uidl.outputOptions || {}
-      uidl.outputOptions.fileName = fileName
 
       chunks.push({
         name: fileName,
@@ -87,31 +80,36 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
         content: generateExportablCSSInterpolate(className, styles),
         linkAfter: ['tokens-chunk'],
       })
+
+      dependencies.css = {
+        type: 'package',
+        path: componentLibrary === 'react' ? 'styled-components' : 'styled-components/native',
+        version: '4.2.0',
+        meta: {
+          namedImport: true,
+        },
+      }
     })
 
-    chunks.push({
-      name: 'tokens-chunk',
-      type: ChunkType.AST,
-      fileType: FileType.JS,
-      content: t.exportNamedDeclaration(
-        t.variableDeclaration('const', [
-          t.variableDeclarator(
-            t.identifier('TOKENS'),
-            ASTUtils.objectToObjectExpression(tokensMap)
-          ),
-        ])
-      ),
-      linkAfter: ['import-local'],
-    })
-
-    dependencies.css = {
-      type: 'package',
-      path: componentLibrary === 'react' ? 'styled-components' : 'styled-components/native',
-      version: '4.2.0',
-      meta: {
-        namedImport: true,
-      },
+    if (Object.keys(tokensMap).length > 0) {
+      chunks.push({
+        name: 'tokens-chunk',
+        type: ChunkType.AST,
+        fileType: FileType.JS,
+        content: t.exportNamedDeclaration(
+          t.variableDeclaration('const', [
+            t.variableDeclarator(
+              t.identifier('TOKENS'),
+              ASTUtils.objectToObjectExpression(tokensMap)
+            ),
+          ])
+        ),
+        linkAfter: ['import-local'],
+      })
     }
+
+    uidl.outputOptions = uidl.outputOptions || {}
+    uidl.outputOptions.fileName = fileName
 
     return structure
   }

--- a/packages/teleport-plugin-react-styled-components/src/utils.ts
+++ b/packages/teleport-plugin-react-styled-components/src/utils.ts
@@ -103,16 +103,16 @@ export const removeUnusedDependencies = (
 
 export const generatePropReferencesSyntax = (
   style: Record<string, UIDLStyleValue>,
-  timesReferred: number,
+  timesPropsReferred?: number,
+  tokensReferred?: string[],
   root?: t.JSXElement,
   propsPrefix?: unknown
 ) => {
-  let tokensUsed = false
-  const transformedStyles = UIDLUtils.transformDynamicStyles(style, (styleValue, attribute) => {
+  return UIDLUtils.transformDynamicStyles(style, (styleValue, attribute) => {
     switch (styleValue.content.referenceType) {
       case 'prop': {
         const dashCaseAttribute = StringUtils.dashCaseToCamelCase(attribute)
-        if (timesReferred === 1 && root && propsPrefix) {
+        if (timesPropsReferred && timesPropsReferred === 1 && root && propsPrefix) {
           ASTUtils.addDynamicAttributeToJSXTag(
             root,
             dashCaseAttribute,
@@ -124,10 +124,9 @@ export const generatePropReferencesSyntax = (
         return `\$\{props => props.${styleValue.content.id}\}`
       }
       case 'token':
-        tokensUsed = true
-        return `\$\{TOKENS.${StringUtils.capitalize(
-          StringUtils.dashCaseToCamelCase(styleValue.content.id)
-        )}\}`
+        const token = StringUtils.capitalize(StringUtils.dashCaseToCamelCase(styleValue.content.id))
+        tokensReferred?.push(token)
+        return `\$\{TOKENS.${token}\}`
       default:
         throw new Error(
           `Error running transformDynamicStyles in reactStyledComponentsPlugin. 
@@ -135,9 +134,4 @@ export const generatePropReferencesSyntax = (
         )
     }
   })
-
-  return {
-    transformedStyles,
-    tokensUsed,
-  }
 }

--- a/packages/teleport-project-generator-angular/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-angular/__tests__/end2end/index.ts
@@ -1,8 +1,9 @@
+import { FileType } from '@teleporthq/teleport-types'
 import uidlSample from '../../../../examples/test-samples/project-sample-with-dependency.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
-import template from './template-definition.json'
+import uidlSampleWithJustTokens from '../../../../examples/test-samples/project-with-only-tokens.json'
 import { createAngularProjectGenerator } from '../../src'
-import { FileType } from '@teleporthq/teleport-types'
+import template from './template-definition.json'
 
 describe('Angular Project Generator', () => {
   const generator = createAngularProjectGenerator()
@@ -63,6 +64,16 @@ import { ModalWindow } from './modal-window/modal-window.component'`)
     expect(pagesFolder.subFolders[0].files[1].content).not.toContain(`import Modal`)
     expect(modalComponent.files[1].content).not.toContain(`import Modal`)
     expect(packageJSON.content).toContain(`"antd": "4.5.4"`)
+  })
+
+  it('creates style sheet and adds to the webpack file', async () => {
+    const result = await generator.generateProject(uidlSampleWithJustTokens, template)
+    const styleSheet = result.subFolders[0].files.find(
+      (file) => file.name === 'style' && file.fileType === FileType.CSS
+    )
+
+    expect(styleSheet).toBeDefined()
+    expect(styleSheet.content).toContain(`--greys-500: #595959`)
   })
 
   it('throws error when invalid UIDL sample is used', async () => {

--- a/packages/teleport-project-generator-angular/src/index.ts
+++ b/packages/teleport-project-generator-angular/src/index.ts
@@ -44,11 +44,7 @@ const createAngularProjectGenerator = () => {
   htmlFileGenerator.addPostProcessor(createPrettierHTMLPostProcessor())
 
   const styleSheetGenerator = createComponentGenerator()
-  styleSheetGenerator.addPlugin(
-    createStyleSheetPlugin({
-      fileName: 'styles',
-    })
-  )
+  styleSheetGenerator.addPlugin(createStyleSheetPlugin())
 
   const generator = createProjectGenerator({
     components: {

--- a/packages/teleport-project-generator-gatsby/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-gatsby/__tests__/end2end/index.ts
@@ -1,9 +1,10 @@
+import { FileType, ReactStyleVariation } from '@teleporthq/teleport-types'
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
 import uidlSampleWithExternalDependencies from '../../../../examples/test-samples/project-sample-with-dependency.json'
+import uidlSampleWithJustTokens from '../../../../examples/test-samples/project-with-only-tokens.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
 import template from './mocks'
 import { createGatsbyProjectGenerator } from '../../src'
-import { FileType, ReactStyleVariation } from '@teleporthq/teleport-types'
 
 describe('Gatsby Project Generator', () => {
   const generator = createGatsbyProjectGenerator()
@@ -58,6 +59,17 @@ describe('Gatsby Project Generator', () => {
     expect(pagesFolder.files[0].content).toContain(`import 'antd/dist/antd.css'`)
   })
 
+  it('runs without crashing and using only tokens', async () => {
+    const result = await generator.generateProject(uidlSampleWithJustTokens, template)
+    const srcFolder = result.subFolders.find((folder) => folder.name === 'src')
+    const styleSheet = srcFolder.files.find(
+      (file) => file.name === 'style.module' && file.fileType === FileType.CSS
+    )
+
+    expect(styleSheet).toBeDefined()
+    expect(styleSheet.content).toContain(`--greys-500: #595959`)
+  })
+
   it('throws error when invalid UIDL sample is used', async () => {
     const result = generator.generateProject(invalidUidlSample, template)
 
@@ -99,6 +111,17 @@ describe('Gatsby Project Generator with Styled Components', () => {
     expect(pagesFolder.files.length).toBeGreaterThan(0)
     expect(componentsFolder.files.length).toBeGreaterThan(0)
     expect(componentsFolder.name).toBe('components')
+  })
+
+  it('runs without crashing and using only tokens', async () => {
+    const result = await generator.generateProject(uidlSampleWithJustTokens, template)
+    const srcFolder = result.subFolders.find((folder) => folder.name === 'src')
+    const styleSheet = srcFolder.files.find(
+      (file) => file.name === 'style' && file.fileType === FileType.JS
+    )
+
+    expect(styleSheet).toBeDefined()
+    expect(styleSheet.content).toContain(`Greys700: '#999999'`)
   })
 
   it('throws error when invalid UIDL sample is used', async () => {

--- a/packages/teleport-project-generator-gatsby/src/index.ts
+++ b/packages/teleport-project-generator-gatsby/src/index.ts
@@ -90,6 +90,7 @@ const createGatsbyProjectGenerator = (config?: GatsbyProjectConfig) => {
       generator: styleSheetGenerator,
       fileName: 'style',
       path: ['src'],
+      importFile: true,
     },
   }
 

--- a/packages/teleport-project-generator-gatsby/src/index.ts
+++ b/packages/teleport-project-generator-gatsby/src/index.ts
@@ -43,10 +43,7 @@ interface GatsbyProjectConfig {
 }
 
 const createGatsbyProjectGenerator = (config?: GatsbyProjectConfig) => {
-  const variation =
-    config?.variation === ReactStyleVariation.CSSModules
-      ? ReactStyleVariation.CSSModules
-      : ReactStyleVariation.StyledComponents
+  const variation = config?.variation || ReactStyleVariation.CSSModules
   const reactComponentGenerator = createCustomReactComponentGenerator(variation)
   const reactPagesGenerator = createCustomReactComponentGenerator(variation, [headConfigPlugin])
 
@@ -68,7 +65,7 @@ const createGatsbyProjectGenerator = (config?: GatsbyProjectConfig) => {
     styleSheetGenerator.addPlugin(importStatementsPlugin)
     styleSheetGenerator.addPostProcessor(prettierJS)
   } else {
-    styleSheetGenerator.addPlugin(createStyleSheetPlugin())
+    styleSheetGenerator.addPlugin(createStyleSheetPlugin({ moduleExtension: true }))
   }
 
   const strategy: ProjectStrategy = {

--- a/packages/teleport-project-generator-gatsby/src/utils.ts
+++ b/packages/teleport-project-generator-gatsby/src/utils.ts
@@ -6,6 +6,7 @@ import {
   FileType,
   ChunkType,
   GeneratedFolder,
+  FrameWorkConfigOptions,
 } from '@teleporthq/teleport-types'
 import { UIDLUtils } from '@teleporthq/teleport-shared'
 import { ASTBuilders, ASTUtils } from '@teleporthq/teleport-plugin-common'
@@ -247,4 +248,32 @@ export const appendToConfigFile = (
     file: configFile,
     dependencies: { ...dependencies, ...STYLED_DEPENDENCIES },
   }
+}
+
+export const styleSheetDependentConfigGenerator = (options: FrameWorkConfigOptions, t = types) => {
+  const chunks: ChunkDefinition[] = []
+  const result = {
+    chunks: {},
+    dependencies: options.dependencies,
+  }
+
+  const {
+    globalStyles: { path, sheetName, isGlobalStylesDependent },
+  } = options
+
+  if (isGlobalStylesDependent) {
+    chunks.push({
+      type: ChunkType.AST,
+      name: 'import-js-chunk',
+      fileType: FileType.JS,
+      content: t.importDeclaration([], t.stringLiteral(`./${path}/${sheetName}.module.css`)),
+      linkAfter: [],
+    })
+  }
+
+  result.chunks = {
+    [FileType.JS]: chunks,
+  }
+
+  return result
 }

--- a/packages/teleport-project-generator-gatsby/src/utils.ts
+++ b/packages/teleport-project-generator-gatsby/src/utils.ts
@@ -17,9 +17,6 @@ export const createCustomHTMLEntryFile = (
   options: EntryFileOptions,
   t = types
 ) => {
-  const reactImport = createImportAST('React', 'react')
-  const propTypesImport = createImportAST('PropTypes', 'prop-types')
-
   const exportBody = t.exportDefaultDeclaration(
     t.functionDeclaration(
       t.identifier('HTML'),
@@ -34,7 +31,7 @@ export const createCustomHTMLEntryFile = (
         name: 'import-chunks',
         type: ChunkType.AST,
         fileType: FileType.JS,
-        content: [reactImport, propTypesImport],
+        content: [createImportAST('React', 'react'), createImportAST('PropTypes', 'prop-types')],
         linkAfter: [],
       },
       {

--- a/packages/teleport-project-generator-next/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-next/__tests__/end2end/index.ts
@@ -1,7 +1,9 @@
+import { FileType } from '@teleporthq/teleport-types'
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
 import uidlSampleWithoutProjectStyleesButImports from './project-with-import-without-global-styles.json'
 import uidlSampleWithProjectStyleSheet from '../../../../examples/test-samples/project-with-import-global-styles.json'
+import uidlSampleWithJustTokens from '../../../../examples/test-samples/project-with-only-tokens.json'
 import template from './template-definition.json'
 import { createNextProjectGenerator } from '../../src'
 
@@ -56,6 +58,24 @@ describe('React Next Project Generator', () => {
     expect(pages.files[0].name).toBe('index')
     expect(pages.files[1].name).toBe('about')
   })
+
+  it('runs without crashing and adds import of style sheet in _app.js', async () => {
+    const result = await generator.generateProject(uidlSampleWithJustTokens, template)
+
+    const pagesFolder = result.subFolders.find((folder) => folder.name === 'pages')
+    const styleSheet = pagesFolder.files.find(
+      (file) => file.name === 'style' && file.fileType === FileType.CSS
+    )
+    const appFile = pagesFolder.files.find(
+      (file) => file.name === '_app' && file.fileType === FileType.JS
+    )
+
+    expect(styleSheet).toBeDefined()
+    expect(styleSheet.content).toContain(`--greys-500: #595959`)
+    expect(appFile).toBeDefined()
+    expect(appFile.content).toContain(`import './style.css'`)
+  })
+
   it('throws error when invalid UIDL sample is used', async () => {
     const result = generator.generateProject(invalidUidlSample, template)
 

--- a/packages/teleport-project-generator-next/src/index.ts
+++ b/packages/teleport-project-generator-next/src/index.ts
@@ -1,7 +1,6 @@
 import { createProjectGenerator } from '@teleporthq/teleport-project-generator'
 import { createComponentGenerator } from '@teleporthq/teleport-component-generator'
 import { createReactComponentGenerator } from '@teleporthq/teleport-component-generator-react'
-
 import { createJSXHeadConfigPlugin } from '@teleporthq/teleport-plugin-jsx-head-config'
 import prettierJS from '@teleporthq/teleport-postprocessor-prettier-js'
 import { Mapping, ReactStyleVariation, FileType } from '@teleporthq/teleport-types'
@@ -31,11 +30,7 @@ const createNextProjectGenerator = () => {
   documentFileGenerator.addPostProcessor(prettierJS)
 
   const styleSheetGenerator = createComponentGenerator()
-  styleSheetGenerator.addPlugin(
-    createStyleSheetPlugin({
-      fileName: 'style',
-    })
-  )
+  styleSheetGenerator.addPlugin(createStyleSheetPlugin())
 
   const configGenerator = createComponentGenerator()
   configGenerator.addPlugin(importStatementsPlugin)

--- a/packages/teleport-project-generator-next/src/utils.ts
+++ b/packages/teleport-project-generator-next/src/utils.ts
@@ -117,7 +117,6 @@ const createDocumentWrapperAST = (htmlNode: types.JSXElement, t = types) => {
 }
 
 export const configContentGenerator = (options: FrameWorkConfigOptions, t = types) => {
-  const path = options.globalStyles?.path === '' ? '.' : options.globalStyles.path
   const chunks: ChunkDefinition[] = []
   const result = {
     chunks: {},
@@ -166,7 +165,7 @@ export const configContentGenerator = (options: FrameWorkConfigOptions, t = type
       fileType: FileType.JS,
       content: t.importDeclaration(
         [],
-        t.stringLiteral(`${path}/${options.globalStyles.sheetName}.css`)
+        t.stringLiteral(`${options.globalStyles.path}/${options.globalStyles.sheetName}.css`)
       ),
       linkAfter: [],
     })

--- a/packages/teleport-project-generator-preact/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-preact/__tests__/end2end/index.ts
@@ -1,6 +1,8 @@
+import { FileType } from '@teleporthq/teleport-types'
 import uidlSampleWithDependencies from '../../../../examples/test-samples/project-sample-with-dependency.json'
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
+import uidlSampleWithJustTokens from '../../../../examples/test-samples/project-with-only-tokens.json'
 import template from './template-definition.json'
 import { createPreactProjectGenerator } from '../../src'
 
@@ -58,6 +60,9 @@ describe('Preact Project Generator', () => {
     expect(componentFiles.length).toBe(6)
     expect(componentFiles[componentFiles.length - 1].fileType).toBe('js')
     expect(componentFiles[componentFiles.length - 1].name).toBe('app')
+    expect(componentFiles[componentFiles.length - 1].content).not.toContain(
+      `import '../routes/style.css'`
+    )
     expect(modalComponent.content).toContain(
       `<Button type="primary" onClick={() => setIsOpen(true)}>
         Show Popup
@@ -68,6 +73,25 @@ describe('Preact Project Generator', () => {
     expect(componentFiles[componentFiles.length - 1].content).toContain(
       `import 'antd/dist/antd.css'`
     )
+  })
+
+  it('runs without crashing and using only tokens', async () => {
+    const result = await generator.generateProject(uidlSampleWithJustTokens, template)
+    const routes = result.subFolders[0].subFolders.find((folder) => folder.name === 'routes')
+    const styleSheet = routes.files.find(
+      (file) => file.name === 'style' && file.fileType === FileType.CSS
+    )
+    const components = result.subFolders[0].subFolders.find(
+      (folder) => folder.name === 'components'
+    )
+    const index = components.files.find(
+      (file) => file.name === 'app' && file.fileType === FileType.JS
+    )
+
+    expect(styleSheet).toBeDefined()
+    expect(styleSheet.content).toContain(`--greys-500: #595959`)
+    expect(index).toBeDefined()
+    expect(index.content).toContain(`import '../routes/style.css'`)
   })
 
   it('throws error when invalid UIDL sample is used', async () => {

--- a/packages/teleport-project-generator-preact/src/index.ts
+++ b/packages/teleport-project-generator-preact/src/index.ts
@@ -1,13 +1,15 @@
 import { createProjectGenerator } from '@teleporthq/teleport-project-generator'
 import { createPreactComponentGenerator } from '@teleporthq/teleport-component-generator-preact'
 import { createComponentGenerator } from '@teleporthq/teleport-component-generator'
-
 import { createReactAppRoutingPlugin } from '@teleporthq/teleport-plugin-react-app-routing'
 import headConfigPlugin from '@teleporthq/teleport-plugin-jsx-head-config'
 import importStatementsPlugin from '@teleporthq/teleport-plugin-import-statements'
 import prettierJS from '@teleporthq/teleport-postprocessor-prettier-js'
 import { Mapping, PreactStyleVariation } from '@teleporthq/teleport-types'
-import { createStyleSheetPlugin } from '@teleporthq/teleport-plugin-css-modules'
+import {
+  createStyleSheetPlugin,
+  createCSSModulesPlugin,
+} from '@teleporthq/teleport-plugin-css-modules'
 
 import PreactTemplate from './project-template'
 import PreactCodesandBoxTemplate from './project-template-codesandbox'
@@ -35,6 +37,7 @@ const createPreactProjectGenerator = () => {
   const routerPlugin = createReactAppRoutingPlugin({ flavor: 'preact' })
   const routingComponentGenerator = createComponentGenerator()
   routingComponentGenerator.addPlugin(routerPlugin)
+  routingComponentGenerator.addPlugin(createCSSModulesPlugin())
   routingComponentGenerator.addPlugin(importStatementsPlugin)
   routingComponentGenerator.addPostProcessor(prettierJS)
 
@@ -56,6 +59,12 @@ const createPreactProjectGenerator = () => {
       generator: routingComponentGenerator,
       path: ['src', 'components'],
       fileName: 'app',
+    },
+    projectStyleSheet: {
+      generator: styleSheetGenerator,
+      fileName: 'style',
+      path: ['src', 'routes'],
+      importFile: true,
     },
     entry: {
       generator: htmlFileGenerator,
@@ -80,11 +89,6 @@ const createPreactProjectGenerator = () => {
           },
         ],
       },
-    },
-    projectStyleSheet: {
-      generator: styleSheetGenerator,
-      fileName: 'style',
-      path: ['src', 'routes'],
     },
     static: {
       prefix: '/assets',

--- a/packages/teleport-project-generator-preact/src/index.ts
+++ b/packages/teleport-project-generator-preact/src/index.ts
@@ -30,7 +30,6 @@ const createPreactProjectGenerator = () => {
   styleSheetGenerator.addPlugin(
     createStyleSheetPlugin({
       fileName: 'style',
-      omitModuleextension: true,
     })
   )
 

--- a/packages/teleport-project-generator-react/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-react/__tests__/end2end/index.ts
@@ -1,5 +1,7 @@
+import { FileType } from '@teleporthq/teleport-types'
 import uidlSampleWithExternalDependencies from '../../../../examples/test-samples/project-sample-with-dependency.json'
 import uidlSample from '../../../../examples/test-samples/project-sample.json'
+import uidlSampleWithJustTokens from '../../../../examples/test-samples/project-with-only-tokens.json'
 import invalidUidlSample from '../../../../examples/test-samples/project-invalid-sample.json'
 import template from './template-definition.json'
 import { createReactProjectGenerator } from '../../src'
@@ -49,6 +51,7 @@ describe('React Project Generator', () => {
     expect(packageJSON.name).toBe('package')
     expect(srcFolder.files[0].name).toBe('index')
     expect(srcFolder.files[0].fileType).toBe('js')
+    expect(srcFolder.files[0].content).not.toContain(`import './style.module.css'`)
     expect(publicFolder.files[0].name).toBe('manifest')
     expect(publicFolder.files[0].fileType).toBe('json')
     expect(publicFolder.files[1].name).toBe('index')
@@ -85,6 +88,22 @@ describe('React Project Generator', () => {
     expect(viewsFolder.files[0].content).toContain(`Page 1<Modal></Modal>`)
     /* Imports that are just need to be inserted are added to router file by default */
     expect(srcFolder.files[0].content).toContain(`import 'antd/dist/antd.css'`)
+  })
+
+  it('runs without crashing and using only tokens', async () => {
+    const result = await generator.generateProject(uidlSampleWithJustTokens, template)
+    const srcFolder = result.subFolders.find((folder) => folder.name === 'src')
+    const styleSheet = srcFolder.files.find(
+      (file) => file.name === 'style.module' && file.fileType === FileType.CSS
+    )
+    const index = srcFolder.files.find(
+      (file) => file.name === 'index' && file.fileType === FileType.JS
+    )
+
+    expect(styleSheet).toBeDefined()
+    expect(styleSheet.content).toContain(`--greys-500: #595959`)
+    expect(index).toBeDefined()
+    expect(index.content).toContain(`import './style.module.css'`)
   })
 
   it('throws error when invalid UIDL sample is used', async () => {

--- a/packages/teleport-project-generator-react/src/index.ts
+++ b/packages/teleport-project-generator-react/src/index.ts
@@ -31,7 +31,7 @@ const createReactProjectGenerator = () => {
   routingComponentGenerator.addPostProcessor(prettierJS)
 
   const styleSheetGenerator = createComponentGenerator()
-  styleSheetGenerator.addPlugin(createStyleSheetPlugin())
+  styleSheetGenerator.addPlugin(createStyleSheetPlugin({ moduleExtension: true }))
 
   const htmlFileGenerator = createComponentGenerator()
   htmlFileGenerator.addPostProcessor(prettierHTML)

--- a/packages/teleport-project-generator-react/src/index.ts
+++ b/packages/teleport-project-generator-react/src/index.ts
@@ -1,15 +1,16 @@
 import { createProjectGenerator } from '@teleporthq/teleport-project-generator'
 import { createReactComponentGenerator } from '@teleporthq/teleport-component-generator-react'
 import { createComponentGenerator } from '@teleporthq/teleport-component-generator'
-
 import reactAppRoutingPlugin from '@teleporthq/teleport-plugin-react-app-routing'
 import importStatementsPlugin from '@teleporthq/teleport-plugin-import-statements'
 import headConfigPlugin from '@teleporthq/teleport-plugin-jsx-head-config'
 import prettierJS from '@teleporthq/teleport-postprocessor-prettier-js'
 import prettierHTML from '@teleporthq/teleport-postprocessor-prettier-html'
 import { Mapping, ReactStyleVariation } from '@teleporthq/teleport-types'
-
-import { createStyleSheetPlugin } from '@teleporthq/teleport-plugin-css-modules'
+import {
+  createStyleSheetPlugin,
+  createCSSModulesPlugin,
+} from '@teleporthq/teleport-plugin-css-modules'
 
 import ReactProjectMapping from './react-project-mapping.json'
 import ReactTemplate from './project-template'
@@ -25,6 +26,7 @@ const createReactProjectGenerator = () => {
 
   const routingComponentGenerator = createComponentGenerator()
   routingComponentGenerator.addPlugin(reactAppRoutingPlugin)
+  routingComponentGenerator.addPlugin(createCSSModulesPlugin({ moduleExtension: true }))
   routingComponentGenerator.addPlugin(importStatementsPlugin)
   routingComponentGenerator.addPostProcessor(prettierJS)
 
@@ -47,6 +49,7 @@ const createReactProjectGenerator = () => {
       generator: styleSheetGenerator,
       fileName: 'style',
       path: ['src'],
+      importFile: true,
     },
     router: {
       generator: routingComponentGenerator,

--- a/packages/teleport-project-generator-vue/src/index.ts
+++ b/packages/teleport-project-generator-vue/src/index.ts
@@ -1,16 +1,13 @@
 import { createProjectGenerator } from '@teleporthq/teleport-project-generator'
 import { createVueComponentGenerator } from '@teleporthq/teleport-component-generator-vue'
 import { createComponentGenerator } from '@teleporthq/teleport-component-generator'
-
 import vueRoutingPlugin from '@teleporthq/teleport-plugin-vue-app-routing'
 import { createVueHeadConfigPlugin } from '@teleporthq/teleport-plugin-vue-head-config'
 import importStatementsPlugin from '@teleporthq/teleport-plugin-import-statements'
 import prettierHTML from '@teleporthq/teleport-postprocessor-prettier-html'
 import prettierJS from '@teleporthq/teleport-postprocessor-prettier-js'
-
 import { Mapping } from '@teleporthq/teleport-types'
-
-import { createStyleSheetPlugin } from '@teleporthq/teleport-plugin-css'
+import pluginCSS, { createStyleSheetPlugin } from '@teleporthq/teleport-plugin-css'
 
 import VueTemplate from './project-template'
 import VueProjectMapping from './vue-project-mapping.json'
@@ -27,6 +24,7 @@ const createVueProjectGenerator = () => {
 
   const vueRouterGenerator = createComponentGenerator()
   vueRouterGenerator.addPlugin(vueRoutingPlugin)
+  vueRouterGenerator.addPlugin(pluginCSS)
   vueRouterGenerator.addPlugin(importStatementsPlugin)
   vueRouterGenerator.addPostProcessor(prettierJS)
 
@@ -34,11 +32,7 @@ const createVueProjectGenerator = () => {
   htmlFileGenerator.addPostProcessor(prettierHTML)
 
   const styleSheetGenerator = createComponentGenerator()
-  styleSheetGenerator.addPlugin(
-    createStyleSheetPlugin({
-      fileName: 'index',
-    })
-  )
+  styleSheetGenerator.addPlugin(createStyleSheetPlugin())
 
   const generator = createProjectGenerator({
     components: {
@@ -51,7 +45,7 @@ const createVueProjectGenerator = () => {
     },
     projectStyleSheet: {
       generator: styleSheetGenerator,
-      fileName: 'index',
+      fileName: 'style',
       path: ['src'],
       importFile: true,
     },

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -77,32 +77,35 @@ export const createRouterFile = async (root: ComponentUIDL, strategy: ProjectStr
     strategy.pages.path
   )
 
-  const relativePathForProjectStyleSheet =
-    PathResolver.relative(
-      /* When each page is created inside a another folder then we just need to 
-          add one more element to the path resolver to maintian the hierarcy */
-      strategy.router.path.join('/'),
-      strategy.projectStyleSheet.path.join('/')
-    ) || '.'
-
-  const options: GeneratorOptions = {
+  let options: GeneratorOptions = {
     localDependenciesPrefix: routerLocalDependenciesPrefix,
     strategy,
     isRootComponent: true,
-    projectStyleSet: {
-      styleSetDefinitions: root?.styleSetDefinitions,
-      fileName: projectStyleSheet.fileName,
-      path: relativePathForProjectStyleSheet,
-      importFile: projectStyleSheet?.importFile || false,
-    },
     designLanguage: root?.designLanguage,
   }
 
+  if (projectStyleSheet) {
+    const relativePathForProjectStyleSheet =
+      PathResolver.relative(
+        /* When each page is created inside a another folder then we just need to 
+          add one more element to the path resolver to maintian the hierarcy */
+        strategy.router.path.join('/'),
+        strategy.projectStyleSheet.path.join('/')
+      ) || '.'
+    options = {
+      ...options,
+      projectStyleSet: {
+        styleSetDefinitions: root?.styleSetDefinitions,
+        fileName: projectStyleSheet.fileName,
+        path: relativePathForProjectStyleSheet,
+        importFile: projectStyleSheet?.importFile || false,
+      },
+    }
+  }
   root.outputOptions = root.outputOptions || {}
   root.outputOptions.fileName = fileName || DEFAULT_ROUTER_FILE_NAME
 
   const { files, dependencies } = await routerGenerator.generateComponent(root, options)
-
   return { routerFile: files[0], dependencies }
 }
 

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -1,6 +1,5 @@
 import { UIDLUtils, StringUtils } from '@teleporthq/teleport-shared'
 import { HASTUtils, HASTBuilders } from '@teleporthq/teleport-plugin-common'
-
 import {
   GeneratedFile,
   GeneratedFolder,
@@ -16,7 +15,7 @@ import {
   FileType,
   ChunkType,
 } from '@teleporthq/teleport-types'
-
+import PathResolver from 'path'
 import { DEFAULT_PACKAGE_JSON, DEFAULT_ROUTER_FILE_NAME } from './constants'
 import { PackageJSON } from './types'
 import { generateLocalDependenciesPrefix } from './utils'
@@ -71,16 +70,32 @@ export const createPageModule = async (
 }
 
 export const createRouterFile = async (root: ComponentUIDL, strategy: ProjectStrategy) => {
+  const { projectStyleSheet } = strategy
   const { generator: routerGenerator, path: routerFilePath, fileName } = strategy.router
   const routerLocalDependenciesPrefix = generateLocalDependenciesPrefix(
     routerFilePath,
     strategy.pages.path
   )
 
+  const relativePathForProjectStyleSheet =
+    PathResolver.relative(
+      /* When each page is created inside a another folder then we just need to 
+          add one more element to the path resolver to maintian the hierarcy */
+      strategy.router.path.join('/'),
+      strategy.projectStyleSheet.path.join('/')
+    ) || '.'
+
   const options: GeneratorOptions = {
     localDependenciesPrefix: routerLocalDependenciesPrefix,
     strategy,
     isRootComponent: true,
+    projectStyleSet: {
+      styleSetDefinitions: root?.styleSetDefinitions,
+      fileName: projectStyleSheet.fileName,
+      path: relativePathForProjectStyleSheet,
+      importFile: projectStyleSheet?.importFile || false,
+    },
+    designLanguage: root?.designLanguage,
   }
 
   root.outputOptions = root.outputOptions || {}

--- a/packages/teleport-project-generator/src/index.ts
+++ b/packages/teleport-project-generator/src/index.ts
@@ -147,7 +147,7 @@ export class ProjectGenerator {
     }
 
     const { components = {} } = uidl
-    const { styleSetDefinitions = {} } = uidl.root
+    const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl.root
 
     // Based on the routing roles, separate pages into distict UIDLs with their own file names and paths
     const pageUIDLs = createPageUIDLs(uidl, this.strategy)
@@ -177,7 +177,10 @@ export class ProjectGenerator {
     }
 
     // Handling project style sheet
-    if (this.strategy.projectStyleSheet?.generator) {
+    if (
+      this.strategy.projectStyleSheet?.generator &&
+      (Object.keys(styleSetDefinitions).length > 0 || Object.keys(tokens).length > 0)
+    ) {
       const { generator, path } = this.strategy.projectStyleSheet
       const { files, dependencies } = await generator.generateComponent(uidl.root, {
         isRootComponent: true,

--- a/packages/teleport-project-generator/src/utils.ts
+++ b/packages/teleport-project-generator/src/utils.ts
@@ -1,5 +1,4 @@
 import { UIDLUtils, StringUtils } from '@teleporthq/teleport-shared'
-
 import {
   GeneratedFile,
   GeneratedFolder,
@@ -14,7 +13,6 @@ import {
   UIDLExternalDependency,
 } from '@teleporthq/teleport-types'
 import { elementNode } from '@teleporthq/teleport-uidl-builders'
-
 import importStatementsPlugin from '@teleporthq/teleport-plugin-import-statements'
 import { createComponentGenerator } from '@teleporthq/teleport-component-generator'
 

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -1,4 +1,4 @@
-import { readFileSync, rmdirSync, mkdirSync } from 'fs'
+import { readFileSync } from 'fs'
 import { join } from 'path'
 import { packProject } from '@teleporthq/teleport-code-generator'
 import { ProjectUIDL, PackerOptions, ProjectType, PublisherType } from '@teleporthq/teleport-types'
@@ -33,8 +33,8 @@ const packerOptions: PackerOptions = {
 const run = async () => {
   try {
     if (packerOptions.publisher === PublisherType.DISK) {
-      rmdirSync('dist', { recursive: true })
-      mkdirSync('dist')
+      // rmdirSync('dist', { recursive: true })
+      // mkdirSync('dist')
     }
 
     let result

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -4,9 +4,9 @@ import { packProject } from '@teleporthq/teleport-code-generator'
 import { ProjectUIDL, PackerOptions, ProjectType, PublisherType } from '@teleporthq/teleport-types'
 
 import reactProjectJSON from '../../../examples/uidl-samples/react-project.json'
-// import projectJSON from '../../../examples/uidl-samples/project.json'
+import projectJSON from '../../../examples/uidl-samples/project.json'
 
-// const projectUIDL = (projectJSON as unknown) as ProjectUIDL
+const projectUIDL = (projectJSON as unknown) as ProjectUIDL
 const reactProjectUIDL = (reactProjectJSON as unknown) as ProjectUIDL
 const assetFile = readFileSync(join(__dirname, 'asset.png'))
 const base64File = Buffer.from(assetFile).toString('base64')
@@ -43,34 +43,34 @@ const run = async () => {
     //   projectType: ProjectType.REACTNATIVE,
     // })
     // console.info(ProjectType.REACTNATIVE, '-', result.payload)
-    // result = await packProject(reactProjectUIDL, {
-    //   ...packerOptions,
-    //   projectType: ProjectType.REACT,
-    // })
-    // console.info(ProjectType.REACT, '-', result.payload)
-    // result = await packProject(projectUIDL, {
-    //   ...packerOptions,
-    //   projectType: ProjectType.NEXT,
-    // })
-    // console.info(ProjectType.NEXT, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
-    // console.info(ProjectType.NUXT, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.VUE })
-    // console.info(ProjectType.VUE, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.STENCIL })
-    // console.info(ProjectType.STENCIL, '-', result.payload)
-    // result = await packProject(projectUIDL, {
-    //   ...packerOptions,
-    //   projectType: ProjectType.PREACT,
-    // })
-    // console.info(ProjectType.PREACT, '-', result.payload)
-    // result = await packProject(projectUIDL, {
-    //   ...packerOptions,
-    //   projectType: ProjectType.ANGULAR,
-    // })
-    // console.info(ProjectType.ANGULAR, '-', result.payload)
-    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GRIDSOME })
-    // console.info(ProjectType.GRIDSOME, '-', result.payload)
+    result = await packProject(reactProjectUIDL, {
+      ...packerOptions,
+      projectType: ProjectType.REACT,
+    })
+    console.info(ProjectType.REACT, '-', result.payload)
+    result = await packProject(projectUIDL, {
+      ...packerOptions,
+      projectType: ProjectType.NEXT,
+    })
+    console.info(ProjectType.NEXT, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
+    console.info(ProjectType.NUXT, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.VUE })
+    console.info(ProjectType.VUE, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.STENCIL })
+    console.info(ProjectType.STENCIL, '-', result.payload)
+    result = await packProject(projectUIDL, {
+      ...packerOptions,
+      projectType: ProjectType.PREACT,
+    })
+    console.info(ProjectType.PREACT, '-', result.payload)
+    result = await packProject(projectUIDL, {
+      ...packerOptions,
+      projectType: ProjectType.ANGULAR,
+    })
+    console.info(ProjectType.ANGULAR, '-', result.payload)
+    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GRIDSOME })
+    console.info(ProjectType.GRIDSOME, '-', result.payload)
     result = await packProject(reactProjectUIDL, {
       ...packerOptions,
       projectType: ProjectType.GATSBY,

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -1,12 +1,12 @@
-import { readFileSync } from 'fs'
+import { readFileSync, mkdirSync, rmdirSync } from 'fs'
 import { join } from 'path'
 import { packProject } from '@teleporthq/teleport-code-generator'
 import { ProjectUIDL, PackerOptions, ProjectType, PublisherType } from '@teleporthq/teleport-types'
 
 import reactProjectJSON from '../../../examples/uidl-samples/react-project.json'
-import projectJSON from '../../../examples/uidl-samples/project.json'
+// import projectJSON from '../../../examples/uidl-samples/project.json'
 
-const projectUIDL = (projectJSON as unknown) as ProjectUIDL
+// const projectUIDL = (projectJSON as unknown) as ProjectUIDL
 const reactProjectUIDL = (reactProjectJSON as unknown) as ProjectUIDL
 const assetFile = readFileSync(join(__dirname, 'asset.png'))
 const base64File = Buffer.from(assetFile).toString('base64')
@@ -33,8 +33,8 @@ const packerOptions: PackerOptions = {
 const run = async () => {
   try {
     if (packerOptions.publisher === PublisherType.DISK) {
-      // rmdirSync('dist', { recursive: true })
-      // mkdirSync('dist')
+      rmdirSync('dist', { recursive: true })
+      mkdirSync('dist')
     }
 
     let result
@@ -43,34 +43,34 @@ const run = async () => {
     //   projectType: ProjectType.REACTNATIVE,
     // })
     // console.info(ProjectType.REACTNATIVE, '-', result.payload)
-    result = await packProject(reactProjectUIDL, {
-      ...packerOptions,
-      projectType: ProjectType.REACT,
-    })
-    console.info(ProjectType.REACT, '-', result.payload)
-    result = await packProject(projectUIDL, {
-      ...packerOptions,
-      projectType: ProjectType.NEXT,
-    })
-    console.info(ProjectType.NEXT, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
-    console.info(ProjectType.NUXT, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.VUE })
-    console.info(ProjectType.VUE, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.STENCIL })
-    console.info(ProjectType.STENCIL, '-', result.payload)
-    result = await packProject(projectUIDL, {
-      ...packerOptions,
-      projectType: ProjectType.PREACT,
-    })
-    console.info(ProjectType.PREACT, '-', result.payload)
-    result = await packProject(projectUIDL, {
-      ...packerOptions,
-      projectType: ProjectType.ANGULAR,
-    })
-    console.info(ProjectType.ANGULAR, '-', result.payload)
-    result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GRIDSOME })
-    console.info(ProjectType.GRIDSOME, '-', result.payload)
+    // result = await packProject(reactProjectUIDL, {
+    //   ...packerOptions,
+    //   projectType: ProjectType.REACT,
+    // })
+    // console.info(ProjectType.REACT, '-', result.payload)
+    // result = await packProject(projectUIDL, {
+    //   ...packerOptions,
+    //   projectType: ProjectType.NEXT,
+    // })
+    // console.info(ProjectType.NEXT, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
+    // console.info(ProjectType.NUXT, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.VUE })
+    // console.info(ProjectType.VUE, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.STENCIL })
+    // console.info(ProjectType.STENCIL, '-', result.payload)
+    // result = await packProject(projectUIDL, {
+    //   ...packerOptions,
+    //   projectType: ProjectType.PREACT,
+    // })
+    // console.info(ProjectType.PREACT, '-', result.payload)
+    // result = await packProject(projectUIDL, {
+    //   ...packerOptions,
+    //   projectType: ProjectType.ANGULAR,
+    // })
+    // console.info(ProjectType.ANGULAR, '-', result.payload)
+    // result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.GRIDSOME })
+    // console.info(ProjectType.GRIDSOME, '-', result.payload)
     result = await packProject(reactProjectUIDL, {
       ...packerOptions,
       projectType: ProjectType.GATSBY,

--- a/packages/teleport-types/src/generators.ts
+++ b/packages/teleport-types/src/generators.ts
@@ -6,6 +6,7 @@ import {
   UIDLElement,
   UIDLStateDefinition,
   UIDLStyleSetDefinition,
+  UIDLDesignTokens,
 } from './uidl'
 
 export enum FileType {
@@ -95,6 +96,9 @@ export interface GeneratorOptions {
     fileName: string
     path: string
     importFile?: boolean
+  }
+  designLanguage?: {
+    tokens?: UIDLDesignTokens
   }
 }
 


### PR DESCRIPTION
Currently `tokens` and `Project StyleSheet` are tightly coupled. Like tokens for `css` and `css-modules` are basically css-variables. Which works only when imported. But if a project is not using `project-style-sheet` at all. Then the tokens are not imported. So, need some extra checks and ways. So, if the project-style-sheet is not used. Then tokens are imported directly in the router of the project. Which is a entry point.

fixes #529 

TODO

- [x] Gatsby + CSS-Modules still needs a solution