### PR TITLE
(fix): use `cjs` build instead of `esm` for `nuxt-js`

### DIFF
--- a/packages/teleport-project-generator-nuxt/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-nuxt/__tests__/end2end/index.ts
@@ -46,7 +46,7 @@ describe('Vue Nuxt Project Generator', () => {
     expect(components.files[2].content).toContain(`import { Button } from 'antd'`)
     expect(pages.files[0].name).toBe('index')
     expect(pages.files[0].content).toContain(
-      `import DangerousHTML from 'dangerous-html/dist/vue/lib.mjs'`
+      `import DangerousHTML from 'dangerous-html/dist/vue/lib.js'`
     )
 
     expect(packageJSON.content).toContain(`"antd": "4.5.4"`)

--- a/packages/teleport-project-generator-nuxt/src/nuxt-project-mapping.ts
+++ b/packages/teleport-project-generator-nuxt/src/nuxt-project-mapping.ts
@@ -15,7 +15,7 @@ export const NuxtProjectMapping: Mapping = {
         path: 'dangerous-html',
         version: '0.1.12',
         meta: {
-          importAlias: 'dangerous-html/dist/vue/lib.mjs',
+          importAlias: 'dangerous-html/dist/vue/lib.js',
         },
       },
     },


### PR DESCRIPTION
Nuxt bundler seems to build in `cjs` mode. And We have a entry point that is leading to `esm` version of the build.  And so the dev setup is breaking. 