### PR TITLE
(fix): Add missing lottie-player dep for html exports

### DIFF
--- a/packages/teleport-component-generator-html/src/plain-html-mapping.ts
+++ b/packages/teleport-component-generator-html/src/plain-html-mapping.ts
@@ -25,6 +25,15 @@ export const PlainHTMLMapping: Mapping = {
     },
     'lottie-node': {
       elementType: 'lottie-player',
+      dependency: {
+        type: 'package',
+        path: 'lottie-player',
+        version: '1.5.7',
+        meta: {
+          importJustPath: true,
+          importAlias: 'https://unpkg.com/@lottiefiles/lottie-player@1.6.0/dist/lottie-player.js',
+        },
+      },
     },
   },
   illegalClassNames: [],


### PR DESCRIPTION
Generators are loading `lottie-player` from npm for all frameworks. But, for html exports we need to use `unpkg`. Where `lottie-player` is a web-component. After this all the exports for `lottie` in html exports will start working.