### PR TITLE
fix(generator): enable jsec encoding to support special characters in AST to code transformation

### DIFF
--- a/packages/teleport-component-generator/src/builder/generators/js-ast-to-code.ts
+++ b/packages/teleport-component-generator/src/builder/generators/js-ast-to-code.ts
@@ -4,5 +4,5 @@ import { Node } from '@babel/types'
 import { CodeGeneratorFunction } from '@teleporthq/teleport-types'
 
 export const generator: CodeGeneratorFunction<Node> = (ast) => {
-  return babelGenerator(ast).code
+  return babelGenerator(ast, { jsescOption: { minimal: true } }).code
 }


### PR DESCRIPTION
Please visit the following URL --> https://repl.teleporthq.io/project/cc023c27-ba39-449a-8d97-013e616256c3

You can see, when a component is passed with props that contains non-english characters. With `jsec` in minimal. It will stop encoding them in babel.

## Result
<img width="569" alt="Screenshot 2021-04-28 at 4 59 07 PM" src="https://user-images.githubusercontent.com/11075561/116396529-23b0da00-a843-11eb-9626-04db59d1727b.png">

