### PR TITLE
Fix missing meta tags issue for HTML generated pages

### DIFF
--- a/packages/teleport-project-generator-html/__tests__/index.ts
+++ b/packages/teleport-project-generator-html/__tests__/index.ts
@@ -67,3 +67,17 @@ describe('Image Resolution', () => {
     expect(fallbackPage).toBeDefined()
   })
 })
+
+describe('Meta tags from globals', () => {
+  it('are added to each page`s head', async () => {
+    const generator = createHTMLProjectGenerator()
+    const { files } = await generator.generateProject(fallbackUidlSample)
+    const pages = files.filter((file) => file.fileType === 'html')
+
+    pages.forEach((page) => {
+      expect(page.content).toContain('<meta charset="utf-8"')
+      expect(page.content).toContain('<meta name="viewport"')
+      expect(page.content).toContain('<meta property="twitter:card"')
+    })
+  })
+})

--- a/packages/teleport-project-generator-html/src/plugin-clone-globals.ts
+++ b/packages/teleport-project-generator-html/src/plugin-clone-globals.ts
@@ -48,7 +48,7 @@ class ProjectPluginCloneGlobals implements ProjectPlugin {
               const parsedIndividualFile = load(file.content)
 
               const metaTags = parsedIndividualFile.root().find('meta')
-              parsedEntry('head').prepend(metaTags.length ? metaTags.toString() : metaTagsFromRoot)
+              parsedEntry('head').prepend(metaTags.toString().concat(metaTagsFromRoot))
               metaTags.remove()
 
               const titleTags = parsedIndividualFile.root().find('title')


### PR DESCRIPTION
Add meta tags from `globals` to each HTML generated page