### PR TITLE
(fix): Enable scoping for styled-jsx for components and disable scoping for global styles in next

### DIFF
--- a/packages/teleport-code-generator/__tests__/end2end/index.ts
+++ b/packages/teleport-code-generator/__tests__/end2end/index.ts
@@ -32,9 +32,7 @@ describe('Generates NEXT-JS project with plugins', () => {
 
     expect(result.files.length).toBe(2)
     expect(packageJSON).toBeDefined()
-    expect(packageJSON.content).toContain(`@zeit/next-css`)
     expect(nextConfig).toBeDefined()
-    expect(nextConfig.content).toContain(`const withCSS = require('@zeit/next-css')`)
     expect(pages.files.length).toBe(6)
     expect(styleModule).toBeDefined()
     expect(styleModule.name).toBe('style.module')

--- a/packages/teleport-component-generator-angular/__tests__/end2end/component-referenced-styles.ts
+++ b/packages/teleport-component-generator-angular/__tests__/end2end/component-referenced-styles.ts
@@ -142,7 +142,7 @@ describe('Referes from project style and adds it to the node, without any styles
 
     expect(files.length).toBe(2)
     expect(cssFile).not.toBeDefined()
-    expect(htmlFile.content).toContain(`class="primaryButton\"`)
+    expect(htmlFile.content).toContain(`class="primary-button\"`)
     expect(tsFile.content).not.toContain(`my-component.css`)
     expect(tsFile.content).not.toContain(`import '../style.css`)
   })

--- a/packages/teleport-component-generator-react/__tests__/integration/component-referenced-styles.ts
+++ b/packages/teleport-component-generator-react/__tests__/integration/component-referenced-styles.ts
@@ -310,7 +310,7 @@ describe('Referes from project style and adds it to the node, without any styles
 
     const { files } = await generator.generateComponent(uidl, cssOptions)
     const jsFile = findFileByType(files, FileType.JS)
-    expect(jsFile.content).toContain(`className={projectStyles['primaryButton']}`)
+    expect(jsFile.content).toContain(`className={projectStyles['primary-button']}`)
     expect(jsFile.content).toContain(`import projectStyles from '../style.module.css'`)
     expect(jsFile.content).not.toContain(`import styles from './my-component.module.css'`)
   })
@@ -329,7 +329,7 @@ describe('Referes from project style and adds it to the node, without any styles
     const { files } = await generator.generateComponent(uidl, cssOptions)
     const jsFile = findFileByType(files, FileType.JS)
 
-    expect(jsFile.content).toContain('className="primaryButton"')
+    expect(jsFile.content).toContain('className="primary-button"')
     expect(jsFile.content).not.toContain(`import '../style.css'`)
     expect(jsFile.content).not.toContain(`import './my-component.css'`)
   })
@@ -355,7 +355,7 @@ describe('Referes from project style and adds it to the node, without any styles
     const { files } = await generator.generateComponent(uidl, options)
     const jsFile = findFileByType(files, FileType.JS)
     // Styled JSX is used only with NextJS, for NextJS we don't need to import anything
-    expect(jsFile.content).toContain('<div className="primaryButton">')
+    expect(jsFile.content).toContain('<div className="primary-button">')
   })
 
   it('React JSS', async () => {

--- a/packages/teleport-component-generator-react/src/index.ts
+++ b/packages/teleport-component-generator-react/src/index.ts
@@ -32,7 +32,7 @@ const createReactComponentGenerator: ComponentGeneratorInstance = ({
     forceScoping: true,
   })
   const cssModulesPlugin = createCSSModulesPlugin({ moduleExtension: true })
-  const reactStyledJSXPlugin = createReactStyledJSXPlugin({ forceScoping: false })
+  const reactStyledJSXPlugin = createReactStyledJSXPlugin({ forceScoping: true })
 
   const stylePlugins = {
     [ReactStyleVariation.InlineStyles]: inlineStylesPlugin,

--- a/packages/teleport-component-generator-vue/__tests__/integration/component-referenced-styles.ts
+++ b/packages/teleport-component-generator-vue/__tests__/integration/component-referenced-styles.ts
@@ -138,7 +138,7 @@ describe('Referes from project style and adds it to the node, without any styles
     const vueFile = findFileByType(files, FileType.VUE)
 
     expect(vueFile).toBeDefined()
-    expect(vueFile.content).toContain(`class="primaryButton"`)
+    expect(vueFile.content).toContain(`class="primary-button"`)
     expect(vueFile.content).not.toContain(`import '../style.css'`)
   })
 })

--- a/packages/teleport-plugin-common/src/builders/style-builders.ts
+++ b/packages/teleport-plugin-common/src/builders/style-builders.ts
@@ -106,9 +106,8 @@ export const generateStylesFromStyleSetDefinitions = (
   Object.keys(styleSetDefinitions).forEach((styleId) => {
     const style = styleSetDefinitions[styleId]
     const { content, conditions = [] } = style
-    const className = forceScoping
-      ? `${componentFileName}-${StringUtils.camelCaseToDashCase(styleId)}`
-      : styleId
+    const styleName = StringUtils.camelCaseToDashCase(styleId)
+    const className = forceScoping ? `${componentFileName}-${styleName}` : styleName
 
     const { staticStyles, tokenStyles } = UIDLUtils.splitDynamicAndStaticStyles(content)
     const collectedStyles = {

--- a/packages/teleport-plugin-css-modules/__tests__/component-scoped.ts
+++ b/packages/teleport-plugin-css-modules/__tests__/component-scoped.ts
@@ -1,4 +1,3 @@
-/* tslint:disable no-string-literal */
 import { createCSSModulesPlugin } from '../src'
 import { staticNode, elementNode, component } from '@teleporthq/teleport-uidl-builders'
 import { ComponentStructure } from '@teleporthq/teleport-types'
@@ -37,7 +36,7 @@ describe('Component Scoped Styles', () => {
     expect(chunks.length).toBe(2)
     expect(styleChunk).toBeDefined()
     expect(styleChunk.content).toContain(`primary-navbar`)
-    expect(styleChunk.content).toContain('secondaryNavbar')
+    expect(styleChunk.content).toContain('secondary-navbar')
   })
 
   it('Generates style sheet and adds them to the node with JSX template', async () => {

--- a/packages/teleport-plugin-css-modules/__tests__/style-sheet.ts
+++ b/packages/teleport-plugin-css-modules/__tests__/style-sheet.ts
@@ -82,14 +82,14 @@ describe('plugin-css-modules-style-sheet', () => {
   --blue-600: #6b7db3;
 }
 `)
-    expect(content).toContain(`.conditionalButton:hover {
+    expect(content).toContain(`.conditional-button:hover {
   background: var(--blue-500);
 }
 `)
     expect(content).toContain(`color: var(--red-500)`)
     expect(content).toContain('.primary-button')
-    expect(content).toContain('.secondaryButton')
-    expect(content).toContain('.conditionalButton:hover')
+    expect(content).toContain('.secondary-button')
+    expect(content).toContain('.conditional-button:hover')
     expect(content).toContain('@media(max-width: 991px)')
   })
 

--- a/packages/teleport-plugin-css-modules/src/index.ts
+++ b/packages/teleport-plugin-css-modules/src/index.ts
@@ -15,7 +15,7 @@
   ProjectStyle sheet are lost. Since, css-modules can have dynamic values only in inline.
 */
 
-import { UIDLUtils } from '@teleporthq/teleport-shared'
+import { StringUtils, UIDLUtils } from '@teleporthq/teleport-shared'
 import { StyleBuilders, ASTUtils } from '@teleporthq/teleport-plugin-common'
 import * as types from '@babel/types'
 import {
@@ -234,7 +234,7 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
               classNamesToAppend.add(
                 types.memberExpression(
                   types.identifier(globalStyleSheetPrefix),
-                  types.identifier(`'${content.referenceId}'`),
+                  types.identifier(`'${StringUtils.camelCaseToDashCase(content.referenceId)}'`),
                   true
                 )
               )

--- a/packages/teleport-plugin-css/__tests__/component-scoped.ts
+++ b/packages/teleport-plugin-css/__tests__/component-scoped.ts
@@ -37,7 +37,7 @@ describe('Component Scoped Styles', () => {
     expect(chunks.length).toBe(2)
     expect(styleChunk).toBeDefined()
     expect(styleChunk.content).toContain(`primary-navbar`)
-    expect(styleChunk.content).toContain('secondaryNavbar')
+    expect(styleChunk.content).toContain('secondary-navbar')
   })
 
   it('Generates style sheet and adds them to the node with JSX template', async () => {

--- a/packages/teleport-plugin-css/__tests__/referenced-styles.ts
+++ b/packages/teleport-plugin-css/__tests__/referenced-styles.ts
@@ -100,7 +100,7 @@ describe('Referenced Styles for inlined and project-referenced with Templates (H
     expect(cssFile).toBeDefined()
     expect(cssFile.content).toContain('width')
     expect(cssFile.content).toContain('@media(max-width: 991px)')
-    expect(nodeReference.properties.class).toBe('container primaryButton')
+    expect(nodeReference.properties.class).toBe('container primary-button')
   })
 })
 

--- a/packages/teleport-plugin-css/__tests__/style-sheet.ts
+++ b/packages/teleport-plugin-css/__tests__/style-sheet.ts
@@ -84,14 +84,14 @@ describe('plugin-css-style-sheet', () => {
   --blue-600: #6b7db3;
 }
 `)
-    expect(content).toContain(`.conditionalButton:hover {
+    expect(content).toContain(`.conditional-button:hover {
   background: var(--blue-500);
 }
 `)
     expect(content).toContain(`color: var(--red-500)`)
-    expect(content).toContain('.primaryButton')
-    expect(content).toContain('secondaryButton')
-    expect(content).toContain('.conditionalButton:hover')
+    expect(content).toContain('.primary-button')
+    expect(content).toContain('secondary-button')
+    expect(content).toContain('.conditional-button:hover')
     expect(content).toContain('@media(max-width: 991px)')
     expect(content).not.toContain('5ecfa1233b8e50f60ea2b64b')
   })

--- a/packages/teleport-plugin-css/src/index.ts
+++ b/packages/teleport-plugin-css/src/index.ts
@@ -265,7 +265,7 @@ export const createCSSPlugin: ComponentPluginFactory<CSSPluginConfig> = (config)
                 `Style used from global stylesheet is missing - ${content.referenceId}`
               )
             }
-            classNamesToAppend.add(content.referenceId)
+            classNamesToAppend.add(StringUtils.camelCaseToDashCase(content.referenceId))
             return
           }
 

--- a/packages/teleport-plugin-css/src/style-sheet.ts
+++ b/packages/teleport-plugin-css/src/style-sheet.ts
@@ -9,10 +9,11 @@ import { UIDLUtils } from '@teleporthq/teleport-shared'
 
 interface StyleSheetPlugin {
   fileName?: string
+  forceScoping?: boolean
 }
 
 export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = (config) => {
-  const { fileName } = config || { fileName: 'style' }
+  const { fileName, forceScoping = false } = config || { fileName: 'style', forceScoping: false }
   const styleSheetPlugin: ComponentPlugin = async (structure) => {
     const { uidl, chunks } = structure
     const { styleSetDefinitions = {}, designLanguage: { tokens = {} } = {} } = uidl
@@ -42,7 +43,8 @@ export const createStyleSheetPlugin: ComponentPluginFactory<StyleSheetPlugin> = 
         styleSetDefinitions,
         cssMap,
         mediaStylesMap,
-        UIDLUtils.getComponentClassName(uidl)
+        UIDLUtils.getComponentClassName(uidl),
+        forceScoping
       )
     }
 

--- a/packages/teleport-plugin-react-jss/__tests__/component-referenced.ts
+++ b/packages/teleport-plugin-react-jss/__tests__/component-referenced.ts
@@ -38,7 +38,7 @@ describe('Component Scoped Styles', () => {
     expect(styleChunk).toBeDefined()
     expect(expression.callee.name).toBe('createUseStyles')
     expect(properties.length).toBe(2)
-    expect(properties[0].key.value).toBe('primary-navbar')
+    expect(properties[0].key.value).toBe('primaryNavbar')
     expect(properties[1].key.value).toBe('secondaryNavbar')
   })
 

--- a/packages/teleport-plugin-react-jss/src/index.ts
+++ b/packages/teleport-plugin-react-jss/src/index.ts
@@ -192,7 +192,7 @@ export const createReactJSSPlugin: ComponentPluginFactory<JSSConfig> = (config) 
               classNamesToAppend.add(
                 types.memberExpression(
                   types.identifier('projectStyles'),
-                  types.identifier(`'${content.referenceId}'`),
+                  types.identifier(`'${StringUtils.dashCaseToCamelCase(content.referenceId)}'`),
                   true
                 )
               )

--- a/packages/teleport-plugin-react-jss/src/utils.ts
+++ b/packages/teleport-plugin-react-jss/src/utils.ts
@@ -8,18 +8,11 @@ export const generateStylesFromStyleSetDefinitions = (params: {
   styleSet: Record<string, unknown>
   mediaStyles: Record<string, Record<string, unknown>>
   tokensUsed?: string[]
-  formatClassName?: boolean
 }) => {
-  const {
-    styleSetDefinitions,
-    styleSet,
-    tokensUsed,
-    formatClassName = false,
-    mediaStyles = {},
-  } = params
+  const { styleSetDefinitions, styleSet, tokensUsed, mediaStyles = {} } = params
   Object.keys(styleSetDefinitions).forEach((styleId) => {
     const style = styleSetDefinitions[styleId]
-    const className = formatClassName ? StringUtils.dashCaseToCamelCase(styleId) : styleId
+    const className = StringUtils.dashCaseToCamelCase(styleId)
     const { conditions = [], content } = style
     styleSet[className] = generateStylesFromStyleObj(content, tokensUsed)
 

--- a/packages/teleport-plugin-react-styled-components/src/index.ts
+++ b/packages/teleport-plugin-react-styled-components/src/index.ts
@@ -237,7 +237,11 @@ export const createReactStyledComponentsPlugin: ComponentPluginFactory<StyledCom
               }
               projectStyleReferences.add(projectVariantPropPrefix)
 
-              ASTUtils.addAttributeToJSXTag(root, projectVariantPropKey, content.referenceId)
+              ASTUtils.addAttributeToJSXTag(
+                root,
+                projectVariantPropKey,
+                StringUtils.dashCaseToCamelCase(content.referenceId)
+              )
               return
             }
             default: {

--- a/packages/teleport-plugin-react-styled-components/src/utils.ts
+++ b/packages/teleport-plugin-react-styled-components/src/utils.ts
@@ -158,7 +158,7 @@ export const generateVariantsfromStyleSet = (
       const { content = {}, conditions = [] } = style
 
       const property = types.objectProperty(
-        types.stringLiteral(styleId),
+        types.stringLiteral(StringUtils.dashCaseToCamelCase(styleId)),
         generateStyledComponentStyles({
           styles: content,
           ...(tokensReferred && { tokensReferred }),

--- a/packages/teleport-plugin-react-styled-jsx/__tests__/component-scoped.ts
+++ b/packages/teleport-plugin-react-styled-jsx/__tests__/component-scoped.ts
@@ -38,7 +38,7 @@ describe('Component Scoped Styles', () => {
 
     expect(chunks.length).toBe(1)
     expect(styles).toContain('primary-navbar')
-    expect(styles).toContain('.secondaryNavbar')
+    expect(styles).toContain('.secondary-navbar')
   })
 
   it('Generates style sheet and adds them to the node with JSX template', async () => {

--- a/packages/teleport-plugin-react-styled-jsx/src/index.ts
+++ b/packages/teleport-plugin-react-styled-jsx/src/index.ts
@@ -138,7 +138,7 @@ export const createReactStyledJSXPlugin: ComponentPluginFactory<StyledJSXConfig>
               )
             }
 
-            classNamesToAppend.add(content.referenceId)
+            classNamesToAppend.add(StringUtils.camelCaseToDashCase(content.referenceId))
             return
           }
 

--- a/packages/teleport-project-generator-gridsome/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-gridsome/__tests__/end2end/index.ts
@@ -37,7 +37,7 @@ describe('Gridsome Project Generator', () => {
     expect(mainFile.content).toContain(`import \"~/./assets/style.css`)
     expect(assetsFoler.files.length).toBe(1)
     expect(assetsFoler.files[0].name).toBe('style')
-    expect(assetsFoler.files[0].content).toContain(`.primaryButton`)
+    expect(assetsFoler.files[0].content).toContain(`.primary-button`)
   })
 
   it('runs without crashing with external dependencies with supported syntaxes', async () => {

--- a/packages/teleport-project-generator-next/src/index.ts
+++ b/packages/teleport-project-generator-next/src/index.ts
@@ -21,6 +21,7 @@ const createNextProjectGenerator = () => {
   })
   const styleSheetPlugin = createStyleSheetPlugin({
     fileName: 'style',
+    forceScoping: false,
   })
 
   const generator = createProjectGenerator({

--- a/packages/teleport-project-packer/src/index.ts
+++ b/packages/teleport-project-packer/src/index.ts
@@ -19,9 +19,7 @@ export interface PackerFactoryParams {
   assets?: AssetsDefinition
 }
 
-export type PackerFactory = (
-  params?: PackerFactoryParams
-) => {
+export type PackerFactory = (params?: PackerFactoryParams) => {
   pack: (
     projectUIDL?: ProjectUIDL,
     params?: PackerFactoryParams


### PR DESCRIPTION
- Includes `scoping` for styles on nodes and disable scoping on `global` styles in NextJS
- Update for NextJS template, now the next projects work with `next-with-css-modules`
- Refactoring `naming` conventions for all style plugins. Either to follow `cameCase` in terms of `styled-components`, `react-jss` to `dashCase` in `css-modules`, `css`, `styled-jsx`