### PR TITLE
fix(proj-react): resolving static url assets using craco for cra template

### DIFF
--- a/packages/teleport-project-generator-react/src/project-template.ts
+++ b/packages/teleport-project-generator-react/src/project-template.ts
@@ -9,16 +9,17 @@ export default {
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@craco/craco": "^6.4.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test --env=jsdom",
+    "eject": "craco eject"
   },
   "browserslist": {
     "production": [
@@ -34,6 +35,22 @@ export default {
   }
 }`,
       fileType: 'json',
+    },
+    {
+      name: 'craco.config',
+      fileType: 'js',
+      content: `module.exports = {
+  reactScriptsVersion: "react-scripts",
+  style: {
+    css: {
+      loaderOptions: () => {
+        return {
+          url: false,
+        };
+      },
+    },
+  },
+};`,
     },
   ],
   subFolders: [],


### PR DESCRIPTION
For using images in crate-react-app. In js files, we need to import using 

```jsx
const Home = (props) => {
  return (
    <div className={styles['container']}>
      <img
        alt="image"
        src="/playground_assets/screenshot%202022-05-09%20at%205.46.56%20pm-400h.png"
        className={styles['image']}
      />
      <div className={styles['container1']}></div>
    </div>
  )
}
```

but while using the same image in `css` files

```css
.container1 {
  flex: 0 0 auto;
  width: 200px;
  border: 2px dashed rgba(120, 120, 120, 0.4);
  height: 400px;
  display: flex;
  align-items: flex-start;
  background-size: cover;
  background-image: url("/playground_assets/screenshot%202022-05-09%20at%205.46.56%20pm-400h.png");
}
```

this syntax doesn't work. The url actually exists, because the `public` folder is copied into the `build` after the `npm run build`. But, `webpack` fails to resolve the same during building. This `craco` helps in disabling `url` loader for css files. 