### PR TITLE
Improve UIDL validation for global assets

### DIFF
--- a/packages/teleport-plugin-common/src/builders/ast-builders.ts
+++ b/packages/teleport-plugin-common/src/builders/ast-builders.ts
@@ -188,7 +188,10 @@ export const appendAssetsAST = (
   bodyNode: types.JSXElement
 ) => {
   assets.forEach((asset) => {
-    const assetPath = UIDLUtils.prefixAssetsPath(options.assetsPrefix, asset.path)
+    let assetPath
+    if ('path' in asset) {
+      assetPath = UIDLUtils.prefixAssetsPath(options.assetsPrefix, asset.path)
+    }
 
     // link canonical for SEO
     if (asset.type === 'canonical' && assetPath) {
@@ -207,7 +210,7 @@ export const appendAssetsAST = (
     }
 
     // inline style
-    if (asset.type === 'style' && asset.content) {
+    if (asset.type === 'style' && 'content' in asset) {
       const styleTag = createJSXTag('style')
       addAttributeToJSXTag(styleTag, 'dangerouslySetInnerHTML', { __html: asset.content })
       addChildJSXTag(headNode, styleTag)
@@ -217,6 +220,7 @@ export const appendAssetsAST = (
     if (asset.type === 'script') {
       const scriptTag = createJSXTag('script')
       addAttributeToJSXTag(scriptTag, 'type', 'text/javascript')
+
       if (assetPath) {
         addAttributeToJSXTag(scriptTag, 'src', assetPath)
         if (asset.options && asset.options.defer) {
@@ -225,7 +229,7 @@ export const appendAssetsAST = (
         if (asset.options && asset.options.async) {
           addAttributeToJSXTag(scriptTag, 'async', true)
         }
-      } else if (asset.content) {
+      } else if ('content' in asset) {
         addAttributeToJSXTag(scriptTag, 'dangerouslySetInnerHTML', {
           __html: asset.content,
         })

--- a/packages/teleport-plugin-common/src/builders/ast-builders.ts
+++ b/packages/teleport-plugin-common/src/builders/ast-builders.ts
@@ -188,10 +188,7 @@ export const appendAssetsAST = (
   bodyNode: types.JSXElement
 ) => {
   assets.forEach((asset) => {
-    let assetPath
-    if ('path' in asset) {
-      assetPath = UIDLUtils.prefixAssetsPath(options.assetsPrefix, asset.path)
-    }
+    const assetPath = UIDLUtils.prefixAssetsPath(options.assetsPrefix, asset.path)
 
     // link canonical for SEO
     if (asset.type === 'canonical' && assetPath) {
@@ -210,7 +207,7 @@ export const appendAssetsAST = (
     }
 
     // inline style
-    if (asset.type === 'style' && 'content' in asset) {
+    if (asset.type === 'style' && asset.content) {
       const styleTag = createJSXTag('style')
       addAttributeToJSXTag(styleTag, 'dangerouslySetInnerHTML', { __html: asset.content })
       addChildJSXTag(headNode, styleTag)
@@ -222,24 +219,22 @@ export const appendAssetsAST = (
       addAttributeToJSXTag(scriptTag, 'type', 'text/javascript')
       if (assetPath) {
         addAttributeToJSXTag(scriptTag, 'src', assetPath)
-        if ('options' in asset && asset.options.defer) {
+        if (asset.options && asset.options.defer) {
           addAttributeToJSXTag(scriptTag, 'defer', true)
         }
-        if ('options' in asset && asset.options.async) {
+        if (asset.options && asset.options.async) {
           addAttributeToJSXTag(scriptTag, 'async', true)
         }
-      } else if ('content' in asset) {
+      } else if (asset.content) {
         addAttributeToJSXTag(scriptTag, 'dangerouslySetInnerHTML', {
           __html: asset.content,
         })
       }
 
-      if ('options' in asset) {
-        if ('target' in asset.options) {
-          addChildJSXTag(bodyNode, scriptTag)
-        } else {
-          addChildJSXTag(headNode, scriptTag)
-        }
+      if (asset.options && asset.options.target === 'body') {
+        addChildJSXTag(bodyNode, scriptTag)
+      } else {
+        addChildJSXTag(headNode, scriptTag)
       }
     }
 

--- a/packages/teleport-plugin-common/src/builders/ast-builders.ts
+++ b/packages/teleport-plugin-common/src/builders/ast-builders.ts
@@ -188,7 +188,10 @@ export const appendAssetsAST = (
   bodyNode: types.JSXElement
 ) => {
   assets.forEach((asset) => {
-    const assetPath = UIDLUtils.prefixAssetsPath(options.assetsPrefix, asset.path)
+    let assetPath
+    if ('path' in asset) {
+      assetPath = UIDLUtils.prefixAssetsPath(options.assetsPrefix, asset.path)
+    }
 
     // link canonical for SEO
     if (asset.type === 'canonical' && assetPath) {
@@ -207,7 +210,7 @@ export const appendAssetsAST = (
     }
 
     // inline style
-    if (asset.type === 'style' && asset.content) {
+    if (asset.type === 'style' && 'content' in asset) {
       const styleTag = createJSXTag('style')
       addAttributeToJSXTag(styleTag, 'dangerouslySetInnerHTML', { __html: asset.content })
       addChildJSXTag(headNode, styleTag)
@@ -219,22 +222,24 @@ export const appendAssetsAST = (
       addAttributeToJSXTag(scriptTag, 'type', 'text/javascript')
       if (assetPath) {
         addAttributeToJSXTag(scriptTag, 'src', assetPath)
-        if (asset.options && asset.options.defer) {
+        if ('options' in asset && asset.options.defer) {
           addAttributeToJSXTag(scriptTag, 'defer', true)
         }
-        if (asset.options && asset.options.async) {
+        if ('options' in asset && asset.options.async) {
           addAttributeToJSXTag(scriptTag, 'async', true)
         }
-      } else if (asset.content) {
+      } else if ('content' in asset) {
         addAttributeToJSXTag(scriptTag, 'dangerouslySetInnerHTML', {
           __html: asset.content,
         })
       }
 
-      if (asset.options && asset.options.target === 'body') {
-        addChildJSXTag(bodyNode, scriptTag)
-      } else {
-        addChildJSXTag(headNode, scriptTag)
+      if ('options' in asset) {
+        if ('target' in asset.options) {
+          addChildJSXTag(bodyNode, scriptTag)
+        } else {
+          addChildJSXTag(headNode, scriptTag)
+        }
       }
     }
 

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -221,7 +221,10 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
   })
 
   assets.forEach((asset) => {
-    const assetPath = UIDLUtils.prefixAssetsPath(assetsPrefix, asset.path)
+    let assetPath
+    if ('path' in asset) {
+      assetPath = UIDLUtils.prefixAssetsPath(options.assetsPrefix, asset.path)
+    }
 
     // link canonical for SEO
     if (asset.type === 'canonical' && assetPath) {
@@ -240,7 +243,7 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
     }
 
     // inline style
-    if (asset.type === 'style' && asset.content) {
+    if (asset.type === 'style' && 'content' in asset) {
       const styleTag = HASTBuilders.createHTMLNode('style')
       HASTUtils.addTextNode(styleTag, asset.content)
       HASTUtils.addChildNode(headNode, styleTag)
@@ -251,6 +254,7 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
       const scriptInBody = (asset.options && asset.options.target === 'body') || false
       const scriptTag = HASTBuilders.createHTMLNode('script')
       HASTUtils.addAttributeToNode(scriptTag, 'type', 'text/javascript')
+
       if (assetPath) {
         HASTUtils.addAttributeToNode(scriptTag, 'src', assetPath)
         if (asset.options && asset.options.defer) {
@@ -259,9 +263,10 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
         if (asset.options && asset.options.async) {
           HASTUtils.addBooleanAttributeToNode(scriptTag, 'async')
         }
-      } else if (asset.content) {
+      } else if ('content' in asset) {
         HASTUtils.addTextNode(scriptTag, asset.content)
       }
+
       if (scriptInBody) {
         HASTUtils.addChildNode(bodyNode, scriptTag)
       } else {

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -221,7 +221,10 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
   })
 
   assets.forEach((asset) => {
-    const assetPath = UIDLUtils.prefixAssetsPath(assetsPrefix, asset.path)
+    let assetPath
+    if ('path' in asset) {
+      assetPath = UIDLUtils.prefixAssetsPath(assetsPrefix, asset.path)
+    }
 
     // link canonical for SEO
     if (asset.type === 'canonical' && assetPath) {
@@ -240,7 +243,7 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
     }
 
     // inline style
-    if (asset.type === 'style' && asset.content) {
+    if (asset.type === 'style' && 'content' in asset) {
       const styleTag = HASTBuilders.createHTMLNode('style')
       HASTUtils.addTextNode(styleTag, asset.content)
       HASTUtils.addChildNode(headNode, styleTag)
@@ -248,18 +251,23 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
 
     // script (external or inline)
     if (asset.type === 'script') {
-      const scriptInBody = (asset.options && asset.options.target === 'body') || false
+      let scriptInBody = false
+      if ('options' in asset) {
+        if ('target' in asset.options && asset.options.target === 'body') {
+          scriptInBody = true
+        }
+      }
       const scriptTag = HASTBuilders.createHTMLNode('script')
       HASTUtils.addAttributeToNode(scriptTag, 'type', 'text/javascript')
       if (assetPath) {
         HASTUtils.addAttributeToNode(scriptTag, 'src', assetPath)
-        if (asset.options && asset.options.defer) {
+        if ('options' in asset && asset.options.defer) {
           HASTUtils.addBooleanAttributeToNode(scriptTag, 'defer')
         }
-        if (asset.options && asset.options.async) {
+        if ('options' in asset && asset.options.async) {
           HASTUtils.addBooleanAttributeToNode(scriptTag, 'async')
         }
-      } else if (asset.content) {
+      } else if ('content' in asset) {
         HASTUtils.addTextNode(scriptTag, asset.content)
       }
       if (scriptInBody) {

--- a/packages/teleport-project-generator/src/file-handlers.ts
+++ b/packages/teleport-project-generator/src/file-handlers.ts
@@ -221,10 +221,7 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
   })
 
   assets.forEach((asset) => {
-    let assetPath
-    if ('path' in asset) {
-      assetPath = UIDLUtils.prefixAssetsPath(assetsPrefix, asset.path)
-    }
+    const assetPath = UIDLUtils.prefixAssetsPath(assetsPrefix, asset.path)
 
     // link canonical for SEO
     if (asset.type === 'canonical' && assetPath) {
@@ -243,7 +240,7 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
     }
 
     // inline style
-    if (asset.type === 'style' && 'content' in asset) {
+    if (asset.type === 'style' && asset.content) {
       const styleTag = HASTBuilders.createHTMLNode('style')
       HASTUtils.addTextNode(styleTag, asset.content)
       HASTUtils.addChildNode(headNode, styleTag)
@@ -251,23 +248,18 @@ const createHTMLEntryFileChunks = (uidl: ProjectUIDL, options: EntryFileOptions)
 
     // script (external or inline)
     if (asset.type === 'script') {
-      let scriptInBody = false
-      if ('options' in asset) {
-        if ('target' in asset.options && asset.options.target === 'body') {
-          scriptInBody = true
-        }
-      }
+      const scriptInBody = (asset.options && asset.options.target === 'body') || false
       const scriptTag = HASTBuilders.createHTMLNode('script')
       HASTUtils.addAttributeToNode(scriptTag, 'type', 'text/javascript')
       if (assetPath) {
         HASTUtils.addAttributeToNode(scriptTag, 'src', assetPath)
-        if ('options' in asset && asset.options.defer) {
+        if (asset.options && asset.options.defer) {
           HASTUtils.addBooleanAttributeToNode(scriptTag, 'defer')
         }
-        if ('options' in asset && asset.options.async) {
+        if (asset.options && asset.options.async) {
           HASTUtils.addBooleanAttributeToNode(scriptTag, 'async')
         }
-      } else if ('content' in asset) {
+      } else if (asset.content) {
         HASTUtils.addTextNode(scriptTag, asset.content)
       }
       if (scriptInBody) {

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -19,18 +19,54 @@ export interface UIDLGlobalProjectValues {
   manifest?: WebManifest
   variables?: Record<string, string>
 }
-export interface UIDLGlobalAsset {
-  type: 'script' | 'style' | 'font' | 'canonical' | 'icon'
-  path?: string
-  content?: string
+export interface UIDLScriptExternalAsset {
+  type: 'script'
+  path: string
   options?: {
     async?: boolean
     defer?: boolean
     target?: string
+  }
+}
+export interface UIDLScriptInlineAsset {
+  type: 'script'
+  content: string
+}
+export type UIDLScriptAsset = UIDLScriptExternalAsset | UIDLScriptInlineAsset
+
+export interface UIDLStyleExternalAsset {
+  type: 'style'
+  path: string
+}
+export interface UIDLStyleInlineAsset {
+  type: 'style'
+  content: string
+}
+export type UIDLStyleAsset = UIDLStyleExternalAsset | UIDLStyleInlineAsset
+
+export interface UIDLFontAsset {
+  type: 'font'
+  path: string
+}
+export interface UIDLCanonicalAsset {
+  type: 'canonical'
+  path: string
+}
+export interface UIDLIconAsset {
+  type: 'icon'
+  path: string
+  options?: {
     iconType?: string
     iconSizes?: string
   }
 }
+export type UIDLGlobalAsset =
+  | UIDLScriptAsset
+  | UIDLStyleInlineAsset
+  | UIDLStyleExternalAsset
+  | UIDLFontAsset
+  | UIDLCanonicalAsset
+  | UIDLIconAsset
 
 export interface ComponentUIDL {
   name: string
@@ -349,7 +385,16 @@ export interface UIDLStyleStateCondition {
   content: UIDLElementStyleStates
 }
 
-export type UIDLElementStyleStates = 'hover' | 'active' | 'focus' | 'focus-within' | 'focus-visible' |  'disabled' | 'visited' | 'checked' | 'placeholder'
+export type UIDLElementStyleStates =
+  | 'hover'
+  | 'active'
+  | 'focus'
+  | 'focus-within'
+  | 'focus-visible'
+  | 'disabled'
+  | 'visited'
+  | 'checked'
+  | 'placeholder'
 
 export interface UIDLStyleSetDefinition {
   id: string

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -19,38 +19,35 @@ export interface UIDLGlobalProjectValues {
   manifest?: WebManifest
   variables?: Record<string, string>
 }
-export interface UIDLScriptExternalAsset {
-  type: 'script'
-  path: string
-  content?: string
+
+export interface UIDLAssetBase {
   options?: {
     async?: boolean
     defer?: boolean
     target?: string
   }
 }
-export interface UIDLScriptInlineAsset {
+
+export interface UIDLScriptInlineAsset extends UIDLAssetBase {
   type: 'script'
   content: string
-  path?: string
-  options?: {
-    async?: boolean
-    defer?: boolean
-    target?: string
-  }
 }
+export interface UIDLScriptExternalAsset extends UIDLAssetBase {
+  type: 'script'
+  path: string
+}
+
 export type UIDLScriptAsset = UIDLScriptExternalAsset | UIDLScriptInlineAsset
 
-export interface UIDLStyleExternalAsset {
-  type: 'style'
-  path: string
-  content?: string
-}
 export interface UIDLStyleInlineAsset {
   type: 'style'
   content: string
-  path?: string
 }
+export interface UIDLStyleExternalAsset {
+  type: 'style'
+  path: string
+}
+
 export type UIDLStyleAsset = UIDLStyleExternalAsset | UIDLStyleInlineAsset
 
 export interface UIDLFontAsset {
@@ -69,6 +66,7 @@ export interface UIDLIconAsset {
     iconSizes?: string
   }
 }
+
 export type UIDLGlobalAsset =
   | UIDLScriptAsset
   | UIDLStyleInlineAsset

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -22,6 +22,7 @@ export interface UIDLGlobalProjectValues {
 export interface UIDLScriptExternalAsset {
   type: 'script'
   path: string
+  content?: string
   options?: {
     async?: boolean
     defer?: boolean
@@ -31,16 +32,24 @@ export interface UIDLScriptExternalAsset {
 export interface UIDLScriptInlineAsset {
   type: 'script'
   content: string
+  path?: string
+  options?: {
+    async?: boolean
+    defer?: boolean
+    target?: string
+  }
 }
 export type UIDLScriptAsset = UIDLScriptExternalAsset | UIDLScriptInlineAsset
 
 export interface UIDLStyleExternalAsset {
   type: 'style'
   path: string
+  content?: string
 }
 export interface UIDLStyleInlineAsset {
   type: 'style'
   content: string
+  path?: string
 }
 export type UIDLStyleAsset = UIDLStyleExternalAsset | UIDLStyleInlineAsset
 

--- a/packages/teleport-uidl-validator/src/decoders/project-decoder.ts
+++ b/packages/teleport-uidl-validator/src/decoders/project-decoder.ts
@@ -1,6 +1,6 @@
 import { Decoder, object, optional, string, dict, array } from '@mojotech/json-type-validation'
 import { UIDLGlobalProjectValues, WebManifest, VProjectUIDL } from '@teleporthq/teleport-types'
-import { globalAssetsValidator } from './utils'
+import { globalAssetsDecoder } from './utils'
 import { componentUIDLDecoder, rootComponentUIDLDecoder } from './component-decoder'
 
 export const webManifestDecoder: Decoder<WebManifest> = object({
@@ -27,7 +27,7 @@ export const globalProjectValuesDecoder: Decoder<UIDLGlobalProjectValues> = obje
     })
   ),
   meta: array(dict(string())),
-  assets: array(globalAssetsValidator),
+  assets: array(globalAssetsDecoder),
   manifest: optional(webManifestDecoder),
   variables: optional(dict(string())),
 })

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -10,7 +10,7 @@ import {
   boolean,
   array,
   lazy,
-  oneOf
+  oneOf,
 } from '@mojotech/json-type-validation'
 import {
   UIDLStaticValue,
@@ -59,6 +59,13 @@ import {
   VUIDLDesignTokens,
   UIDLPropCallEvent,
   UIDLStateModifierEvent,
+  UIDLScriptExternalAsset,
+  UIDLScriptInlineAsset,
+  UIDLStyleInlineAsset,
+  UIDLStyleExternalAsset,
+  UIDLFontAsset,
+  UIDLCanonicalAsset,
+  UIDLIconAsset,
 } from '@teleporthq/teleport-types'
 import { CustomCombinators } from './custom-combinators'
 
@@ -160,21 +167,64 @@ export const pageOptionsDecoder: Decoder<UIDLPageOptions> = object({
   fileName: optional((isValidFileName() as unknown) as Decoder<string>),
 })
 
-export const globalAssetsValidator: Decoder<UIDLGlobalAsset> = object({
-  type: union(
-    constant('script'),
-    constant('style'),
-    constant('font'),
-    constant('canonical'),
-    constant('icon')
-  ),
-  path: optional(string()),
-  content: optional(string()),
+export const globalAssetsValidator: Decoder<UIDLGlobalAsset> = union(
+  lazy(() => inlineScriptAssetDecoder),
+  lazy(() => externalScriptAssetDecoder),
+  lazy(() => inlineStyletAssetDecoder),
+  lazy(() => externalStyleAssetDecoder),
+  lazy(() => fontAssetDecoder),
+  lazy(() => canonicalAssetDecoder),
+  lazy(() => iconAssetDecoder)
+)
+
+export const inlineScriptAssetDecoder: Decoder<UIDLScriptInlineAsset> = object({
+  type: constant('script'),
+  content: string(),
+})
+
+export const externalScriptAssetDecoder: Decoder<UIDLScriptExternalAsset> = object({
+  type: constant('script'),
+  path: string(),
   options: optional(
     object({
       async: optional(boolean()),
       defer: optional(boolean()),
       target: optional(string()),
+    })
+  ),
+})
+
+export const inlineStyletAssetDecoder: Decoder<UIDLStyleInlineAsset> = object({
+  type: constant('style'),
+  content: string(),
+})
+
+export const externalStyleAssetDecoder: Decoder<UIDLStyleExternalAsset> = object({
+  type: constant('style'),
+  path: string(),
+  options: optional(
+    object({
+      async: optional(boolean()),
+      defer: optional(boolean()),
+    })
+  ),
+})
+
+export const fontAssetDecoder: Decoder<UIDLFontAsset> = object({
+  type: constant('font'),
+  path: string(),
+})
+
+export const canonicalAssetDecoder: Decoder<UIDLCanonicalAsset> = object({
+  type: constant('canonical'),
+  path: string(),
+})
+
+export const iconAssetDecoder: Decoder<UIDLIconAsset> = object({
+  type: constant('icon'),
+  path: string(),
+  options: optional(
+    object({
       iconType: optional(string()),
       iconSizes: optional(string()),
     })


### PR DESCRIPTION
For issue #457 I've added types for each asset and made changes based on that. But I'm confused about where to write the logic for "For handling style tags, we need a string content or a path. But not both at the same time"?