### PR TITLE
prefix asset path computation fix

### DIFF
--- a/packages/teleport-shared/__tests__/utils/uidl-utils.ts
+++ b/packages/teleport-shared/__tests__/utils/uidl-utils.ts
@@ -474,6 +474,23 @@ describe('prefixAssetsPath', () => {
       })
     ).toBe('/no/identifier/custom/kitten.png')
   })
+
+  it('returns the original string appended with custom path for the asset without identifier', () => {
+    expect(
+      prefixAssetsPath('/kitten.png', {
+        prefix: '/noidentifier',
+        mappings: { 'kitten.png': 'custom' },
+      })
+    ).toBe('/noidentifier/custom/kitten.png')
+  })
+
+  it('returns the original string appended with prefix without identifier', () => {
+    expect(
+      prefixAssetsPath('/kitten.png', {
+        prefix: '/noidentifier',
+      })
+    ).toBe('/noidentifier/kitten.png')
+  })
 })
 
 const nodeToTraverse = elementNode(

--- a/packages/teleport-shared/src/utils/uidl-utils.ts
+++ b/packages/teleport-shared/src/utils/uidl-utils.ts
@@ -142,9 +142,15 @@ export const prefixAssetsPath = (
   */
 
   if (!mappings[assetName]) {
+    if (!identifier) {
+      return [prefix, assetName].join('/')
+    }
     return [prefix, identifier, assetName].join('/')
   }
 
+  if (!identifier) {
+    return [prefix, mappings[assetName], assetName].join('/')
+  }
   return [prefix, identifier, mappings[assetName], assetName].join('/')
 }
 


### PR DESCRIPTION
if identifier was null the computation was still appending a / that was messing up with the expected path / url