### PR TITLE
Fix build when project name contains paranthesis

### DIFF
--- a/packages/teleport-project-generator-vue/src/project-template.ts
+++ b/packages/teleport-project-generator-vue/src/project-template.ts
@@ -39,7 +39,9 @@ export default {
     {
       name: 'vue.config',
       fileType: 'js',
-      content: `module.exports = {
+      content: String.raw`const path = require('path')
+
+module.exports = {
   css: {
     loaderOptions: {
       css: {
@@ -47,6 +49,15 @@ export default {
       },
     },
   },
+  chainWebpack: config => {
+    config.plugin('copy').tap(args => {
+      const UNESCAPED_GLOB_SYMBOLS_RE = /(\\?)([()*?[\]{|}]|^!|[!+@](?=\())/g;
+      const publicDir = path.resolve(process.VUE_CLI_SERVICE.context, 'public').replace(/\\/g, '/');
+      const escapePublicDir= publicDir.replace(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
+      args[0].patterns[0].globOptions.ignore = args[0].patterns[0].globOptions.ignore.map(i => i.replace(publicDir, escapePublicDir));
+      return args;
+  });
+  }
 };`,
     },
     {


### PR DESCRIPTION
Issue: 
 1. save on local machine a vue project which has a parenthesis in the project name.
 2. try building the project
 
Actual: build fails

Related issue ->  https://github.com/vuejs/vue-cli/issues/7043