### PR TITLE
feat: Export sandboxes to cloud templates to make gatsby and next have better support

### DIFF
--- a/packages/teleport-publisher-codesandbox/src/constants.ts
+++ b/packages/teleport-publisher-codesandbox/src/constants.ts
@@ -1,3 +1,3 @@
 export const BASE_URL = 'https://codesandbox.io/api/v1/sandboxes/define'
 
-export const BASE_SANDBOX_URL = 'https://codesandbox.io/s/'
+export const BASE_SANDBOX_URL = 'https://codesandbox.io/p/sandbox/'

--- a/packages/teleport-publisher-codesandbox/src/index.ts
+++ b/packages/teleport-publisher-codesandbox/src/index.ts
@@ -38,7 +38,7 @@ export const createCodesandboxPublisher: PublisherFactory<
         'Content-Type': 'application/json',
       },
       method: 'POST',
-      body: JSON.stringify({ files: flatProject }),
+      body: JSON.stringify({ files: flatProject, environment: 'server' }),
     })
 
     if (response.status >= 500) {


### PR DESCRIPTION
Often project exports like `next`, `gatsby`, which needs server to run. Are very laggy and slow in the traditional sandboxes. This will make those load inside VM's. Which gives much better editing experience.