### PR TITLE
(feat): Add `none` response type so mappers can read headers and body both using the repsonse type

### DIFF
--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -680,6 +680,13 @@ export const generateRemoteResourceASTs = (resource: UIDLResourceItem) => {
       break
     }
 
+    case 'none': {
+      responseJSONAST = types.variableDeclaration('const', [
+        types.variableDeclarator(types.identifier('response'), types.identifier('data')),
+      ])
+      break
+    }
+
     default: {
       responseJSONAST = types.variableDeclaration('const', [
         types.variableDeclarator(types.identifier('response'), types.identifier('data')),

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -54,7 +54,7 @@ export interface UIDLResourceItem {
   params?: Record<string, UIDLStaticValue | UIDLPropValue | UIDLStateValue>
   mappers?: string[]
   response?: {
-    type: 'headers' | 'text' | 'json'
+    type: 'headers' | 'text' | 'json' | 'none'
   }
 }
 

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -158,7 +158,10 @@ export const resourceItemDecoder: Decoder<UIDLResourceItem> = object({
   params: optional(dict(union(staticValueDecoder, dyamicFunctionParam, dyamicFunctionStateParam))),
   response: optional(
     object({
-      type: withDefault('json', union(constant('json'), constant('headers'), constant('text'))),
+      type: withDefault(
+        'json',
+        union(constant('json'), constant('headers'), constant('text'), constant('none'))
+      ),
     })
   ),
 })


### PR DESCRIPTION
We are making all the mappers to have a same signature to return the data. You can check it in the PR here
https://github.com/teleporthq/teleport-cms-mappers/pull/2

But for wordpress, the pagination comes from `headers` and the data comes from `body` at the same time. So, we the mappers need access to the whole response object to read the data. And return as the same signature as all the `mappers`. 

```js
export default async function (params = {}) {
  const urlParams = {
    per_page: 2,
    page: 1,
  }
  const data = await fetch(
    `${process.env.CMS_URL}/wp-json/wp/v2/book?${new URLSearchParams(
      urlParams
    )}`,
    {
      method: 'GET',
      headers: {
        Authorization: `Bearer ${process.env.CMS_ACCESS_TOKEN}`,
      },
    }
  )
  const response = data
  return normalize(response)
}
```