### PR TITLE
fix(css): importing global style sheet by default in the root of the project

### DIFF
--- a/packages/teleport-component-generator-react/__tests__/integration/component-referenced-styles.ts
+++ b/packages/teleport-component-generator-react/__tests__/integration/component-referenced-styles.ts
@@ -333,7 +333,7 @@ describe('Referes from project style and adds it to the node, without any styles
     const jsFile = findFileByType(files, FileType.JS)
 
     expect(jsFile.content).toContain('className="primaryButton"')
-    expect(jsFile.content).toContain(`import '../style.css'`)
+    expect(jsFile.content).not.toContain(`import '../style.css'`)
     expect(jsFile.content).not.toContain(`import './my-component.css'`)
   })
 

--- a/packages/teleport-component-generator-vue/__tests__/integration/component-referenced-styles.ts
+++ b/packages/teleport-component-generator-vue/__tests__/integration/component-referenced-styles.ts
@@ -145,6 +145,6 @@ describe('Referes from project style and adds it to the node, without any styles
 
     expect(vueFile).toBeDefined()
     expect(vueFile.content).toContain(`class="primaryButton"`)
-    expect(vueFile.content).toContain(`import '../style.css'`)
+    expect(vueFile.content).not.toContain(`import '../style.css'`)
   })
 })

--- a/packages/teleport-plugin-css-modules/src/index.ts
+++ b/packages/teleport-plugin-css-modules/src/index.ts
@@ -53,7 +53,7 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
       projectStyleSet || {}
 
     if (isRootComponent) {
-      if (Object.keys(tokens).length > 0 && Object.keys(styleSetDefinitions).length === 0) {
+      if (Object.keys(tokens).length > 0 || Object.keys(styleSetDefinitions).length > 0) {
         const fileName = moduleExtension ? `${projectStyleSheetName}.module` : projectStyleSheetName
         dependencies[projectStylesReferenceOffset] = {
           type: 'local',

--- a/packages/teleport-uidl-validator/src/validator/utils.ts
+++ b/packages/teleport-uidl-validator/src/validator/utils.ts
@@ -182,7 +182,7 @@ export const checkRouteDefinition = (input: ProjectUIDL) => {
 }
 
 // All referenced components inside of the projectUIDL should be defined
-// in the component section and all the project-references and tokens
+// in the components section and all the project-referenced styles and tokens
 export const checkComponentExistenceAndReferences = (input: ProjectUIDL) => {
   const errors: string[] = []
   const components = Object.keys(input.components || {})


### PR DESCRIPTION
fixes #536 

Importing global style sheet by default in the entry of the file by default for css and css-modules.