### PR TITLE
(feat): Add response type for resources

### DIFF
--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -694,17 +694,55 @@ export const generateRemoteResourceASTs = (resource: UIDLResourceItem) => {
     ),
   ])
 
-  const responseJSONAST = types.variableDeclaration('const', [
-    types.variableDeclarator(
-      types.identifier('response'),
-      types.awaitExpression(
-        types.callExpression(
-          types.memberExpression(types.identifier('data'), types.identifier('json'), false),
-          []
-        )
-      )
-    ),
-  ])
+  const responseType = resource?.response?.type ?? 'json'
+  let responseJSONAST
+
+  switch (responseType) {
+    case 'json':
+      responseJSONAST = types.variableDeclaration('const', [
+        types.variableDeclarator(
+          types.identifier('response'),
+          types.awaitExpression(
+            types.callExpression(
+              types.memberExpression(types.identifier('data'), types.identifier('json'), false),
+              []
+            )
+          )
+        ),
+      ])
+      break
+
+    case 'text': {
+      responseJSONAST = types.variableDeclaration('const', [
+        types.variableDeclarator(
+          types.identifier('response'),
+          types.awaitExpression(
+            types.callExpression(
+              types.memberExpression(types.identifier('data'), types.identifier('text'), false),
+              []
+            )
+          )
+        ),
+      ])
+      break
+    }
+
+    case 'headers': {
+      responseJSONAST = types.variableDeclaration('const', [
+        types.variableDeclarator(
+          types.identifier('response'),
+          types.memberExpression(types.identifier('data'), types.identifier('headers'))
+        ),
+      ])
+      break
+    }
+
+    default: {
+      responseJSONAST = types.variableDeclaration('const', [
+        types.variableDeclarator(types.identifier('response'), types.identifier('data')),
+      ])
+    }
+  }
 
   return [paramsAST, fetchAST, responseJSONAST]
 }

--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -697,6 +697,15 @@ export const generateRemoteResourceASTs = (resource: UIDLResourceItem) => {
   const responseType = resource?.response?.type ?? 'json'
   let responseJSONAST
 
+  /**
+   * Responce types can be of json, text and we might be reading just headers
+   * So, with the response type of the resource. We are returning either
+   * - data.json()
+   * - data.text()
+   * - data.headers
+   * back to the caller, from the fetch response.
+   */
+
   switch (responseType) {
     case 'json':
       responseJSONAST = types.variableDeclaration('const', [

--- a/packages/teleport-plugin-next-static-paths/src/utils.ts
+++ b/packages/teleport-plugin-next-static-paths/src/utils.ts
@@ -64,7 +64,7 @@ const computePropsAST = (
           types.identifier('headers'),
           types.callExpression(
             types.memberExpression(types.identifier('Object'), types.identifier('fromEntries')),
-            [types.memberExpression(types.identifier('response'), types.identifier('headers'))]
+            [types.identifier('response')]
           )
         ),
       ])

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -45,6 +45,9 @@ export interface UIDLResourceItem {
   body?: Record<string, UIDLStaticValue>
   params?: Record<string, UIDLStaticValue | UIDLPropValue>
   mappers?: string[]
+  response?: {
+    type: 'headers' | 'text' | 'json'
+  }
 }
 
 /**

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -148,6 +148,11 @@ export const resourceItemDecoder: Decoder<UIDLResourceItem> = object({
   body: optional(dict(staticValueDecoder)),
   mappers: withDefault([], array(string())),
   params: optional(dict(union(staticValueDecoder, dyamicFunctionParam))),
+  response: optional(
+    object({
+      type: withDefault('json', union(constant('json'), constant('headers'), constant('text'))),
+    })
+  ),
 })
 
 export const initialPropsDecoder: Decoder<UIDLInitialPropsData> = object({


### PR DESCRIPTION
By default we return the response into `json`. But in few cases we need headers alone instead of `json` result. So, Adding the response type for the resources.

This will respond the resource with `data.headers` instead of `data.json()`

```js
  const response = data.headers
  return response
```