### PR TITLE
(refactor): Wrap `html-node` with a div with styles lifted to the paret

### DIFF
--- a/examples/test-samples/project-sample-with-dependency.json
+++ b/examples/test-samples/project-sample-with-dependency.json
@@ -148,6 +148,9 @@
                         "type": "element",
                         "content": {
                           "elementType": "html-node",
+                          "style": {
+                            "width": "10px"
+                          },
                           "attrs": {
                             "html": {
                               "type": "raw",

--- a/packages/teleport-component-generator-html/src/plain-html-mapping.ts
+++ b/packages/teleport-component-generator-html/src/plain-html-mapping.ts
@@ -16,10 +16,10 @@ export const PlainHTMLMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importJustPath: true,
-          importAlias: 'https://unpkg.com/dangerous-html@0.1.10/dist/default/lib.umd.js',
+          importAlias: 'https://unpkg.com/dangerous-html@0.1.11/dist/default/lib.umd.js',
         },
       },
     },

--- a/packages/teleport-component-generator-preact/src/preact-mapping.ts
+++ b/packages/teleport-component-generator-preact/src/preact-mapping.ts
@@ -7,7 +7,7 @@ export const PreactMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importJustPath: true,
         },

--- a/packages/teleport-component-generator-react/src/react-mapping.ts
+++ b/packages/teleport-component-generator-react/src/react-mapping.ts
@@ -18,7 +18,7 @@ export const ReactMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importAlias: 'dangerous-html/react',
         },

--- a/packages/teleport-component-generator-stencil/src/stencil-mapping.ts
+++ b/packages/teleport-component-generator-stencil/src/stencil-mapping.ts
@@ -7,7 +7,7 @@ export const StencilMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importJustPath: true,
         },

--- a/packages/teleport-component-generator-vue/src/vue-mapping.ts
+++ b/packages/teleport-component-generator-vue/src/vue-mapping.ts
@@ -7,7 +7,7 @@ export const VueMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importAlias: 'dangerous-html/vue',
         },

--- a/packages/teleport-project-generator-angular/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-angular/__tests__/end2end/index.ts
@@ -70,7 +70,7 @@ import { ModalWindow } from './modal-window/modal-window.component'`)
     expect(pagesFolder.subFolders[0].files[1].content).not.toContain(`import Modal`)
     expect(modalComponent.files[1].content).not.toContain(`import Modal`)
     expect(packageJSON.content).toContain(`"antd": "4.5.4"`)
-    expect(packageJSON.content).toContain(`"dangerous-html": "0.1.10"`)
+    expect(packageJSON.content).toContain(`"dangerous-html": "0.1.11"`)
   })
 
   it('creates style sheet and adds to the webpack file', async () => {

--- a/packages/teleport-project-generator-angular/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-angular/__tests__/end2end/index.ts
@@ -60,8 +60,8 @@ import { ModalWindow } from './modal-window/modal-window.component'`)
     expect(pagesFolder.subFolders[0].files[0].content).toContain(`<app-modal></app-modal>`)
     expect(pagesFolder.subFolders[0].files[0].content).toContain(
       `<dangerous-html
-    html=\"<script src='https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>\"
-  ></dangerous-html>`
+      html=\"<script src='https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>\"
+    ></dangerous-html>`
     )
     /*
      * Modal is used in home page but don't need to import since all components are packed

--- a/packages/teleport-project-generator-gatsby/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-gatsby/__tests__/end2end/index.ts
@@ -45,7 +45,7 @@ describe('Gatsby Project Generator', () => {
     expect(outputFolder.name).toBe(template.name)
     expect(outputFolder.files[0].name).toBe('package')
     expect(outputFolder.files[0].content).toContain(`"antd": "4.5.4"`)
-    expect(outputFolder.files[0].content).toContain(`"dangerous-html": "0.1.10"`)
+    expect(outputFolder.files[0].content).toContain(`"dangerous-html": "0.1.11"`)
     expect(srcFolder.files[0].name).toBe('html')
     expect(srcFolder.files[0].fileType).toBe(FileType.JS)
     expect(srcFolder.files[0].content).toBeDefined()

--- a/packages/teleport-project-generator-gatsby/src/gatsby-project-mapping.ts
+++ b/packages/teleport-project-generator-gatsby/src/gatsby-project-mapping.ts
@@ -21,7 +21,7 @@ export const GatsbyProjectMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importAlias: 'dangerous-html/react',
         },

--- a/packages/teleport-project-generator-gridsome/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-gridsome/__tests__/end2end/index.ts
@@ -62,7 +62,7 @@ describe('Gridsome Project Generator', () => {
 
     expect(components.files[2].content).toContain(`import { Button } from 'antd'`)
     expect(packageJSON.content).toContain(`"antd": "4.5.4"`)
-    expect(packageJSON.content).toContain(`"dangerous-html": "0.1.10"`)
+    expect(packageJSON.content).toContain(`"dangerous-html": "0.1.11"`)
 
     /** For Nuxt based projects, just imports are injected in index file of the routes */
     expect(pages.files[0].content).toContain(`import 'antd/dist/antd.css'`)

--- a/packages/teleport-project-generator-gridsome/src/gridsome-project-mapping.ts
+++ b/packages/teleport-project-generator-gridsome/src/gridsome-project-mapping.ts
@@ -13,7 +13,7 @@ export const GridsomeProjectMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importAlias: 'dangerous-html/dist/vue/lib.mjs',
         },

--- a/packages/teleport-project-generator-next/src/next-project-mapping.ts
+++ b/packages/teleport-project-generator-next/src/next-project-mapping.ts
@@ -23,5 +23,16 @@ export const NextProjectMapping: Mapping = {
         },
       ],
     },
+    'html-node': {
+      elementType: 'DangerousHTML',
+      dependency: {
+        type: 'package',
+        path: 'dangerous-html',
+        version: '0.1.11',
+        meta: {
+          importAlias: 'dangerous-html/react',
+        },
+      },
+    },
   },
 }

--- a/packages/teleport-project-generator-nuxt/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-nuxt/__tests__/end2end/index.ts
@@ -50,7 +50,7 @@ describe('Vue Nuxt Project Generator', () => {
     )
 
     expect(packageJSON.content).toContain(`"antd": "4.5.4"`)
-    expect(packageJSON.content).toContain(`"dangerous-html": "0.1.10"`)
+    expect(packageJSON.content).toContain(`"dangerous-html": "0.1.11"`)
 
     /* For Nuxt based projects, just imports are injected in index file of the routes */
     expect(pages.files[0].content).toContain(`import 'antd/dist/antd.css'`)

--- a/packages/teleport-project-generator-nuxt/src/nuxt-project-mapping.ts
+++ b/packages/teleport-project-generator-nuxt/src/nuxt-project-mapping.ts
@@ -13,7 +13,7 @@ export const NuxtProjectMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importAlias: 'dangerous-html/dist/vue/lib.mjs',
         },

--- a/packages/teleport-project-generator-preact/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-preact/__tests__/end2end/index.ts
@@ -50,7 +50,7 @@ describe('Preact Project Generator', () => {
   "version": "1.0.0",
   "description": "Project generated based on a UIDL document",
   "dependencies": {
-    "dangerous-html": "0.1.10",
+    "dangerous-html": "0.1.11",
     "react-helmet": "^6.1.0",
     "prop-types": "15.7.2",
     "antd": "4.5.4"

--- a/packages/teleport-project-generator-preact/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-preact/__tests__/end2end/index.ts
@@ -79,9 +79,11 @@ describe('Preact Project Generator', () => {
     expect(routes.subFolders[0].files[0].content).toContain(`import 'dangerous-html'`)
     expect(routes.subFolders[0].files[0].content).toContain(`Page 1<Modal></Modal>`)
     expect(routes.subFolders[0].files[0].content).toContain(
-      `<dangerous-html
-        html={\`<script src='https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>\`}
-      ></dangerous-html>`
+      `<div class={styles['div']}>
+        <dangerous-html
+          html={\`<script src='https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>\`}
+        ></dangerous-html>
+      </div>`
     )
 
     /** Imports which are just inserted and left like css one's are added directly in app.js file */

--- a/packages/teleport-project-generator-react/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-react/__tests__/end2end/index.ts
@@ -103,7 +103,7 @@ describe('React Project Generator', () => {
   "version": "1.0.0",
   "description": "Project generated based on a UIDL document",
   "dependencies": {
-    "dangerous-html": "0.1.10",
+    "dangerous-html": "0.1.11",
     "react-helmet": "^6.1.0",
     "prop-types": "15.7.2",
     "antd": "4.5.4"

--- a/packages/teleport-project-generator-react/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-react/__tests__/end2end/index.ts
@@ -122,9 +122,11 @@ describe('React Project Generator', () => {
     )
     expect(viewsFolder.files[0].content).toContain(`Page 1<Modal></Modal>`)
     expect(viewsFolder.files[0].content).toContain(
-      `<DangerousHTML
-        html={\`<script src='https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>\`}
-      ></DangerousHTML>`
+      `<div className="home-div">
+        <DangerousHTML
+          html={\`<script src='https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>\`}
+        ></DangerousHTML>
+      </div>`
     )
     /* Imports that are just need to be inserted are added to router file by default */
     expect(srcFolder.files[0].content).toContain(`import 'antd/dist/antd.css'`)

--- a/packages/teleport-project-generator-vue/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-vue/__tests__/end2end/index.ts
@@ -55,7 +55,7 @@ describe('Vue Project Generator', () => {
   "version": "1.0.0",
   "description": "Project generated based on a UIDL document",
   "dependencies": {
-    "dangerous-html": "0.1.10",
+    "dangerous-html": "0.1.11",
     "antd": "4.5.4"
   }
 }`)

--- a/packages/teleport-test/src/component.ts
+++ b/packages/teleport-test/src/component.ts
@@ -28,12 +28,20 @@ const run = async () => {
   const { files: reactFiles } = await reactGenerator.generateComponent(
     component(
       'Test Code Embed Component',
-      elementNode('html-node', {
-        html: {
-          type: 'raw',
-          content: `<script src'https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>`,
+      elementNode(
+        'html-node',
+        {
+          html: {
+            type: 'raw',
+            content: `<script src'https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>`,
+          },
         },
-      })
+        [],
+        null,
+        {
+          width: staticNode('100px'),
+        }
+      )
     )
   )
   addfilesToDisk(reactFiles)

--- a/packages/teleport-uidl-resolver/__tests__/html-node/index.ts
+++ b/packages/teleport-uidl-resolver/__tests__/html-node/index.ts
@@ -1,0 +1,59 @@
+import { wrapHtmlNode, createDivNode } from '../../src/resolvers/html-node/utils'
+import { elementNode, staticNode } from '@teleporthq/teleport-uidl-builders'
+import { UIDLElementNode, UIDLStyleDefinitions } from '@teleporthq/teleport-types'
+import { create } from 'domain'
+
+describe('wrap html-node element', () => {
+  it('wraps a simple element', () => {
+    const node = elementNode(
+      'html-node',
+      {
+        html: {
+          type: 'raw',
+          content: `<script src'https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>`,
+        },
+      },
+      [],
+      undefined,
+      {
+        width: staticNode('100px'),
+      }
+    )
+
+    const result = wrapHtmlNode(node, {})
+    expect(result.content.elementType).toBe('div')
+    expect(result.content.children?.length).toBe(1)
+    const childNode = result.content.children?.[0] as UIDLElementNode
+    expect(childNode.content.elementType).toBe('html-node')
+    expect(childNode.content.attrs?.html.content).toBe(
+      `<script src'https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>`
+    )
+  })
+})
+
+describe('create div', () => {
+  it('creates wrapping div', () => {
+    const node = elementNode(
+      'html-node',
+      {
+        html: {
+          type: 'raw',
+          content: `<script src'https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js'></script> <lottie-player src='https://assets6.lottiefiles.com/packages/lf20_gSMVZV7ZdZ.json'  background='transparent'  speed='1'  style='width: 300px; height: 300px;'  loop controls autoplay></lottie-player>`,
+        },
+      },
+      [],
+      undefined,
+      {
+        width: staticNode('100px'),
+      }
+    )
+
+    const result = createDivNode(node)
+
+    expect(result.content.elementType).toBe('div')
+    expect(result.content.children?.length).toBe(0)
+    expect(result.content.attrs?.html).toBeUndefined()
+    expect(result.content.style).toBeDefined()
+    expect(Object.keys(result.content.style as UIDLStyleDefinitions).length).toBe(1)
+  })
+})

--- a/packages/teleport-uidl-resolver/src/html-mapping.ts
+++ b/packages/teleport-uidl-resolver/src/html-mapping.ts
@@ -27,7 +27,7 @@ export const HTMLMapping: Mapping = {
       dependency: {
         type: 'package',
         path: 'dangerous-html',
-        version: '0.1.10',
+        version: '0.1.11',
         meta: {
           importJustPath: true,
         },

--- a/packages/teleport-uidl-resolver/src/resolver.ts
+++ b/packages/teleport-uidl-resolver/src/resolver.ts
@@ -4,6 +4,7 @@ import { ComponentUIDL, UIDLElement, Mapping, GeneratorOptions } from '@teleport
 import { resolveAbilities } from './resolvers/abilities'
 import { resolveStyleSetDefinitions } from './resolvers/style-set-definitions'
 import { resolveReferencedStyle } from './resolvers/referenced-styles'
+import { resolveHtmlNode } from './resolvers/html-node'
 
 /**
  * The resolver takes the input UIDL and converts all the abstract node types into
@@ -48,6 +49,7 @@ export default class Resolver {
 
     resolveReferencedStyle(uidl, newOptions)
 
+    resolveHtmlNode(uidl, newOptions)
     // TODO: Rename into apply mappings
     utils.resolveNode(uidl.node, newOptions)
 

--- a/packages/teleport-uidl-resolver/src/resolvers/html-node/index.ts
+++ b/packages/teleport-uidl-resolver/src/resolvers/html-node/index.ts
@@ -1,0 +1,6 @@
+import { ComponentUIDL, GeneratorOptions } from '@teleporthq/teleport-types'
+import { wrapHtmlNode } from './utils'
+
+export const resolveHtmlNode = (uidl: ComponentUIDL, options: GeneratorOptions) => {
+  uidl.node = wrapHtmlNode(uidl.node, options)
+}

--- a/packages/teleport-uidl-resolver/src/resolvers/html-node/utils.ts
+++ b/packages/teleport-uidl-resolver/src/resolvers/html-node/utils.ts
@@ -1,0 +1,62 @@
+import { GeneratorOptions, UIDLAttributeValue, UIDLElementNode } from '@teleporthq/teleport-types'
+
+export const wrapHtmlNode = (node: UIDLElementNode, options: GeneratorOptions): UIDLElementNode => {
+  const { children, attrs } = node.content
+
+  node.content.children = children?.map((child) => {
+    if (child.type === 'element') {
+      return wrapHtmlNode(child, options)
+    }
+
+    if (child.type === 'repeat') {
+      child.content.node = wrapHtmlNode(child.content.node, options)
+    }
+
+    if (child.type === 'conditional' && child.content.node.type === 'element') {
+      child.content.node = wrapHtmlNode(child.content.node, options)
+    }
+
+    if (child.type === 'slot' && child.content.fallback?.type === 'element') {
+      child.content.fallback = wrapHtmlNode(child.content.fallback, options)
+    }
+
+    return child
+  })
+
+  if (attrs?.html) {
+    const newNode = createDivNode(node)
+    newNode.content.children.push(node)
+
+    node.content.style = {}
+    node.content.referencedStyles = {}
+    node.content.events = {}
+
+    return newNode
+  }
+
+  return node
+}
+
+export const createDivNode = (node: UIDLElementNode): UIDLElementNode => {
+  const attrs = Object.keys(node.content.attrs).reduce(
+    (acc: Record<string, UIDLAttributeValue>, attrKey: string) => {
+      if (attrKey !== 'html') {
+        acc[attrKey] = node.content.attrs[attrKey]
+      }
+
+      return acc
+    },
+    {}
+  )
+
+  return {
+    type: 'element',
+    content: {
+      ...node.content,
+      attrs,
+      elementType: 'div',
+      semanticType: 'div',
+      children: [],
+    },
+  }
+}


### PR DESCRIPTION
Currently the html-node doesn't consider any style we're sending. In order to do that, we wrap it into a div element that will have the node content (styles, events, attributes) it receives on the html-node and it will render it as a child node. 