### PR TITLE
custom url html export issue

### DIFF
--- a/packages/teleport-project-generator-html/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-html/__tests__/end2end/index.ts
@@ -73,7 +73,7 @@ describe('Unwinds the slot inside the component when used in page', () => {
       (file) => file.name === 'index' && file.fileType === FileType.HTML
     )
     const cssFile = result.files.find(
-      (file) => file.name === 'home' && file.fileType === FileType.CSS
+      (file) => file.name === 'index' && file.fileType === FileType.CSS
     )
 
     expect(indexFile).toBeDefined()

--- a/packages/teleport-project-generator-html/__tests__/index.ts
+++ b/packages/teleport-project-generator-html/__tests__/index.ts
@@ -20,7 +20,7 @@ describe('Passes the rootClass which using the component', () => {
       (file) => file.name === 'index' && file.fileType === FileType.HTML
     )
     const styleFile = result.files.find(
-      (file) => file.name === 'landing-page' && file.fileType === FileType.CSS
+      (file) => file.name === 'index' && file.fileType === FileType.CSS
     )
 
     expect(mainFile).toBeDefined()
@@ -41,7 +41,7 @@ describe('Image Resolution', () => {
     })
     const { files } = await generator.generateProject(uidlWithImages)
 
-    const mainCSS = files.find((file) => file.name === 'home' && file.fileType === FileType.CSS)
+    const mainCSS = files.find((file) => file.name === 'index' && file.fileType === FileType.CSS)
     const indexFile = files.find((file) => file.name === 'index' && file.fileType === FileType.HTML)
 
     expect(indexFile).toBeDefined()

--- a/packages/teleport-project-generator-html/src/index.ts
+++ b/packages/teleport-project-generator-html/src/index.ts
@@ -20,6 +20,9 @@ const createHTMLProjectGenerator = (config?: { individualEntyFile: boolean }) =>
     pages: {
       generator: createHTMLComponentGenerator,
       path: [''],
+      options: {
+        useFileNameForNavigation: true,
+      },
     },
     static: {
       prefix: 'public',


### PR DESCRIPTION
Needed to add a page option for html project generator to enable custom url to be used, else the pages were generated with their page name making links with the custom url not working