### PR TITLE
fix/link-path-using-prefix-assets-path

### DIFF
--- a/packages/teleport-project-generator-html/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-html/__tests__/end2end/index.ts
@@ -9,8 +9,11 @@ describe('Html Project Generator', () => {
   it('runs without crasing', async () => {
     const generator = createHTMLProjectGenerator()
     generator.setAssets({
-      mappings: {},
+      mappings: {
+        'kitten.png': '',
+      },
       identifier: 'playground_assets',
+      prefix: 'public',
     })
     const { name, files, subFolders } = await generator.generateProject(uidlSample, HTMLTemplate)
     const aboutPage = files.find((page) => page.name === 'about' && page.fileType === FileType.HTML)
@@ -29,8 +32,11 @@ describe('Html Project Generator', () => {
   it('run withut crashing and appends entry things into single index.html', async () => {
     const singularGenerator = createHTMLProjectGenerator({ individualEntyFile: false })
     singularGenerator.setAssets({
-      mappings: {},
+      mappings: {
+        'kitten.png': '',
+      },
       identifier: 'playground_assets',
+      prefix: 'public',
     })
     const { name, files, subFolders } = await singularGenerator.generateProject(
       uidlSample,

--- a/packages/teleport-project-generator-html/__tests__/index.ts
+++ b/packages/teleport-project-generator-html/__tests__/index.ts
@@ -33,9 +33,11 @@ describe('Image Resolution', () => {
   it('resolves all local assets to be refered from public folder', async () => {
     const generator = createHTMLProjectGenerator()
     generator.setAssets({
-      mappings: {},
+      mappings: {
+        'kitten.png': '',
+      },
       identifier: 'playground_assets',
-      prefix: '/public',
+      prefix: 'public',
     })
     const { files } = await generator.generateProject(uidlWithImages)
 

--- a/packages/teleport-shared/__tests__/utils/uidl-utils.ts
+++ b/packages/teleport-shared/__tests__/utils/uidl-utils.ts
@@ -488,6 +488,7 @@ describe('prefixAssetsPath', () => {
     expect(
       prefixAssetsPath('/kitten.png', {
         prefix: '/noidentifier',
+        mappings: { 'kitten.png': '' },
       })
     ).toBe('/noidentifier/kitten.png')
   })

--- a/packages/teleport-shared/src/utils/uidl-utils.ts
+++ b/packages/teleport-shared/src/utils/uidl-utils.ts
@@ -141,8 +141,21 @@ export const prefixAssetsPath = (
      - It's not a asset and so we don't need to provide any mapping for it
   */
 
-  if (!mappings[assetName]) {
+  if (!(typeof mappings[assetName] === 'string')) {
     return originalString
+  }
+
+  /*
+    If the value from the mapping is an empty string
+    we need to not join it in the return path as it would append
+    a wrong /
+  */
+
+  if (!mappings[assetName]) {
+    if (!identifier) {
+      return [prefix, assetName].join('/')
+    }
+    return [prefix, identifier, assetName].join('/')
   }
 
   if (!identifier) {

--- a/packages/teleport-shared/src/utils/uidl-utils.ts
+++ b/packages/teleport-shared/src/utils/uidl-utils.ts
@@ -142,10 +142,7 @@ export const prefixAssetsPath = (
   */
 
   if (!mappings[assetName]) {
-    if (!identifier) {
-      return [prefix, assetName].join('/')
-    }
-    return [prefix, identifier, assetName].join('/')
+    return originalString
   }
 
   if (!identifier) {

--- a/packages/teleport-uidl-resolver/__tests__/utils.ts
+++ b/packages/teleport-uidl-resolver/__tests__/utils.ts
@@ -450,12 +450,28 @@ describe('resolveLinkElement', () => {
     illegalClassNames: [],
     illegalPropNames: ['title'],
   }
-  const uidlElement = element('Link', {
+  const linkElement = element('Link', {
     url: staticNode('/test'),
   })
 
-  it('returns a mapped content node', () => {
-    resolveElement(uidlElement, { assets, mapping: genereicMapping })
-    expect(uidlElement.attrs?.url.content).toBe('/test')
+  const linkHTMLElement = element('a', {
+    url: staticNode('/test'),
+  })
+
+  const assetElement = element('image', {
+    src: staticNode('/kittens.png'),
+  })
+
+  it('resolve link element', () => {
+    resolveElement(linkElement, { assets, mapping: genereicMapping })
+    expect(linkElement.attrs?.url.content).toBe('/test')
+  })
+  it('resolve link html element', () => {
+    resolveElement(linkHTMLElement, { assets, mapping: genereicMapping })
+    expect(linkHTMLElement.attrs?.url.content).toBe('/test')
+  })
+  it('resolve image element', () => {
+    resolveElement(assetElement, { assets, mapping: genereicMapping })
+    expect(assetElement.attrs?.src.content).toBe('public/assets/sub1/sub2/kittens.png')
   })
 })

--- a/packages/teleport-uidl-resolver/__tests__/utils.ts
+++ b/packages/teleport-uidl-resolver/__tests__/utils.ts
@@ -5,6 +5,7 @@ import {
   dynamicNode,
   component,
   definition,
+  element,
 } from '@teleporthq/teleport-uidl-builders'
 import {
   generateUniqueKeys,
@@ -15,6 +16,7 @@ import {
   checkForIllegalNames,
   checkForDefaultPropsContainingAssets,
   checkForDefaultStateValueContainingAssets,
+  resolveElement,
 } from '../src/utils'
 import { UIDLElement, UIDLNode, UIDLRepeatNode, Mapping } from '@teleporthq/teleport-types'
 import mapping from './mapping.json'
@@ -113,11 +115,11 @@ describe('ensureDataSourceUniqueness', () => {
     )
 
     const repeatNodeSample1 = JSON.parse(JSON.stringify(repeatNodeSample))
-    const element = elementNode('container', {}, [repeatNodeSample, repeatNodeSample1])
+    const elementSample = elementNode('container', {}, [repeatNodeSample, repeatNodeSample1])
 
-    ensureDataSourceUniqueness(element)
-    const firstRepeat = element.content.children[0] as UIDLRepeatNode
-    const secondRepeat = element.content.children[1] as UIDLRepeatNode
+    ensureDataSourceUniqueness(elementSample)
+    const firstRepeat = elementSample.content.children[0] as UIDLRepeatNode
+    const secondRepeat = elementSample.content.children[1] as UIDLRepeatNode
 
     expect(firstRepeat.content.meta.dataSourceIdentifier).toBe('items')
     expect(secondRepeat.content.meta.dataSourceIdentifier).toBe('items1')
@@ -421,5 +423,39 @@ describe('checkForDefaultStateValueContainingAssets', () => {
         'public/assets/dog/pictures/dogs.png'
       )
     }
+  })
+})
+
+describe('resolveLinkElement', () => {
+  const assets = {
+    prefix: 'public',
+    identifier: 'assets',
+    mappings: {
+      'kittens.png': 'sub1/sub2',
+      'dogs.png': 'dog/pictures',
+    },
+  }
+  const genereicMapping: Mapping = {
+    elements: {
+      text: {
+        elementType: 'span',
+      },
+      picture: {
+        elementType: 'picture',
+        children: [{ type: 'dynamic', content: { referenceType: 'children', id: 'children' } }],
+      },
+    },
+    events: {},
+    attributes: {},
+    illegalClassNames: [],
+    illegalPropNames: ['title'],
+  }
+  const uidlElement = element('Link', {
+    url: staticNode('/test'),
+  })
+
+  it('returns a mapped content node', () => {
+    resolveElement(uidlElement, { assets, mapping: genereicMapping })
+    expect(uidlElement.attrs?.url.content).toBe('/test')
   })
 })

--- a/packages/teleport-uidl-resolver/src/utils.ts
+++ b/packages/teleport-uidl-resolver/src/utils.ts
@@ -138,7 +138,9 @@ export const resolveElement = (element: UIDLElement, options: GeneratorOptions) 
       if (attrValue.type === 'static' && typeof attrValue.content === 'string') {
         originalElement.attrs[attrKey].content = UIDLUtils.prefixAssetsPath(
           attrValue.content,
-          options.assets
+          originalElement.elementType === 'Link' || originalElement.elementType === 'a'
+            ? {}
+            : options.assets
         )
       }
     })

--- a/packages/teleport-uidl-resolver/src/utils.ts
+++ b/packages/teleport-uidl-resolver/src/utils.ts
@@ -1,5 +1,4 @@
 import { UIDLUtils, StringUtils } from '@teleporthq/teleport-shared'
-import { prefixAssetsPath } from '@teleporthq/teleport-shared/dist/cjs/utils/uidl-utils'
 import {
   UIDLEventDefinitions,
   UIDLElement,
@@ -138,9 +137,7 @@ export const resolveElement = (element: UIDLElement, options: GeneratorOptions) 
       if (attrValue.type === 'static' && typeof attrValue.content === 'string') {
         originalElement.attrs[attrKey].content = UIDLUtils.prefixAssetsPath(
           attrValue.content,
-          originalElement.elementType === 'Link' || originalElement.elementType === 'a'
-            ? {}
-            : options.assets
+          options.assets
         )
       }
     })
@@ -504,7 +501,10 @@ export const checkForDefaultPropsContainingAssets = (
     Object.keys(uidl.propDefinitions).forEach((prop) => {
       const propDefaultValue = uidl.propDefinitions[prop].defaultValue
       if (typeof propDefaultValue === 'string' && assets) {
-        uidl.propDefinitions[prop].defaultValue = prefixAssetsPath(propDefaultValue, assets)
+        uidl.propDefinitions[prop].defaultValue = UIDLUtils.prefixAssetsPath(
+          propDefaultValue,
+          assets
+        )
       }
     })
   }
@@ -518,7 +518,10 @@ export const checkForDefaultStateValueContainingAssets = (
     Object.keys(uidl.stateDefinitions).forEach((state) => {
       const stateDefaultValue = uidl.stateDefinitions[state].defaultValue
       if (typeof stateDefaultValue === 'string' && assets) {
-        uidl.stateDefinitions[state].defaultValue = prefixAssetsPath(stateDefaultValue, assets)
+        uidl.stateDefinitions[state].defaultValue = UIDLUtils.prefixAssetsPath(
+          stateDefaultValue,
+          assets
+        )
       }
     })
   }


### PR DESCRIPTION
Local links are using the prefixAssetsPath function and they start with a '/' they be considered as asset and then prefixed with public folder and / or by asset identifier if there is any
An idea would be, in the case the node being resolved is a link to send an empty object instead of the assets options to not append anything before the local links