### PR TITLE
(default-func): Add void func as default handler for `propDefinitions` of type `func`

### DIFF
--- a/examples/uidl-samples/project.json
+++ b/examples/uidl-samples/project.json
@@ -992,6 +992,12 @@
     },
     "ContactForm": {
       "name": "ContactForm",
+      "propDefinitions": {
+        "isClicked": {
+          "type": "func",
+          "defaultValue": "() => {}"
+        }
+      },
       "node": {
         "type": "element",
         "content": {
@@ -999,6 +1005,14 @@
           "attrs": {
             "type": "get",
             "url": "/"
+          },
+          "events": {
+            "click": [
+              {
+                "type": "propCall",
+                "calls": "isClicked"
+              }
+            ]
           },
           "style": {
             "margin": "20px",

--- a/examples/uidl-samples/react-project.json
+++ b/examples/uidl-samples/react-project.json
@@ -1238,6 +1238,12 @@
     },
     "ContactForm": {
       "name": "ContactForm",
+      "propDefinitions": {
+        "isClicked": {
+          "type": "func",
+          "defaultValue": "() => {}"
+        }
+      },
       "node": {
         "type": "element",
         "content": {
@@ -1245,6 +1251,14 @@
           "attrs": {
             "type": "get",
             "url": "/"
+          },
+          "events": {
+            "click": [
+              {
+                "type": "propCall",
+                "calls": "isClicked"
+              }
+            ]
           },
           "style": {
             "margin": "20px",

--- a/packages/teleport-plugin-jsx-proptypes/__tests__/index.ts
+++ b/packages/teleport-plugin-jsx-proptypes/__tests__/index.ts
@@ -6,6 +6,12 @@ import {
   FileType,
   ChunkDefinition,
 } from '@teleporthq/teleport-types'
+import type {
+  AssignmentExpression,
+  ExpressionStatement,
+  ObjectExpression,
+  ObjectProperty,
+} from '@babel/types'
 
 describe('plugin-jsx-proptypes', () => {
   const plugin = createPropTypesPlugin()
@@ -123,5 +129,39 @@ describe('plugin-jsx-proptypes', () => {
     expect(defaultProps.length).toEqual(0)
     expect(propTypes.length).toEqual(1)
     expect(propTypes[0].type).toBe(ChunkType.AST)
+  })
+
+  it('creates default void function for props with type as func', async () => {
+    const structure: ComponentStructure = {
+      chunks: [reactChunk, exportChunk],
+      options: {},
+      uidl: component(
+        'Test',
+        elementNode(
+          'container',
+          null,
+          [],
+          null,
+          {},
+          { click: [{ type: 'propCall', calls: 'onChange' }] }
+        ),
+        {
+          onChange: {
+            type: 'func',
+            defaultValue: '() => {}',
+          },
+        }
+      ),
+      dependencies: {},
+    }
+    const { chunks } = await plugin(structure)
+    const defaultPropsChunk = chunks.find((chunk) => chunk.name === 'component-default-props')
+    const statement = defaultPropsChunk.content as ExpressionStatement
+    const rightProperties = (statement.expression as AssignmentExpression).right as ObjectExpression
+
+    expect(statement).toBeDefined()
+    expect((rightProperties.properties[0] as ObjectProperty).value.type).toBe(
+      'ArrowFunctionExpression'
+    )
   })
 })

--- a/packages/teleport-plugin-jsx-proptypes/src/utils.ts
+++ b/packages/teleport-plugin-jsx-proptypes/src/utils.ts
@@ -14,7 +14,16 @@ export const buildDefaultPropsAst = (
   const defaultValuesSearch = Object.keys(propDefinitions).reduce(
     // tslint:disable-next-line no-any
     (acc: any, key) => {
-      const { defaultValue } = propDefinitions[key]
+      const { defaultValue, type } = propDefinitions[key]
+
+      if (type === 'func') {
+        acc.values[key] = new ParsedASTNode(
+          types.arrowFunctionExpression([], types.blockStatement([]))
+        )
+        acc.count++
+        return acc
+      }
+
       if (typeof defaultValue !== 'undefined') {
         acc.values[key] = defaultValue
         acc.count++

--- a/packages/teleport-plugin-stencil-base-component/src/utils.ts
+++ b/packages/teleport-plugin-stencil-base-component/src/utils.ts
@@ -10,14 +10,17 @@ export const createClassDeclaration = (
   jsxTagTree: types.JSXElement,
   t = types
 ) => {
-  const propDeclaration = Object.keys(propDefinitions).map((propKey) =>
-    t.classProperty(
+  const propDeclaration = Object.keys(propDefinitions).map((propKey) => {
+    const { defaultValue, type } = propDefinitions[propKey]
+    return t.classProperty(
       t.identifier(propKey),
-      ASTUtils.convertValueToLiteral(propDefinitions[propKey].defaultValue),
-      types.tsTypeAnnotation(ASTUtils.getTSAnnotationForType(propDefinitions[propKey].type)),
+      type === 'func'
+        ? types.arrowFunctionExpression([], types.blockStatement([]))
+        : ASTUtils.convertValueToLiteral(defaultValue),
+      types.tsTypeAnnotation(ASTUtils.getTSAnnotationForType(type)),
       [t.decorator(t.callExpression(t.identifier('Prop'), []))]
     )
-  )
+  })
 
   const stateDeclaration = Object.keys(stateDefinitions).map((stateKey) =>
     t.classProperty(

--- a/packages/teleport-plugin-vue-base-component/src/utils.ts
+++ b/packages/teleport-plugin-vue-base-component/src/utils.ts
@@ -123,7 +123,11 @@ const createVuePropsDefinition = (
 
     let defaultPropValue = null
 
-    if (defaultValue !== undefined) {
+    if (type === 'func') {
+      defaultPropValue = new ParsedASTNode(
+        types.arrowFunctionExpression([], types.blockStatement([]))
+      )
+    } else if (defaultValue !== undefined) {
       defaultPropValue =
         type === 'array' || type === 'object'
           ? new ParsedASTNode(


### PR DESCRIPTION
fixes #638 