### PR TITLE
(feat) - Adds support for tailwind in angular, vue and craco based react frameworks

### DIFF
--- a/examples/uidl-samples/project-tailwind.json
+++ b/examples/uidl-samples/project-tailwind.json
@@ -1,0 +1,596 @@
+{
+  "name": "Nocturnal Tender Magpie",
+  "globals": {
+    "settings": {
+      "title": "Nocturnal Tender Magpie",
+      "language": "en"
+    },
+    "assets": [
+      {
+        "type": "style",
+        "attrs": {
+          "data-tag": {
+            "type": "static",
+            "content": "reset-style-sheet"
+          }
+        },
+        "content": "html {  line-height: 1.15;}body {  margin: 0;}* {  box-sizing: border-box;  border-width: 0;  border-style: solid;}p,li,ul,pre,div,h1,h2,h3,h4,h5,h6 {  margin: 0;  padding: 0;}button,input,optgroup,select,textarea {  font-family: inherit;  font-size: 100%;  line-height: 1.15;  margin: 0;}button,select {  text-transform: none;}button,[type=\"button\"],[type=\"reset\"],[type=\"submit\"] {  -webkit-appearance: button;}button::-moz-focus-inner,[type=\"button\"]::-moz-focus-inner,[type=\"reset\"]::-moz-focus-inner,[type=\"submit\"]::-moz-focus-inner {  border-style: none;  padding: 0;}button:-moz-focus,[type=\"button\"]:-moz-focus,[type=\"reset\"]:-moz-focus,[type=\"submit\"]:-moz-focus {  outline: 1px dotted ButtonText;}a {  color: inherit;  text-decoration: inherit;}input {  padding: 2px 4px;}img {  display: block;}html { scroll-behavior: smooth  }"
+      },
+      {
+        "type": "style",
+        "attrs": {
+          "data-tag": {
+            "type": "static",
+            "content": "default-style-sheet"
+          }
+        },
+        "content": "\n  html {\n    font-family: Inter;\n    font-size: 16px;\n  }\n\n  body {\n    font-weight: 400;\n    font-style:normal;\n    text-decoration: none;\n    text-transform: none;\n    letter-spacing: normal;\n    line-height: 1.15;\n    color: var(--dl-color-gray-black);\n    background-color: var(--dl-color-gray-white);\n    \n  }\n\n  \n"
+      },
+      {
+        "type": "font",
+        "path": "https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap",
+        "attrs": {
+          "data-tag": {
+            "type": "static",
+            "content": "font"
+          }
+        }
+      }
+    ],
+    "meta": [
+      {
+        "name": "viewport",
+        "content": "width=device-width, initial-scale=1.0"
+      },
+      {
+        "charSet": "utf-8"
+      },
+      {
+        "property": "twitter:card",
+        "content": "summary_large_image"
+      }
+    ],
+    "customCode": {}
+  },
+  "root": {
+    "name": "App",
+    "designLanguage": {
+      "tokens": {
+        "--dl-color-primary-300": {
+          "type": "static",
+          "content": "#0074F0"
+        },
+        "--dl-radius-radius-radius8": {
+          "type": "static",
+          "content": "8px"
+        },
+        "--dl-space-space-unit": {
+          "type": "static",
+          "content": "16px"
+        },
+        "--dl-size-size-maxwidth": {
+          "type": "static",
+          "content": "1400px"
+        },
+        "--dl-space-space-oneandhalfunits": {
+          "type": "static",
+          "content": "24px"
+        },
+        "--dl-color-danger-700": {
+          "type": "static",
+          "content": "#E14747"
+        },
+        "--dl-size-size-xxlarge": {
+          "type": "static",
+          "content": "288px"
+        },
+        "--dl-size-size-xsmall": {
+          "type": "static",
+          "content": "16px"
+        },
+        "--dl-space-space-fiveunits": {
+          "type": "static",
+          "content": "80px"
+        },
+        "--dl-color-danger-500": {
+          "type": "static",
+          "content": "#BF2626"
+        },
+        "--dl-radius-radius-round": {
+          "type": "static",
+          "content": "50%"
+        },
+        "--dl-space-space-sixunits": {
+          "type": "static",
+          "content": "96px"
+        },
+        "--dl-radius-radius-radius4": {
+          "type": "static",
+          "content": "4px"
+        },
+        "--dl-color-success-700": {
+          "type": "static",
+          "content": "#4CC366"
+        },
+        "--dl-radius-radius-radius2": {
+          "type": "static",
+          "content": "2px"
+        },
+        "--dl-space-space-halfunit": {
+          "type": "static",
+          "content": "8px"
+        },
+        "--dl-color-gray-500": {
+          "type": "static",
+          "content": "#595959"
+        },
+        "--dl-color-gray-black": {
+          "type": "static",
+          "content": "#000000"
+        },
+        "--dl-color-primary-500": {
+          "type": "static",
+          "content": "#14A9FF"
+        },
+        "--dl-color-primary-100": {
+          "type": "static",
+          "content": "#003EB3"
+        },
+        "--dl-color-success-500": {
+          "type": "static",
+          "content": "#32A94C"
+        },
+        "--dl-color-gray-700": {
+          "type": "static",
+          "content": "#999999"
+        },
+        "--dl-color-primary-700": {
+          "type": "static",
+          "content": "#85DCFF"
+        },
+        "--dl-size-size-small": {
+          "type": "static",
+          "content": "48px"
+        },
+        "--dl-space-space-fourunits": {
+          "type": "static",
+          "content": "64px"
+        },
+        "--dl-color-gray-900": {
+          "type": "static",
+          "content": "#D9D9D9"
+        },
+        "--dl-color-danger-300": {
+          "type": "static",
+          "content": "#A22020"
+        },
+        "--dl-space-space-threeunits": {
+          "type": "static",
+          "content": "48px"
+        },
+        "--dl-size-size-xlarge": {
+          "type": "static",
+          "content": "192px"
+        },
+        "--dl-size-size-medium": {
+          "type": "static",
+          "content": "96px"
+        },
+        "--dl-color-success-300": {
+          "type": "static",
+          "content": "#199033"
+        },
+        "--dl-space-space-twounits": {
+          "type": "static",
+          "content": "32px"
+        },
+        "--dl-color-gray-white": {
+          "type": "static",
+          "content": "#FFFFFF"
+        },
+        "--dl-size-size-large": {
+          "type": "static",
+          "content": "144px"
+        }
+      }
+    },
+    "styleSetDefinitions": {
+      "button": {
+        "type": "reusable-project-style-map",
+        "content": {
+          "color": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-black"
+            }
+          },
+          "display": {
+            "type": "static",
+            "content": "inline-block"
+          },
+          "padding": {
+            "type": "static",
+            "content": "0.5rem 1rem"
+          },
+          "borderColor": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-black"
+            }
+          },
+          "borderWidth": {
+            "type": "static",
+            "content": "1px"
+          },
+          "borderRadius": {
+            "type": "static",
+            "content": "4px"
+          },
+          "backgroundColor": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-white"
+            }
+          }
+        },
+        "conditions": []
+      },
+      "input": {
+        "type": "reusable-project-style-map",
+        "content": {
+          "color": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-black"
+            }
+          },
+          "cursor": {
+            "type": "static",
+            "content": "auto"
+          },
+          "padding": {
+            "type": "static",
+            "content": "0.5rem 1rem"
+          },
+          "borderColor": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-black"
+            }
+          },
+          "borderWidth": {
+            "type": "static",
+            "content": "1px"
+          },
+          "borderRadius": {
+            "type": "static",
+            "content": "4px"
+          },
+          "backgroundColor": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-white"
+            }
+          }
+        },
+        "conditions": []
+      },
+      "textarea": {
+        "type": "reusable-project-style-map",
+        "content": {
+          "color": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-black"
+            }
+          },
+          "cursor": {
+            "type": "static",
+            "content": "auto"
+          },
+          "padding": {
+            "type": "static",
+            "content": "0.5rem"
+          },
+          "borderColor": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-black"
+            }
+          },
+          "borderWidth": {
+            "type": "static",
+            "content": "1px"
+          },
+          "borderRadius": {
+            "type": "static",
+            "content": "4px"
+          },
+          "backgroundColor": {
+            "type": "dynamic",
+            "content": {
+              "referenceType": "token",
+              "id": "--dl-color-gray-white"
+            }
+          }
+        },
+        "conditions": []
+      },
+      "list": {
+        "type": "reusable-project-style-map",
+        "content": {
+          "width": {
+            "type": "static",
+            "content": "100%"
+          },
+          "margin": {
+            "type": "static",
+            "content": "1em 0px 1em 0px"
+          },
+          "display": {
+            "type": "static",
+            "content": "block"
+          },
+          "padding": {
+            "type": "static",
+            "content": "0px 0px 0px 1.5rem"
+          },
+          "listStyleType": {
+            "type": "static",
+            "content": "none"
+          },
+          "listStylePosition": {
+            "type": "static",
+            "content": "outside"
+          }
+        },
+        "conditions": []
+      },
+      "list-item": {
+        "type": "reusable-project-style-map",
+        "content": {
+          "display": {
+            "type": "static",
+            "content": "list-item"
+          }
+        },
+        "conditions": []
+      },
+      "teleport-show": {
+        "type": "reusable-project-style-map",
+        "content": {
+          "display": {
+            "type": "static",
+            "content": "flex !important"
+          }
+        },
+        "conditions": []
+      },
+      "content": {
+        "type": "reusable-project-style-map",
+        "content": {
+          "fontSize": {
+            "type": "static",
+            "content": "16px"
+          },
+          "fontFamily": {
+            "type": "static",
+            "content": "Inter"
+          },
+          "fontWeight": {
+            "type": "static",
+            "content": "400"
+          },
+          "lineHeight": {
+            "type": "static",
+            "content": "1.15"
+          },
+          "textTransform": {
+            "type": "static",
+            "content": "none"
+          },
+          "textDecoration": {
+            "type": "static",
+            "content": "none"
+          }
+        }
+      },
+      "heading": {
+        "type": "reusable-project-style-map",
+        "content": {
+          "fontSize": {
+            "type": "static",
+            "content": "32px"
+          },
+          "fontFamily": {
+            "type": "static",
+            "content": "Inter"
+          },
+          "fontWeight": {
+            "type": "static",
+            "content": "700"
+          },
+          "lineHeight": {
+            "type": "static",
+            "content": "1.15"
+          },
+          "textTransform": {
+            "type": "static",
+            "content": "none"
+          },
+          "textDecoration": {
+            "type": "static",
+            "content": "none"
+          }
+        }
+      }
+    },
+    "stateDefinitions": {
+      "route": {
+        "type": "string",
+        "defaultValue": "Home",
+        "values": [
+          {
+            "value": "Home",
+            "seo": {
+              "title": "Nocturnal Tender Magpie",
+              "metaTags": [
+                {
+                  "property": "og:title",
+                  "content": "Nocturnal Tender Magpie"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "node": {
+      "type": "element",
+      "content": {
+        "elementType": "Router",
+        "children": [
+          {
+            "type": "conditional",
+            "content": {
+              "node": {
+                "type": "element",
+                "content": {
+                  "elementType": "container",
+                  "referencedStyles": {},
+                  "abilities": {},
+                  "style": {
+                    "width": {
+                      "type": "static",
+                      "content": "100%"
+                    },
+                    "display": {
+                      "type": "static",
+                      "content": "flex"
+                    },
+                    "overflow": {
+                      "type": "static",
+                      "content": "auto"
+                    },
+                    "minHeight": {
+                      "type": "static",
+                      "content": "100vh"
+                    },
+                    "alignItems": {
+                      "type": "static",
+                      "content": "center"
+                    },
+                    "flexDirection": {
+                      "type": "static",
+                      "content": "row"
+                    },
+                    "justifyContent": {
+                      "type": "static",
+                      "content": "center"
+                    }
+                  },
+                  "children": [
+                    {
+                      "type": "element",
+                      "content": {
+                        "elementType": "text",
+                        "referencedStyles": {
+                          "e19e6d07-860e-4fe7-9d0d-a23a02c58157": {
+                            "type": "style-map",
+                            "content": {
+                              "conditions": [
+                                {
+                                  "content": "hover",
+                                  "conditionType": "element-state"
+                                }
+                              ],
+                              "mapType": "inlined",
+                              "styles": {
+                                "color": {
+                                  "type": "dynamic",
+                                  "content": {
+                                    "referenceType": "token",
+                                    "id": "--dl-color-primary-100"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "abilities": {},
+                        "style": {
+                          "color": {
+                            "type": "dynamic",
+                            "content": {
+                              "referenceType": "token",
+                              "id": "--dl-color-primary-500"
+                            }
+                          },
+                          "transition": {
+                            "type": "static",
+                            "content": "0.3s"
+                          }
+                        },
+                        "children": [
+                          {
+                            "type": "static",
+                            "content": "Heading"
+                          }
+                        ],
+                        "semanticType": "h1"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "content": {
+                        "elementType": "text",
+                        "referencedStyles": {
+                          "85acbda4-547b-464e-9027-9c78f8822687": {
+                            "type": "style-map",
+                            "content": {
+                              "mapType": "component-referenced",
+                              "content": {
+                                "type": "static",
+                                "content": "hover:text-purple-100 text-purple-500"
+                              }
+                            }
+                          }
+                        },
+                        "abilities": {},
+                        "children": [
+                          {
+                            "type": "static",
+                            "content": "Heading"
+                          }
+                        ],
+                        "semanticType": "h1"
+                      }
+                    }
+                  ],
+                  "semanticType": "div"
+                }
+              },
+              "value": "Home",
+              "reference": {
+                "type": "dynamic",
+                "content": {
+                  "referenceType": "state",
+                  "id": "route"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "components": {}
+}

--- a/packages/teleport-code-generator/src/index.ts
+++ b/packages/teleport-code-generator/src/index.ts
@@ -112,17 +112,17 @@ const componentGeneratorProjectMappings = {
 }
 
 const projectGeneratorFactories = {
-  [ProjectType.REACT]: createReactProjectGenerator(),
-  [ProjectType.NEXT]: createNextProjectGenerator(),
-  [ProjectType.VUE]: createVueProjectGenerator(),
-  [ProjectType.NUXT]: createNuxtProjectGenerator(),
-  [ProjectType.PREACT]: createPreactProjectGenerator(),
-  [ProjectType.STENCIL]: createStencilProjectGenerator(),
-  [ProjectType.ANGULAR]: createAngularProjectGenerator(),
-  [ProjectType.REACTNATIVE]: createReactNativeProjectGenerator(),
-  [ProjectType.GRIDSOME]: createGridsomeProjectGenerator(),
-  [ProjectType.GATSBY]: createGatsbyProjectGenerator(),
-  [ProjectType.HTML]: createHTMLProjectGenerator(),
+  [ProjectType.REACT]: createReactProjectGenerator,
+  [ProjectType.NEXT]: createNextProjectGenerator,
+  [ProjectType.VUE]: createVueProjectGenerator,
+  [ProjectType.NUXT]: createNuxtProjectGenerator,
+  [ProjectType.PREACT]: createPreactProjectGenerator,
+  [ProjectType.STENCIL]: createStencilProjectGenerator,
+  [ProjectType.ANGULAR]: createAngularProjectGenerator,
+  [ProjectType.REACTNATIVE]: createReactNativeProjectGenerator,
+  [ProjectType.GRIDSOME]: createGridsomeProjectGenerator,
+  [ProjectType.GATSBY]: createGatsbyProjectGenerator,
+  [ProjectType.HTML]: createHTMLProjectGenerator,
 }
 
 const templates = {
@@ -167,7 +167,7 @@ export const packProject: PackProjectFunction = async (
     publisher = projectPublisherFactories[publisherType]
   }
 
-  const projectGeneratorFactory = projectGeneratorFactories[projectType]
+  const projectGeneratorFactory = projectGeneratorFactories[projectType]()
   projectGeneratorFactory.cleanPlugins()
 
   if (projectType === ProjectType.HTML) {

--- a/packages/teleport-project-generator-angular/src/project-template.ts
+++ b/packages/teleport-project-generator-angular/src/project-template.ts
@@ -18,24 +18,24 @@ export const template: GeneratedFolder = {
   },
   "private": true,
   "dependencies": {
-    "@angular/common": "~12.0.3",
-    "@angular/compiler": "~12.0.3",
-    "@angular/core": "~12.0.3",
-    "@angular/forms": "~12.0.3",
-    "@angular/platform-browser": "~12.0.3",
-    "@angular/platform-browser-dynamic": "~12.0.3",
-    "@angular/router": "~12.0.3",
+    "@angular/common": "^14.0.0",
+    "@angular/compiler": "^14.0.0",
+    "@angular/core": "^14.0.0",
+    "@angular/forms": "^14.0.0",
+    "@angular/platform-browser": "^14.0.0",
+    "@angular/platform-browser-dynamic": "^14.0.0",
+    "@angular/router": "^14.0.0",
+    "core-js": "~3.0.1",
     "rxjs": "~6.6.0",
     "tslib": "^2.1.0",
-    "core-js": "~3.0.1",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.900.7",
-    "@angular/cli": "~12.0.3",
-    "@angular/compiler-cli": "~12.0.3",
+    "@angular-devkit/build-angular": "^14.0.0",
+    "@angular/cli": "^14.0.0",
+    "@angular/compiler-cli": "^14.0.0",
     "@types/node": "^12.11.1",
-    "typescript": "~4.2.3"
+    "typescript": "^4.7.3"
   }
 }`,
       fileType: 'json',
@@ -63,7 +63,7 @@ export const template: GeneratedFolder = {
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "aot": false,
+            "aot": true,
             "assets": [
               "src/favicon.ico",
               "src/assets"

--- a/packages/teleport-project-generator-nuxt/src/project-template.ts
+++ b/packages/teleport-project-generator-nuxt/src/project-template.ts
@@ -15,8 +15,8 @@ export default {
     "start": "nuxt start",
     "generate": "nuxt generate"
   },
-  "dependencies": {
-    "nuxt": "^2.15.6"
+  "devDependencies": {
+    "nuxt": "^2.15.8"
   }
 }`,
       fileType: 'json',

--- a/packages/teleport-project-generator-preact/src/project-template.ts
+++ b/packages/teleport-project-generator-preact/src/project-template.ts
@@ -32,7 +32,7 @@ export default {
     "eslint-config-preact": "^1.1.0",
     "jest": "^24.9.0",
     "jest-preset-preact": "^1.0.0",
-    "preact-cli": "^3.0.0",
+    "preact-cli": "^3.3.5",
     "sirv-cli": "1.0.3"
   },
   "dependencies": {

--- a/packages/teleport-project-generator-react/src/project-template.ts
+++ b/packages/teleport-project-generator-react/src/project-template.ts
@@ -12,8 +12,7 @@ export default {
     "@craco/craco": "^6.4.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^5.2.0",
-    "react-scripts": "4.0.3"
+    "react-router-dom": "^5.2.0"
   },
   "scripts": {
     "start": "craco start",
@@ -32,6 +31,9 @@ export default {
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "react-scripts": "^5.0.1"
   }
 }`,
       fileType: 'json',

--- a/packages/teleport-project-generator-stencil/src/project-template.ts
+++ b/packages/teleport-project-generator-stencil/src/project-template.ts
@@ -15,7 +15,7 @@ export default {
     "start": "stencil build --dev --watch --serve"
   },
   "dependencies": {
-    "@stencil/core": "^1.2.1",
+    "@stencil/core": "^2.16.1",
     "@stencil/router": "^1.0.1"
   }
 }`,
@@ -47,6 +47,7 @@ export const config: Config = {
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "declaration": false,
+    "skipLibCheck": true,
     "experimentalDecorators": true,
     "lib": [
       "dom",

--- a/packages/teleport-project-generator-vue/src/project-template.ts
+++ b/packages/teleport-project-generator-vue/src/project-template.ts
@@ -18,8 +18,8 @@ export default {
     "vue-meta": "^2.2.1"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.4.1",
-    "@vue/cli-service": "^3.4.1",
+    "@vue/cli-plugin-babel": "^5.0.4",
+    "@vue/cli-service": "^5.0.4",
     "vue-template-compiler": "^2.6.7"
   },
   "postcss": {
@@ -34,6 +34,19 @@ export default {
   ]
 }`,
       fileType: 'json',
+    },
+    {
+      name: 'vue.config',
+      fileType: 'js',
+      content: `module.exports = {
+  css: {
+    loaderOptions: {
+      css: {
+        url: false,
+      },
+    },
+  },
+};`,
     },
     {
       name: 'babel.config',

--- a/packages/teleport-project-plugin-tailwind/__tests__/index.ts
+++ b/packages/teleport-project-plugin-tailwind/__tests__/index.ts
@@ -34,8 +34,6 @@ describe('Plugins adds tailwind as devDependnecy when used with Next', () => {
     })
     const plugin = new ProjectPluginTailwind({
       framework: ProjectType.NEXT,
-      config: {},
-      css: `.tailwind-class{ }`,
     })
     const { files } = await plugin.runAfter(structure)
     const appFile = files.get('_app').files[0]
@@ -62,8 +60,6 @@ describe('Plugins adds tailwind as devDependnecy when used with Next', () => {
 
     const plugin = new ProjectPluginTailwind({
       framework: ProjectType.NEXT,
-      config: {},
-      css: `.tailwind-class{ }`,
     })
     const { files } = await plugin.runAfter(structure)
 

--- a/packages/teleport-project-plugin-tailwind/package.json
+++ b/packages/teleport-project-plugin-tailwind/package.json
@@ -24,6 +24,9 @@
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.json --module commonjs --outDir dist/cjs"
   },
   "dependencies": {
-    "@teleporthq/teleport-types": "^0.21.7"
+    "@teleporthq/teleport-types": "^0.21.7",
+    "@teleporthq/teleport-plugin-react-app-routing": "^0.21.7",
+    "@teleporthq/teleport-plugin-css": "^0.21.7",
+    "@teleporthq/teleport-plugin-import-statements": "^0.21.7"
   }
 }

--- a/packages/teleport-project-plugin-tailwind/src/angular.ts
+++ b/packages/teleport-project-plugin-tailwind/src/angular.ts
@@ -1,17 +1,17 @@
 import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
 import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
-export const vueTailwindModifier = async (
+export const angularTailwindModifier = async (
   structure: ProjectPluginStructure,
   config: Record<string, unknown>,
   css: string
 ): Promise<void> => {
-  const { devDependencies, files, rootFolder } = structure
-  config.content = ['./src/**/*.{vue,js,ts,jsx,tsx}']
+  const { devDependencies, files } = structure
+  config.content = ['./src/**/*.{html,ts}']
 
   const projectSheet = files
     .get('projectStyleSheet')
-    ?.files.find((file) => file.name === 'style' && file.fileType === FileType.CSS)
+    ?.files.find((file) => file.name === 'styles' && file.fileType === FileType.CSS)
   let globalStyleSheet = css
 
   if (projectSheet) {
@@ -36,34 +36,21 @@ export const vueTailwindModifier = async (
         fileType: FileType.JS,
         content: `module.exports = ${JSON.stringify(config, null, 2)}`,
       },
+      {
+        name: 'postcss.config',
+        fileType: FileType.JS,
+        content: `module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};`,
+      },
     ],
     path: [''],
-  })
-
-  rootFolder.files.forEach((file) => {
-    const { name, fileType } = file
-
-    if (name === 'package' && fileType === 'json') {
-      const jsonContent = JSON.parse(file.content)
-      if (jsonContent?.postcss) {
-        jsonContent.postcss.plugins = {
-          ...(jsonContent.postcss?.plugins || {}),
-          tailwindcss: {},
-        }
-      } else {
-        jsonContent.postcss = {
-          plugins: {
-            autoprefixer: {},
-            tailwindcss: {},
-          },
-        }
-      }
-      file.content = JSON.stringify(jsonContent, null, 2)
-    }
   })
 
   devDependencies.autoprefixer = AUTO_PREFIXER
   devDependencies.postcss = POSTCSS
   devDependencies.tailwindcss = TAILWIND
-  devDependencies['postcss-loader'] = '^7.0.0'
 }

--- a/packages/teleport-project-plugin-tailwind/src/angular.ts
+++ b/packages/teleport-project-plugin-tailwind/src/angular.ts
@@ -1,11 +1,9 @@
-import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
+import { FileType } from '@teleporthq/teleport-types'
+import { TailwindPluginParams } from '.'
 import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
-export const angularTailwindModifier = async (
-  structure: ProjectPluginStructure,
-  config: Record<string, unknown>,
-  css: string
-): Promise<void> => {
+export const angularTailwindModifier = async (params: TailwindPluginParams): Promise<void> => {
+  const { structure, css, config, path } = params
   const { devDependencies, files } = structure
   config.content = ['./src/**/*.{html,ts}']
 
@@ -20,7 +18,7 @@ export const angularTailwindModifier = async (
   }
 
   files.set('projectStyleSheet', {
-    path: ['src'],
+    path: path || ['src'],
     files: [
       {
         ...projectSheet,

--- a/packages/teleport-project-plugin-tailwind/src/constants.ts
+++ b/packages/teleport-project-plugin-tailwind/src/constants.ts
@@ -1,0 +1,3 @@
+export const AUTO_PREFIXER = '^10.4.7'
+export const TAILWIND = '^3.0.24'
+export const POSTCSS = '^8.4.14'

--- a/packages/teleport-project-plugin-tailwind/src/default.ts
+++ b/packages/teleport-project-plugin-tailwind/src/default.ts
@@ -12,20 +12,22 @@ export const defaultTailwindModifier = async (
   const projectSheet = files
     .get('projectStyleSheet')
     ?.files.find((file) => file.name === 'style' && file.fileType === FileType.CSS)
+  let globalStyleSheet = css
 
   if (projectSheet) {
     files.delete('projectStyleSheet')
-    files.set('projectStyleSheet', {
-      path: ['src', 'teleporthq'],
-      files: [
-        {
-          ...projectSheet,
-          content: `${css}\n${projectSheet.content}`,
-        },
-      ],
-    })
+    globalStyleSheet = `${globalStyleSheet} \n \n ${projectSheet.content}`
   }
 
+  files.set('projectStyleSheet', {
+    path: ['src', 'teleporthq'],
+    files: [
+      {
+        ...projectSheet,
+        content: globalStyleSheet,
+      },
+    ],
+  })
   files.set('tailwindConfig', {
     files: [
       {

--- a/packages/teleport-project-plugin-tailwind/src/index.ts
+++ b/packages/teleport-project-plugin-tailwind/src/index.ts
@@ -1,10 +1,21 @@
-import { ProjectPlugin, ProjectPluginStructure, ProjectType } from '@teleporthq/teleport-types'
+import {
+  FileType,
+  PreactStyleVariation,
+  ProjectPlugin,
+  ProjectPluginStructure,
+  ProjectType,
+} from '@teleporthq/teleport-types'
 import { nextJSTailwindModifier } from './next'
 import { defaultTailwindModifier } from './default'
 import { reactTailwindModifier } from './react'
 import { vueTailwindModifier } from './vue'
 import { angularTailwindModifier } from './angular'
 import { nuxtTailwindModifier } from './nuxt'
+import { preactTailwindModifier } from './preact'
+import { stencilTailwindModifier } from './stencil'
+import { createCSSPlugin, createStyleSheetPlugin } from '@teleporthq/teleport-plugin-css'
+import { createReactAppRoutingPlugin } from '@teleporthq/teleport-plugin-react-app-routing'
+import importStatementsPlugin from '@teleporthq/teleport-plugin-import-statements'
 
 export type SUPPORTED_TAILWIND_FRAMEWORKS =
   | ProjectType.HTML
@@ -13,6 +24,8 @@ export type SUPPORTED_TAILWIND_FRAMEWORKS =
   | ProjectType.VUE
   | ProjectType.NUXT
   | ProjectType.ANGULAR
+  | ProjectType.PREACT
+  | ProjectType.STENCIL
 
 export interface TailwindPluginParams {
   structure: ProjectPluginStructure
@@ -31,6 +44,8 @@ const frameworkMap: Record<
   [ProjectType.VUE]: vueTailwindModifier,
   [ProjectType.ANGULAR]: angularTailwindModifier,
   [ProjectType.NUXT]: nuxtTailwindModifier,
+  [ProjectType.PREACT]: preactTailwindModifier,
+  [ProjectType.STENCIL]: stencilTailwindModifier,
 }
 
 export class ProjectPluginTailwind implements ProjectPlugin {
@@ -53,6 +68,29 @@ export class ProjectPluginTailwind implements ProjectPlugin {
   }
 
   async runBefore(structure: ProjectPluginStructure) {
+    if (this.framework === ProjectType.PREACT) {
+      const { strategy, rootFolder } = structure
+      strategy.style = PreactStyleVariation.CSS
+      const styleSheetPlugin = createStyleSheetPlugin({
+        fileName: 'global-style',
+      })
+      const routerPlugin = createReactAppRoutingPlugin({ flavor: 'preact' })
+
+      strategy.projectStyleSheet.plugins = [styleSheetPlugin]
+      strategy.router.plugins = [routerPlugin, createCSSPlugin(), importStatementsPlugin]
+
+      rootFolder.files.push({
+        name: 'preact.config',
+        fileType: FileType.JS,
+        content: `export default (config, env, helpers, options) => {
+    const css = helpers.getLoadersByName(config, 'css-loader')[0];
+    css.loader.options.modules = false;
+}`,
+      })
+
+      return structure
+    }
+
     return structure
   }
 

--- a/packages/teleport-project-plugin-tailwind/src/index.ts
+++ b/packages/teleport-project-plugin-tailwind/src/index.ts
@@ -1,37 +1,38 @@
 import { ProjectPlugin, ProjectPluginStructure, ProjectType } from '@teleporthq/teleport-types'
 import { nextJSTailwindModifier } from './nextjs'
 import { defaultTailwindModifier } from './default'
+import { reactTailwindModifier } from './react'
+import { vueTailwindModifier } from './vue'
 
-type SUPPORTED_FRAMEWORKS = ProjectType.HTML | ProjectType.NEXT
+type SUPPORTED_FRAMEWORKS =
+  | ProjectType.HTML
+  | ProjectType.NEXT
+  | ProjectType.REACT
+  | ProjectType.VUE
 
 const frameworkMap: Record<
   SUPPORTED_FRAMEWORKS,
-  (
-    structure: ProjectPluginStructure,
-    config: Record<string, unknown>,
-    content: string[],
-    css: string
-  ) => Promise<void>
+  (structure: ProjectPluginStructure, config: Record<string, unknown>, css: string) => Promise<void>
 > = {
   [ProjectType.NEXT]: nextJSTailwindModifier,
   [ProjectType.HTML]: defaultTailwindModifier,
+  [ProjectType.REACT]: reactTailwindModifier,
+  [ProjectType.VUE]: vueTailwindModifier,
 }
 
 export class ProjectPluginTailwind implements ProjectPlugin {
   config: Record<string, unknown>
-  content: string[]
   css: string
   framework: SUPPORTED_FRAMEWORKS
 
   constructor(params: {
     config?: Record<string, unknown>
-    css: string
-    content?: string[]
+    css?: string
     framework?: SUPPORTED_FRAMEWORKS
   }) {
     this.css = params.css
+    this.css = params?.css || `@tailwind utilities;`
     this.config = params?.config || {}
-    this.content = params?.content || ['./src/**/*.{vue,js,ts,jsx,tsx}']
     this.framework = params?.framework || ProjectType.HTML
   }
 
@@ -44,7 +45,7 @@ export class ProjectPluginTailwind implements ProjectPlugin {
     if (!projectModifier) {
       throw new Error(`Requested ${this.framework} doesn't have a predefined modifier`)
     }
-    await projectModifier(structure, this.config, this.content, this.css)
+    await projectModifier(structure, this.config, this.css)
     return structure
   }
 }

--- a/packages/teleport-project-plugin-tailwind/src/index.ts
+++ b/packages/teleport-project-plugin-tailwind/src/index.ts
@@ -1,42 +1,55 @@
 import { ProjectPlugin, ProjectPluginStructure, ProjectType } from '@teleporthq/teleport-types'
-import { nextJSTailwindModifier } from './nextjs'
+import { nextJSTailwindModifier } from './next'
 import { defaultTailwindModifier } from './default'
 import { reactTailwindModifier } from './react'
 import { vueTailwindModifier } from './vue'
 import { angularTailwindModifier } from './angular'
+import { nuxtTailwindModifier } from './nuxt'
 
-type SUPPORTED_FRAMEWORKS =
+export type SUPPORTED_TAILWIND_FRAMEWORKS =
   | ProjectType.HTML
   | ProjectType.NEXT
   | ProjectType.REACT
   | ProjectType.VUE
+  | ProjectType.NUXT
   | ProjectType.ANGULAR
 
+export interface TailwindPluginParams {
+  structure: ProjectPluginStructure
+  config: Record<string, unknown>
+  css: string
+  path?: string[]
+}
+
 const frameworkMap: Record<
-  SUPPORTED_FRAMEWORKS,
-  (structure: ProjectPluginStructure, config: Record<string, unknown>, css: string) => Promise<void>
+  SUPPORTED_TAILWIND_FRAMEWORKS,
+  (params: TailwindPluginParams) => Promise<void>
 > = {
   [ProjectType.NEXT]: nextJSTailwindModifier,
   [ProjectType.HTML]: defaultTailwindModifier,
   [ProjectType.REACT]: reactTailwindModifier,
   [ProjectType.VUE]: vueTailwindModifier,
   [ProjectType.ANGULAR]: angularTailwindModifier,
+  [ProjectType.NUXT]: nuxtTailwindModifier,
 }
 
 export class ProjectPluginTailwind implements ProjectPlugin {
   config: Record<string, unknown>
   css: string
-  framework: SUPPORTED_FRAMEWORKS
+  path: string[] | null
+  framework: SUPPORTED_TAILWIND_FRAMEWORKS
 
   constructor(params: {
     config?: Record<string, unknown>
     css?: string
-    framework?: SUPPORTED_FRAMEWORKS
+    framework?: SUPPORTED_TAILWIND_FRAMEWORKS
+    path?: string[]
   }) {
     this.css = params.css
     this.css = params?.css || `@tailwind utilities;`
     this.config = params?.config || {}
     this.framework = params?.framework || ProjectType.HTML
+    this.path = params?.path ?? undefined
   }
 
   async runBefore(structure: ProjectPluginStructure) {
@@ -48,7 +61,7 @@ export class ProjectPluginTailwind implements ProjectPlugin {
     if (!projectModifier) {
       throw new Error(`Requested ${this.framework} doesn't have a predefined modifier`)
     }
-    await projectModifier(structure, this.config, this.css)
+    await projectModifier({ structure, config: this.config, css: this.css, path: this.path })
     return structure
   }
 }

--- a/packages/teleport-project-plugin-tailwind/src/index.ts
+++ b/packages/teleport-project-plugin-tailwind/src/index.ts
@@ -3,12 +3,14 @@ import { nextJSTailwindModifier } from './nextjs'
 import { defaultTailwindModifier } from './default'
 import { reactTailwindModifier } from './react'
 import { vueTailwindModifier } from './vue'
+import { angularTailwindModifier } from './angular'
 
 type SUPPORTED_FRAMEWORKS =
   | ProjectType.HTML
   | ProjectType.NEXT
   | ProjectType.REACT
   | ProjectType.VUE
+  | ProjectType.ANGULAR
 
 const frameworkMap: Record<
   SUPPORTED_FRAMEWORKS,
@@ -18,6 +20,7 @@ const frameworkMap: Record<
   [ProjectType.HTML]: defaultTailwindModifier,
   [ProjectType.REACT]: reactTailwindModifier,
   [ProjectType.VUE]: vueTailwindModifier,
+  [ProjectType.ANGULAR]: angularTailwindModifier,
 }
 
 export class ProjectPluginTailwind implements ProjectPlugin {

--- a/packages/teleport-project-plugin-tailwind/src/next.ts
+++ b/packages/teleport-project-plugin-tailwind/src/next.ts
@@ -1,11 +1,9 @@
-import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
+import { FileType } from '@teleporthq/teleport-types'
+import { TailwindPluginParams } from '.'
 import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
-export const nextJSTailwindModifier = async (
-  structure: ProjectPluginStructure,
-  config: Record<string, unknown>,
-  css: string
-): Promise<void> => {
+export const nextJSTailwindModifier = async (params: TailwindPluginParams): Promise<void> => {
+  const { structure, config, css, path } = params
   const { files, devDependencies } = structure
   config.content = ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}']
 
@@ -16,7 +14,7 @@ export const nextJSTailwindModifier = async (
   if (projectSheet) {
     files.delete('projectStyleSheet')
     files.set('projectStyleSheet', {
-      path: ['pages'],
+      path: path || ['pages'],
       files: [
         {
           ...projectSheet,

--- a/packages/teleport-project-plugin-tailwind/src/nextjs.ts
+++ b/packages/teleport-project-plugin-tailwind/src/nextjs.ts
@@ -15,7 +15,7 @@ export const nextJSTailwindModifier = async (
 
   if (projectSheet) {
     files.delete('projectStyleSheet')
-    files.set('projectsStyleSheet', {
+    files.set('projectStyleSheet', {
       path: ['pages'],
       files: [
         {
@@ -42,7 +42,7 @@ export const nextJSTailwindModifier = async (
         ),
         {
           ...rootFile,
-          content: `import "./global.css"\n${rootFile.content}`,
+          content: `import "./global.css" \n \n ${rootFile.content}`,
         },
       ],
       path: ['pages'],

--- a/packages/teleport-project-plugin-tailwind/src/nextjs.ts
+++ b/packages/teleport-project-plugin-tailwind/src/nextjs.ts
@@ -1,13 +1,13 @@
 import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
+import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
 export const nextJSTailwindModifier = async (
   structure: ProjectPluginStructure,
   config: Record<string, unknown>,
-  content: string[],
   css: string
 ): Promise<void> => {
   const { files, devDependencies } = structure
-  config.content = content
+  config.content = ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}']
 
   const projectSheet = files
     .get('projectStyleSheet')
@@ -15,7 +15,7 @@ export const nextJSTailwindModifier = async (
 
   if (projectSheet) {
     files.delete('projectStyleSheet')
-    files.set('projectStyleSheet', {
+    files.set('projectsStyleSheet', {
       path: ['pages'],
       files: [
         {
@@ -80,7 +80,7 @@ export const nextJSTailwindModifier = async (
     path: [''],
   })
 
-  devDependencies.tailwindcss = '^3.0.24'
-  devDependencies.autoprefixer = '^9.8.6'
-  devDependencies.postcss = '^8.2.15'
+  devDependencies.tailwindcss = TAILWIND
+  devDependencies.autoprefixer = AUTO_PREFIXER
+  devDependencies.postcss = POSTCSS
 }

--- a/packages/teleport-project-plugin-tailwind/src/nuxt.ts
+++ b/packages/teleport-project-plugin-tailwind/src/nuxt.ts
@@ -2,10 +2,16 @@ import { FileType } from '@teleporthq/teleport-types'
 import { TailwindPluginParams } from '.'
 import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
-export const defaultTailwindModifier = async (params: TailwindPluginParams): Promise<void> => {
+export const nuxtTailwindModifier = async (params: TailwindPluginParams): Promise<void> => {
   const { structure, config, css, path } = params
-  const { files, devDependencies } = structure
-  config.content = ['./src/**/*.{html,js,ts,jsx,tsx}', './*.{html}']
+  const { devDependencies, files } = structure
+  config.content = [
+    './components/**/*.{js,vue,ts}',
+    './layouts/**/*.vue',
+    './pages/**/*.vue',
+    './plugins/**/*.{js,ts}',
+    './nuxt.config.{js,ts}',
+  ]
 
   const projectSheet = files
     .get('projectStyleSheet')
@@ -18,7 +24,7 @@ export const defaultTailwindModifier = async (params: TailwindPluginParams): Pro
   }
 
   files.set('projectStyleSheet', {
-    path: path || ['src', 'teleporthq'],
+    path: path || [''],
     files: [
       {
         ...projectSheet,
@@ -26,6 +32,7 @@ export const defaultTailwindModifier = async (params: TailwindPluginParams): Pro
       },
     ],
   })
+
   files.set('tailwindConfig', {
     files: [
       {
@@ -33,21 +40,38 @@ export const defaultTailwindModifier = async (params: TailwindPluginParams): Pro
         fileType: FileType.JS,
         content: `module.exports = ${JSON.stringify(config, null, 2)}`,
       },
-      {
-        name: 'postcss.config',
-        fileType: FileType.JS,
-        content: `module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};`,
-      },
     ],
     path: [''],
   })
 
-  devDependencies.tailwindcss = TAILWIND
+  if (files.get('nuxt.config')) {
+    files.delete('nuxt.config')
+  }
+
+  files.set('nuxt.config', {
+    path: [''],
+    files: [
+      {
+        name: 'nuxt.config',
+        fileType: FileType.JS,
+        content: `export default {
+  css: ["~/style.css"],
+  buildModules: ["@nuxt/postcss8"],
+  build: {
+    postcss: {
+      plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+      },
+    },
+  },
+};`,
+      },
+    ],
+  })
+
   devDependencies.autoprefixer = AUTO_PREFIXER
   devDependencies.postcss = POSTCSS
+  devDependencies.tailwindcss = TAILWIND
+  devDependencies['@nuxt/postcss8'] = '^1.1.3'
 }

--- a/packages/teleport-project-plugin-tailwind/src/preact.ts
+++ b/packages/teleport-project-plugin-tailwind/src/preact.ts
@@ -2,14 +2,14 @@ import { FileType } from '@teleporthq/teleport-types'
 import { TailwindPluginParams } from '.'
 import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
-export const defaultTailwindModifier = async (params: TailwindPluginParams): Promise<void> => {
+export const preactTailwindModifier = async (params: TailwindPluginParams) => {
   const { structure, config, css, path } = params
-  const { files, devDependencies, rootFolder } = structure
-  config.content = ['./src/**/*.{html,js,ts,jsx,tsx}', './*.html']
+  const { files, devDependencies } = structure
+  config.content = ['./src/**/*.{js,ts,jsx,tsx}']
 
   const projectSheet = files
     .get('projectStyleSheet')
-    ?.files.find((file) => file.name === 'style' && file.fileType === FileType.CSS)
+    ?.files.find((file) => file.name === 'global-style' && file.fileType === FileType.CSS)
   let globalStyleSheet = css
 
   if (projectSheet) {
@@ -17,21 +17,8 @@ export const defaultTailwindModifier = async (params: TailwindPluginParams): Pro
     globalStyleSheet = `${globalStyleSheet} \n \n ${projectSheet.content}`
   }
 
-  rootFolder.files.forEach((file) => {
-    const { name, fileType } = file
-
-    if (name === 'package' && fileType === 'json') {
-      const jsonContent = JSON.parse(file.content)
-      jsonContent.scripts = {
-        ...jsonContent?.scripts,
-        tailwind: 'tailwindcss -o style.css -c ./tailwind.config.js',
-      }
-      file.content = JSON.stringify(jsonContent, null, 2)
-    }
-  })
-
   files.set('projectStyleSheet', {
-    path: path || ['src', 'teleporthq'],
+    path: path || ['src'],
     files: [
       {
         ...projectSheet,

--- a/packages/teleport-project-plugin-tailwind/src/react.ts
+++ b/packages/teleport-project-plugin-tailwind/src/react.ts
@@ -1,7 +1,7 @@
 import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
 import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
-export const defaultTailwindModifier = async (
+export const reactTailwindModifier = async (
   structure: ProjectPluginStructure,
   config: Record<string, unknown>,
   css: string
@@ -16,7 +16,7 @@ export const defaultTailwindModifier = async (
   if (projectSheet) {
     files.delete('projectStyleSheet')
     files.set('projectStyleSheet', {
-      path: ['src', 'teleporthq'],
+      path: ['src'],
       files: [
         {
           ...projectSheet,

--- a/packages/teleport-project-plugin-tailwind/src/react.ts
+++ b/packages/teleport-project-plugin-tailwind/src/react.ts
@@ -12,19 +12,22 @@ export const reactTailwindModifier = async (
   const projectSheet = files
     .get('projectStyleSheet')
     ?.files.find((file) => file.name === 'style' && file.fileType === FileType.CSS)
+  let globalStyleSheet = css
 
   if (projectSheet) {
     files.delete('projectStyleSheet')
-    files.set('projectStyleSheet', {
-      path: ['src'],
-      files: [
-        {
-          ...projectSheet,
-          content: `${css}\n${projectSheet.content}`,
-        },
-      ],
-    })
+    globalStyleSheet = `${globalStyleSheet} \n \n ${projectSheet.content}`
   }
+
+  files.set('projectStyleSheet', {
+    path: ['src'],
+    files: [
+      {
+        ...projectSheet,
+        content: globalStyleSheet,
+      },
+    ],
+  })
 
   files.set('tailwindConfig', {
     files: [

--- a/packages/teleport-project-plugin-tailwind/src/react.ts
+++ b/packages/teleport-project-plugin-tailwind/src/react.ts
@@ -1,11 +1,9 @@
-import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
+import { FileType } from '@teleporthq/teleport-types'
+import { TailwindPluginParams } from '.'
 import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
-export const reactTailwindModifier = async (
-  structure: ProjectPluginStructure,
-  config: Record<string, unknown>,
-  css: string
-): Promise<void> => {
+export const reactTailwindModifier = async (params: TailwindPluginParams): Promise<void> => {
+  const { structure, config, css, path } = params
   const { files, devDependencies } = structure
   config.content = ['./src/**/*.{js,ts,jsx,tsx}']
 
@@ -20,7 +18,7 @@ export const reactTailwindModifier = async (
   }
 
   files.set('projectStyleSheet', {
-    path: ['src'],
+    path: path || ['src'],
     files: [
       {
         ...projectSheet,

--- a/packages/teleport-project-plugin-tailwind/src/stencil.ts
+++ b/packages/teleport-project-plugin-tailwind/src/stencil.ts
@@ -1,0 +1,84 @@
+import { FileType } from '@teleporthq/teleport-types'
+import { TailwindPluginParams } from '.'
+import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
+
+export const stencilTailwindModifier = async (params: TailwindPluginParams) => {
+  const { structure, config, css, path } = params
+  const { files, devDependencies } = structure
+  config.content = ['./src/**/*.{ts,tsx,html}']
+
+  const projectSheet = files
+    .get('projectStyleSheet')
+    ?.files.find((file) => file.name === 'style' && file.fileType === FileType.CSS)
+  let globalStyleSheet = css
+
+  if (projectSheet) {
+    files.delete('projectStyleSheet')
+    globalStyleSheet = `${globalStyleSheet} \n \n ${projectSheet.content}`
+  }
+
+  files.set('projectStyleSheet', {
+    path: path || ['src'],
+    files: [
+      {
+        ...projectSheet,
+        content: globalStyleSheet,
+      },
+    ],
+  })
+
+  files.set('tailwindConfig', {
+    files: [
+      {
+        name: 'tailwind.config',
+        fileType: FileType.JS,
+        content: `module.exports = ${JSON.stringify(config, null, 2)}`,
+      },
+    ],
+    path: [''],
+  })
+
+  files.delete('stencil.config')
+  files.set('stencil.config', {
+    files: [
+      {
+        name: 'stencil.config',
+        fileType: FileType.TS,
+        content: `import { Config } from "@stencil/core";
+import tailwind, { tailwindHMR } from "stencil-tailwind-plugin";
+import tailwindConfig from "./tailwind.config";
+import autoprefixer from "autoprefixer";
+
+export const config: Config = {
+  namespace: "app",
+  globalStyle: "src/style.css",
+  outputTargets: [
+    {
+      type: "www",
+      // comment the following line to disable service workers in production
+      serviceWorker: null,
+      baseUrl: "https://myapp.local/",
+    },
+  ],
+  plugins: [
+    tailwind({
+      // @ts-ignore
+      tailwindConfig,
+      tailwindCssContents: '@tailwind utilities;',
+      postcss: {
+        plugins: [autoprefixer()],
+      },
+    }),
+    tailwindHMR(),
+  ],
+};`,
+      },
+    ],
+    path: [''],
+  })
+
+  devDependencies.tailwindcss = TAILWIND
+  devDependencies.autoprefixer = AUTO_PREFIXER
+  devDependencies.postcss = POSTCSS
+  devDependencies['stencil-tailwind-plugin'] = '^1.3.0'
+}

--- a/packages/teleport-project-plugin-tailwind/src/vue.ts
+++ b/packages/teleport-project-plugin-tailwind/src/vue.ts
@@ -1,11 +1,9 @@
-import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
+import { FileType } from '@teleporthq/teleport-types'
+import { TailwindPluginParams } from '.'
 import { AUTO_PREFIXER, POSTCSS, TAILWIND } from './constants'
 
-export const vueTailwindModifier = async (
-  structure: ProjectPluginStructure,
-  config: Record<string, unknown>,
-  css: string
-): Promise<void> => {
+export const vueTailwindModifier = async (params: TailwindPluginParams): Promise<void> => {
+  const { structure, config, css, path } = params
   const { devDependencies, files, rootFolder } = structure
   config.content = ['./src/**/*.{vue,js,ts,jsx,tsx}']
 
@@ -20,7 +18,7 @@ export const vueTailwindModifier = async (
   }
 
   files.set('projectStyleSheet', {
-    path: ['src'],
+    path: path || ['src'],
     files: [
       {
         ...projectSheet,

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -304,8 +304,27 @@ const run = async () => {
         },
       })
 
-      console.info(ProjectType.REACT, '+' + 'tailwind', '-', result.payload)
-      return `React - Tailwind`
+      console.info(ProjectType.VUE, '+' + 'tailwind', '-', result.payload)
+      return `VUE - Tailwind`
+    })
+
+    await log(async () => {
+      result = await packProject(tailwindProjectUIDL, {
+        ...packerOptions,
+        projectType: ProjectType.ANGULAR,
+        plugins: [
+          new ProjectPluginTailwind({
+            framework: ProjectType.ANGULAR,
+          }),
+        ],
+        publishOptions: {
+          ...packerOptions.publishOptions,
+          projectSlug: 'teleport-project-angular-tailwind',
+        },
+      })
+
+      console.info(ProjectType.ANGULAR, '+' + 'tailwind', '-', result.payload)
+      return `Angular - Tailwind`
     })
   } catch (e) {
     console.info(e)

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -16,9 +16,11 @@ import { ProjectPluginTailwind } from '@teleporthq/teleport-project-plugin-tailw
 import { ProjectPluginStyledComponents } from '@teleporthq/teleport-project-plugin-styled-components'
 import reactProjectJSON from '../../../examples/uidl-samples/react-project.json'
 import projectJSON from '../../../examples/uidl-samples/project.json'
+import tailwindProjectJSON from '../../../examples/uidl-samples/project-tailwind.json'
 
 const projectUIDL = projectJSON as unknown as ProjectUIDL
 const reactProjectUIDL = reactProjectJSON as unknown as ProjectUIDL
+const tailwindProjectUIDL = tailwindProjectJSON as unknown as ProjectUIDL
 const assetFile = readFileSync(join(__dirname, 'asset.png'))
 const base64File = Buffer.from(assetFile).toString('base64')
 const packerOptions: PackerOptions = {
@@ -81,14 +83,6 @@ const run = async () => {
       result = await packProject(projectUIDL, {
         ...packerOptions,
         projectType: ProjectType.NEXT,
-        plugins: [
-          new ProjectPluginTailwind({
-            config: {},
-            css: `@tailwind utils`,
-            content: ['./pages/**/*.ts'],
-            framework: ProjectType.NEXT,
-          }),
-        ],
       })
       console.info(ProjectType.NEXT, '-', result.payload)
       return ProjectType.NEXT
@@ -253,6 +247,65 @@ const run = async () => {
       })
       console.info(ProjectType.REACTNATIVE, '-', result.payload)
       return ProjectType.REACTNATIVE
+    })
+
+    /* Frameworks using default + tailwind ccss */
+
+    await log(async () => {
+      result = await packProject(tailwindProjectUIDL, {
+        ...packerOptions,
+        projectType: ProjectType.NEXT,
+        plugins: [
+          new ProjectPluginTailwind({
+            framework: ProjectType.NEXT,
+          }),
+        ],
+        publishOptions: {
+          ...packerOptions.publishOptions,
+          projectSlug: 'teleport-project-next-tailwind',
+        },
+      })
+
+      console.info(ProjectType.NEXT, '+' + 'tailwind', '-', result.payload)
+      return `Next - Tailwind`
+    })
+
+    await log(async () => {
+      result = await packProject(tailwindProjectUIDL, {
+        ...packerOptions,
+        projectType: ProjectType.REACT,
+        plugins: [
+          new ProjectPluginTailwind({
+            framework: ProjectType.REACT,
+          }),
+        ],
+        publishOptions: {
+          ...packerOptions.publishOptions,
+          projectSlug: 'teleport-project-react-tailwind',
+        },
+      })
+
+      console.info(ProjectType.REACT, '+' + 'tailwind', '-', result.payload)
+      return `React - Tailwind`
+    })
+
+    await log(async () => {
+      result = await packProject(tailwindProjectUIDL, {
+        ...packerOptions,
+        projectType: ProjectType.VUE,
+        plugins: [
+          new ProjectPluginTailwind({
+            framework: ProjectType.VUE,
+          }),
+        ],
+        publishOptions: {
+          ...packerOptions.publishOptions,
+          projectSlug: 'teleport-project-vue-tailwind',
+        },
+      })
+
+      console.info(ProjectType.REACT, '+' + 'tailwind', '-', result.payload)
+      return `React - Tailwind`
     })
   } catch (e) {
     console.info(e)

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { readFileSync, mkdirSync, rmdirSync } from 'fs'
 import { join } from 'path'
 import chalk from 'chalk'
@@ -365,6 +364,45 @@ const run = async () => {
 
       console.info(ProjectType.HTML, '+' + 'tailwind', '-', result.payload)
       return `Html - Tailwind`
+    })
+
+    await log(async () => {
+      result = await packProject(tailwindProjectUIDL, {
+        ...packerOptions,
+        projectType: ProjectType.PREACT,
+        plugins: [
+          new ProjectPluginTailwind({
+            framework: ProjectType.PREACT,
+          }),
+        ],
+        publishOptions: {
+          ...packerOptions.publishOptions,
+          projectSlug: 'teleport-project-preact-tailwind',
+        },
+      })
+
+      console.info(ProjectType.PREACT, '+' + 'tailwind', '-', result.payload)
+      return `Preact - Tailwind`
+    })
+
+    await log(async () => {
+      result = await packProject(tailwindProjectUIDL, {
+        ...packerOptions,
+        projectType: ProjectType.STENCIL,
+        plugins: [
+          new ProjectPluginTailwind({
+            framework: ProjectType.STENCIL,
+            path: [''],
+          }),
+        ],
+        publishOptions: {
+          ...packerOptions.publishOptions,
+          projectSlug: 'teleport-project-stencil-tailwind',
+        },
+      })
+
+      console.info(ProjectType.STENCIL, '+' + 'tailwind', '-', result.payload)
+      return `Stencil - Tailwind`
     })
   } catch (e) {
     console.info(e)

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { readFileSync, mkdirSync, rmdirSync } from 'fs'
 import { join } from 'path'
 import chalk from 'chalk'
@@ -325,6 +326,45 @@ const run = async () => {
 
       console.info(ProjectType.ANGULAR, '+' + 'tailwind', '-', result.payload)
       return `Angular - Tailwind`
+    })
+
+    await log(async () => {
+      result = await packProject(tailwindProjectUIDL, {
+        ...packerOptions,
+        projectType: ProjectType.NUXT,
+        plugins: [
+          new ProjectPluginTailwind({
+            framework: ProjectType.NUXT,
+          }),
+        ],
+        publishOptions: {
+          ...packerOptions.publishOptions,
+          projectSlug: 'teleport-project-nuxt-tailwind',
+        },
+      })
+
+      console.info(ProjectType.NUXT, '+' + 'tailwind', '-', result.payload)
+      return `Nuxt - Tailwind`
+    })
+
+    await log(async () => {
+      result = await packProject(tailwindProjectUIDL, {
+        ...packerOptions,
+        projectType: ProjectType.HTML,
+        plugins: [
+          new ProjectPluginTailwind({
+            framework: ProjectType.HTML,
+            path: [''],
+          }),
+        ],
+        publishOptions: {
+          ...packerOptions.publishOptions,
+          projectSlug: 'teleport-project-html-tailwind',
+        },
+      })
+
+      console.info(ProjectType.HTML, '+' + 'tailwind', '-', result.payload)
+      return `Html - Tailwind`
     })
   } catch (e) {
     console.info(e)


### PR DESCRIPTION
Update all default frameworks to latest version of webpack. And add support for tailwindcss with all the frameworks.

- [x] Craco React (Updates to webpack 5 and postcss 8)
- [x] Vue (Updates to latest vue-cli and postcss 8 )
- [x] HTML (Works alongside with parcel )
- [x] Preact (Updated to latest preact cli)
- [x] Next JS
- [x] Nuxt JS
- [x] Angular (Updated to angular 14 and webpack to 5)
- [ ] Gridsome
- [ ] Gatsby
- [x] Stencil