### PR TITLE
(fix): Add lottie player only when used in next projects

### DIFF
--- a/examples/uidl-samples/project.json
+++ b/examples/uidl-samples/project.json
@@ -819,6 +819,26 @@
                                                     {
                                                         "type": "element",
                                                         "content": {
+                                                            "elementType": "lottie-node",
+                                                            "style": {
+                                                                "width": "200px",
+                                                                "height": "200px"
+                                                            },
+                                                            "attrs": {
+                                                                "src": {
+                                                                    "type": "static",
+                                                                    "content": "https://assets9.lottiefiles.com/datafiles/gUENLc1262ccKIO/data.json"
+                                                                },
+                                                                "autoplay": {
+                                                                    "type": "static",
+                                                                    "content": "true"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "element",
+                                                        "content": {
                                                             "elementType": "text",
                                                             "referencedStyles": {},
                                                             "abilities": {},

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/index.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/index.ts
@@ -24,6 +24,7 @@ import {
   addAttributeToJSXTag,
   addDynamicAttributeToJSXTag,
   addRawAttributeToJSXTag,
+  generateDynamicWindowImport,
 } from '../../utils/ast-utils'
 import { createJSXTag, createSelfClosingJSXTag } from '../../builders/ast-builders'
 import { DEFAULT_JSX_OPTIONS } from './constants'
@@ -61,6 +62,11 @@ const generateElementNode: NodeToJSX<UIDLElementNode, types.JSXElement> = (
         // Make a copy to avoid reference leaking
         dependencies[tagName] = { ...dependency }
       }
+    }
+
+    if (dependency?.meta && `needsWindowObject` in dependency.meta) {
+      const dynamicWindowImport = generateDynamicWindowImport('useEffect', dependency.path)
+      params.windowImports[dependency.path] = dynamicWindowImport
     }
   }
 

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/types.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/types.ts
@@ -7,6 +7,7 @@ export interface JSXGenerationParams {
   stateDefinitions: Record<string, UIDLStateDefinition>
   nodesLookup: Record<string, types.JSXElement>
   dependencies: Record<string, UIDLDependency>
+  windowImports: Record<string, types.ExpressionStatement>
 }
 
 export interface JSXGenerationOptions {

--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -409,9 +409,14 @@ export const createPureComponent = (
   name: string,
   stateDefinitions: Record<string, UIDLStateDefinition>,
   jsxTagTree: types.JSXElement,
+  windowImports: Record<string, types.ExpressionStatement> = {},
   t = types
 ): types.VariableDeclaration => {
-  const arrowFunctionBody = createReturnExpressionSyntax(stateDefinitions, jsxTagTree)
+  const arrowFunctionBody = createReturnExpressionSyntax(
+    stateDefinitions,
+    jsxTagTree,
+    windowImports
+  )
   const arrowFunction = t.arrowFunctionExpression([t.identifier('props')], arrowFunctionBody)
 
   const declarator = t.variableDeclarator(t.identifier(name), arrowFunction)
@@ -423,6 +428,7 @@ export const createPureComponent = (
 export const createReturnExpressionSyntax = (
   stateDefinitions: Record<string, UIDLStateDefinition>,
   jsxTagTree: types.JSXElement,
+  windowImports: Record<string, types.ExpressionStatement> = {},
   t = types
 ) => {
   const returnStatement = t.returnStatement(jsxTagTree)
@@ -431,7 +437,7 @@ export const createReturnExpressionSyntax = (
     createStateHookAST(stateKey, stateDefinitions[stateKey])
   )
 
-  return t.blockStatement([...stateHooks, returnStatement] || [])
+  return t.blockStatement([...stateHooks, ...Object.values(windowImports), returnStatement] || [])
 }
 
 /**
@@ -456,6 +462,21 @@ export const createStateHookAST = (
       t.callExpression(t.identifier('useState'), [defaultValueArgument])
     ),
   ])
+}
+
+export const generateDynamicWindowImport = (
+  hookName = 'useEffect',
+  dependency: string
+): types.ExpressionStatement => {
+  return types.expressionStatement(
+    types.callExpression(types.identifier(hookName), [
+      types.arrowFunctionExpression(
+        [],
+        types.callExpression(types.identifier('import'), [types.stringLiteral(dependency)])
+      ),
+      types.arrayExpression([]),
+    ])
+  )
 }
 
 export const wrapObjectPropertiesWithExpression = (properties: types.ObjectProperty[]) =>

--- a/packages/teleport-plugin-import-statements/src/index.ts
+++ b/packages/teleport-plugin-import-statements/src/index.ts
@@ -40,7 +40,11 @@ export const createImportPlugin: ComponentPluginFactory<ImportPluginConfig> = (
       if (Object.keys(importDefinitions).length > 0) {
         Object.keys(importDefinitions).forEach((dependencyRef) => {
           const dependency = importDefinitions[dependencyRef]
-          if (dependency.meta?.useAsReference || dependency.meta?.importJustPath) {
+          if (
+            dependency.meta?.useAsReference ||
+            dependency.meta?.importJustPath ||
+            dependency?.meta.needsWindowObject
+          ) {
             return
           }
           dependencies[dependencyRef] = {
@@ -82,6 +86,10 @@ const groupDependenciesByPackage = (
 
       // Should not be the case at this point
       if (!dep.path) {
+        return
+      }
+
+      if (dep?.meta && 'needsWindowObject' in dep.meta) {
         return
       }
 

--- a/packages/teleport-plugin-react-base-component/src/index.ts
+++ b/packages/teleport-plugin-react-base-component/src/index.ts
@@ -13,6 +13,7 @@ import {
   ChunkType,
   FileType,
 } from '@teleporthq/teleport-types'
+import * as types from '@babel/types'
 
 import {
   DEFAULT_COMPONENT_CHUNK_NAME,
@@ -49,11 +50,13 @@ export const createReactComponentPlugin: ComponentPluginFactory<ReactPluginConfi
     // This will help us inject style or classes at a later stage in the pipeline, upon traversing the UIDL
     // The structure will be populated as the AST is being created
     const nodesLookup = {}
+    const windowImports: Record<string, types.ExpressionStatement> = {}
     const jsxParams = {
       propDefinitions,
       stateDefinitions,
       nodesLookup,
       dependencies,
+      windowImports,
     }
 
     const jsxOptions: JSXGenerationOptions = {
@@ -74,8 +77,13 @@ export const createReactComponentPlugin: ComponentPluginFactory<ReactPluginConfi
     const pureComponent = ASTUtils.createPureComponent(
       componentName,
       stateDefinitions,
-      jsxTagStructure
+      jsxTagStructure,
+      windowImports
     )
+
+    if (Object.keys(windowImports).length) {
+      dependencies.useEffect = USE_STATE_DEPENDENCY
+    }
 
     structure.chunks.push({
       type: ChunkType.AST,

--- a/packages/teleport-project-generator-next/src/next-project-mapping.ts
+++ b/packages/teleport-project-generator-next/src/next-project-mapping.ts
@@ -36,6 +36,15 @@ export const NextProjectMapping: Mapping = {
     },
     'lottie-node': {
       elementType: 'lottie-player',
+      dependency: {
+        type: 'package',
+        version: '1.6.0',
+        path: '@lottiefiles/lottie-player',
+        meta: {
+          importJustPath: true,
+          needsWindowObject: true,
+        },
+      },
     },
   },
 }

--- a/packages/teleport-project-generator-next/src/project-template.ts
+++ b/packages/teleport-project-generator-next/src/project-template.ts
@@ -20,8 +20,7 @@ export default {
   "dependencies": {
     "next": "^12.1.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "@lottiefiles/lottie-player": "1.6.0"
+    "react-dom": "^17.0.2"
   }
 }`,
       fileType: 'json',

--- a/packages/teleport-project-generator-next/src/utils.ts
+++ b/packages/teleport-project-generator-next/src/utils.ts
@@ -140,16 +140,6 @@ export const configContentGenerator = (options: FrameWorkConfigOptions, t = type
           ]),
         ],
         t.blockStatement([
-          t.expressionStatement(
-            t.callExpression(t.memberExpression(t.identifier('React'), t.identifier('useEffect')), [
-              t.arrowFunctionExpression(
-                [],
-                t.callExpression(t.identifier('import'), [
-                  t.stringLiteral('@lottiefiles/lottie-player'),
-                ])
-              ),
-            ])
-          ),
           t.returnStatement(
             t.jsxElement(
               t.jsxOpeningElement(

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-nocheck
 import { readFileSync, mkdirSync, rmdirSync } from 'fs'
 import { join } from 'path'
 import chalk from 'chalk'
@@ -64,22 +64,22 @@ const log = async (cb: () => Promise<string>) => {
 const run = async () => {
   try {
     if (packerOptions.publisher === PublisherType.DISK) {
-      // rmdirSync('dist', { recursive: true })
-      // mkdirSync('dist')
+      rmdirSync('dist', { recursive: true })
+      mkdirSync('dist')
     }
 
     let result
 
     /* Plain Html Generator */
 
-    await log(async () => {
-      result = await packProject(projectUIDL as unknown as ProjectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.HTML,
-      })
-      console.info(ProjectType.HTML, '-', result.payload)
-      return ProjectType.HTML
-    })
+    // await log(async () => {
+    //   result = await packProject(projectUIDL as unknown as ProjectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.HTML,
+    //   })
+    //   console.info(ProjectType.HTML, '-', result.payload)
+    //   return ProjectType.HTML
+    // })
 
     /* Styled JSX */
     await log(async () => {
@@ -93,218 +93,218 @@ const run = async () => {
 
     /* Frameworks using Css-Modules */
 
-    await log(async () => {
-      result = await packProject(projectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.NEXT,
-        plugins: [new ProjectPluginCSSModules({ framework: ProjectType.NEXT })],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-next-css-modules',
-        },
-      })
-      console.info(ProjectType.NEXT + '-' + ReactStyleVariation.CSSModules, '-', result.payload)
-      return `Next - CSSModules`
-    })
+    // await log(async () => {
+    //   result = await packProject(projectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.NEXT,
+    //     plugins: [new ProjectPluginCSSModules({ framework: ProjectType.NEXT })],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-next-css-modules',
+    //     },
+    //   })
+    //   console.info(ProjectType.NEXT + '-' + ReactStyleVariation.CSSModules, '-', result.payload)
+    //   return `Next - CSSModules`
+    // })
 
-    /* Frameworks use CSS */
+    // /* Frameworks use CSS */
 
-    await log(async () => {
-      result = await packProject(projectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.REACT,
-      })
-      console.info(ProjectType.REACT, '-', result.payload)
-      return ProjectType.REACT
-    })
+    // await log(async () => {
+    //   result = await packProject(projectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.REACT,
+    //   })
+    //   console.info(ProjectType.REACT, '-', result.payload)
+    //   return ProjectType.REACT
+    // })
 
-    await log(async () => {
-      result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
-      console.info(ProjectType.NUXT, '-', result.payload)
-      return ProjectType.NUXT
-    })
+    // await log(async () => {
+    //   result = await packProject(projectUIDL, { ...packerOptions, projectType: ProjectType.NUXT })
+    //   console.info(ProjectType.NUXT, '-', result.payload)
+    //   return ProjectType.NUXT
+    // })
 
-    await log(async () => {
-      result = await packProject(projectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.VUE,
-      })
-      console.info(ProjectType.VUE, '-', result.payload)
-      return ProjectType.VUE
-    })
+    // await log(async () => {
+    //   result = await packProject(projectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.VUE,
+    //   })
+    //   console.info(ProjectType.VUE, '-', result.payload)
+    //   return ProjectType.VUE
+    // })
 
-    await log(async () => {
-      result = await packProject(projectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.ANGULAR,
-      })
-      console.info(ProjectType.ANGULAR, '-', result.payload)
-      return ProjectType.ANGULAR
-    })
+    // await log(async () => {
+    //   result = await packProject(projectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.ANGULAR,
+    //   })
+    //   console.info(ProjectType.ANGULAR, '-', result.payload)
+    //   return ProjectType.ANGULAR
+    // })
 
-    /* React JSS */
-    await log(async () => {
-      result = await packProject(projectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.NEXT,
-        plugins: [new ProjectPluginReactJSS({ framework: ProjectType.NEXT })],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-next-react-jss',
-        },
-      })
-      console.info(ProjectType.NEXT + '-' + ReactStyleVariation.ReactJSS, '-', result.payload)
-      return `NEXT - React-JSS`
-    })
+    // /* React JSS */
+    // await log(async () => {
+    //   result = await packProject(projectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.NEXT,
+    //     plugins: [new ProjectPluginReactJSS({ framework: ProjectType.NEXT })],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-next-react-jss',
+    //     },
+    //   })
+    //   console.info(ProjectType.NEXT + '-' + ReactStyleVariation.ReactJSS, '-', result.payload)
+    //   return `NEXT - React-JSS`
+    // })
 
-    /* Styled Components */
-    await log(async () => {
-      result = await packProject(reactProjectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.REACT,
-        plugins: [new ProjectPluginStyledComponents({ framework: ProjectType.REACT })],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: `teleport-project-react-styled-components`,
-        },
-      })
-      return `React - StyledComponents`
-    })
+    // /* Styled Components */
+    // await log(async () => {
+    //   result = await packProject(reactProjectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.REACT,
+    //     plugins: [new ProjectPluginStyledComponents({ framework: ProjectType.REACT })],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: `teleport-project-react-styled-components`,
+    //     },
+    //   })
+    //   return `React - StyledComponents`
+    // })
 
-    await log(async () => {
-      result = await packProject(projectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.NEXT,
-        plugins: [new ProjectPluginStyledComponents({ framework: ProjectType.NEXT })],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-next-styled-components',
-        },
-      })
-      console.info(
-        ProjectType.NEXT + '-' + ReactStyleVariation.StyledComponents,
-        '-',
-        result.payload
-      )
-      return `Next - StyledComponents`
-    })
+    // await log(async () => {
+    //   result = await packProject(projectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.NEXT,
+    //     plugins: [new ProjectPluginStyledComponents({ framework: ProjectType.NEXT })],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-next-styled-components',
+    //     },
+    //   })
+    //   console.info(
+    //     ProjectType.NEXT + '-' + ReactStyleVariation.StyledComponents,
+    //     '-',
+    //     result.payload
+    //   )
+    //   return `Next - StyledComponents`
+    // })
 
-    /* Frameworks using default + tailwind ccss */
+    // /* Frameworks using default + tailwind ccss */
 
-    await log(async () => {
-      result = await packProject(tailwindProjectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.NEXT,
-        plugins: [
-          new ProjectPluginTailwind({
-            framework: ProjectType.NEXT,
-          }),
-        ],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-next-tailwind',
-        },
-      })
+    // await log(async () => {
+    //   result = await packProject(tailwindProjectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.NEXT,
+    //     plugins: [
+    //       new ProjectPluginTailwind({
+    //         framework: ProjectType.NEXT,
+    //       }),
+    //     ],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-next-tailwind',
+    //     },
+    //   })
 
-      console.info(ProjectType.NEXT, '+' + 'tailwind', '-', result.payload)
-      return `Next - Tailwind`
-    })
+    //   console.info(ProjectType.NEXT, '+' + 'tailwind', '-', result.payload)
+    //   return `Next - Tailwind`
+    // })
 
-    await log(async () => {
-      result = await packProject(tailwindProjectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.REACT,
-        plugins: [
-          new ProjectPluginTailwind({
-            framework: ProjectType.REACT,
-          }),
-        ],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-react-tailwind',
-        },
-      })
+    // await log(async () => {
+    //   result = await packProject(tailwindProjectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.REACT,
+    //     plugins: [
+    //       new ProjectPluginTailwind({
+    //         framework: ProjectType.REACT,
+    //       }),
+    //     ],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-react-tailwind',
+    //     },
+    //   })
 
-      console.info(ProjectType.REACT, '+' + 'tailwind', '-', result.payload)
-      return `React - Tailwind`
-    })
+    //   console.info(ProjectType.REACT, '+' + 'tailwind', '-', result.payload)
+    //   return `React - Tailwind`
+    // })
 
-    await log(async () => {
-      result = await packProject(tailwindProjectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.VUE,
-        plugins: [
-          new ProjectPluginTailwind({
-            framework: ProjectType.VUE,
-          }),
-        ],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-vue-tailwind',
-        },
-      })
+    // await log(async () => {
+    //   result = await packProject(tailwindProjectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.VUE,
+    //     plugins: [
+    //       new ProjectPluginTailwind({
+    //         framework: ProjectType.VUE,
+    //       }),
+    //     ],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-vue-tailwind',
+    //     },
+    //   })
 
-      console.info(ProjectType.VUE, '+' + 'tailwind', '-', result.payload)
-      return `VUE - Tailwind`
-    })
+    //   console.info(ProjectType.VUE, '+' + 'tailwind', '-', result.payload)
+    //   return `VUE - Tailwind`
+    // })
 
-    await log(async () => {
-      result = await packProject(tailwindProjectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.ANGULAR,
-        plugins: [
-          new ProjectPluginTailwind({
-            framework: ProjectType.ANGULAR,
-          }),
-        ],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-angular-tailwind',
-        },
-      })
+    // await log(async () => {
+    //   result = await packProject(tailwindProjectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.ANGULAR,
+    //     plugins: [
+    //       new ProjectPluginTailwind({
+    //         framework: ProjectType.ANGULAR,
+    //       }),
+    //     ],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-angular-tailwind',
+    //     },
+    //   })
 
-      console.info(ProjectType.ANGULAR, '+' + 'tailwind', '-', result.payload)
-      return `Angular - Tailwind`
-    })
+    //   console.info(ProjectType.ANGULAR, '+' + 'tailwind', '-', result.payload)
+    //   return `Angular - Tailwind`
+    // })
 
-    await log(async () => {
-      result = await packProject(tailwindProjectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.NUXT,
-        plugins: [
-          new ProjectPluginTailwind({
-            framework: ProjectType.NUXT,
-          }),
-        ],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-nuxt-tailwind',
-        },
-      })
+    // await log(async () => {
+    //   result = await packProject(tailwindProjectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.NUXT,
+    //     plugins: [
+    //       new ProjectPluginTailwind({
+    //         framework: ProjectType.NUXT,
+    //       }),
+    //     ],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-nuxt-tailwind',
+    //     },
+    //   })
 
-      console.info(ProjectType.NUXT, '+' + 'tailwind', '-', result.payload)
-      return `Nuxt - Tailwind`
-    })
+    //   console.info(ProjectType.NUXT, '+' + 'tailwind', '-', result.payload)
+    //   return `Nuxt - Tailwind`
+    // })
 
-    await log(async () => {
-      result = await packProject(tailwindProjectUIDL, {
-        ...packerOptions,
-        projectType: ProjectType.HTML,
-        plugins: [
-          new ProjectPluginTailwind({
-            framework: ProjectType.HTML,
-            path: [''],
-          }),
-        ],
-        publishOptions: {
-          ...packerOptions.publishOptions,
-          projectSlug: 'teleport-project-html-tailwind',
-        },
-      })
+    // await log(async () => {
+    //   result = await packProject(tailwindProjectUIDL, {
+    //     ...packerOptions,
+    //     projectType: ProjectType.HTML,
+    //     plugins: [
+    //       new ProjectPluginTailwind({
+    //         framework: ProjectType.HTML,
+    //         path: [''],
+    //       }),
+    //     ],
+    //     publishOptions: {
+    //       ...packerOptions.publishOptions,
+    //       projectSlug: 'teleport-project-html-tailwind',
+    //     },
+    //   })
 
-      console.info(ProjectType.HTML, '+' + 'tailwind', '-', result.payload)
-      return `Html - Tailwind`
-    })
+    //   console.info(ProjectType.HTML, '+' + 'tailwind', '-', result.payload)
+    //   return `Html - Tailwind`
+    // })
   } catch (e) {
     console.info(e)
   }

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -362,6 +362,7 @@ export interface UIDLExternalDependency {
     importJustPath?: boolean
     useAsReference?: boolean
     importAlias?: string
+    needsWindowObject?: boolean
   }
 }
 

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -310,6 +310,7 @@ export const externaldependencyDecoder: Decoder<UIDLExternalDependency> = object
       originalName: optional(string()),
       importJustPath: optional(boolean()),
       useAsReference: optional(boolean()),
+      needsWindowObject: optional(boolean()),
     })
   ),
 })


### PR DESCRIPTION
This fixes build size for all NextJS projects. I will cross check for all other frameworks too. `lottie` player is little heavy. Right now, it's being added into all projects. 

<img width="1800" alt="Screenshot 2023-04-22 at 20 30 12" src="https://user-images.githubusercontent.com/11075561/233806603-32a07353-13df-4f28-9902-290616354348.png">
<img width="1800" alt="Screenshot 2023-04-22 at 20 30 46" src="https://user-images.githubusercontent.com/11075561/233806607-71846820-d4c4-4daf-91a6-bfa03c652581.png">
