### PR TITLE
(refactor): Add better error handling for revalidation end-points

### DIFF
--- a/packages/teleport-project-plugin-next-revalidate-api/src/utils.ts
+++ b/packages/teleport-project-plugin-next-revalidate-api/src/utils.ts
@@ -38,20 +38,48 @@ export const generateCallbackExpression = (
   const switchCases: types.SwitchCase[] = Object.entries(routeMappings).map(
     ([contentType, paths]) => {
       return types.switchCase(types.stringLiteral(contentType), [
-        ...paths.map((dynamicPath) => {
-          const expression = ASTUtils.getExpressionFromUIDLExpressionNode({
-            type: 'expr',
-            content: '`' + appendDataToObjectExpression(dynamicPath) + '`',
-          }) as types.TemplateLiteral
+        types.blockStatement([
+          types.tryStatement(
+            types.blockStatement([
+              ...paths.map((dynamicPath) => {
+                const expression = ASTUtils.getExpressionFromUIDLExpressionNode({
+                  type: 'expr',
+                  content: '`' + appendDataToObjectExpression(dynamicPath) + '`',
+                }) as types.TemplateLiteral
 
-          return types.expressionStatement(
-            types.callExpression(
-              types.memberExpression(types.identifier('res'), types.identifier('revalidate')),
-              [expression]
+                return types.expressionStatement(
+                  types.awaitExpression(
+                    types.callExpression(
+                      types.memberExpression(
+                        types.identifier('res'),
+                        types.identifier('revalidate')
+                      ),
+                      [expression]
+                    )
+                  )
+                )
+              }),
+            ]),
+            types.catchClause(
+              types.identifier('error'),
+              types.blockStatement([
+                types.expressionStatement(
+                  types.callExpression(
+                    types.memberExpression(types.identifier('console'), types.identifier('log')),
+                    [types.stringLiteral('Failed in clearing cache')]
+                  )
+                ),
+                types.expressionStatement(
+                  types.callExpression(
+                    types.memberExpression(types.identifier('console'), types.identifier('log')),
+                    [types.identifier('error')]
+                  )
+                ),
+              ])
             )
-          )
-        }),
-        types.breakStatement(),
+          ),
+          types.breakStatement(),
+        ]),
       ])
     }
   )
@@ -60,7 +88,8 @@ export const generateCallbackExpression = (
     types.switchCase(null, [
       types.throwStatement(
         types.newExpression(types.identifier('Error'), [
-          types.stringLiteral('Invalid content type'),
+          types.stringLiteral('Invalid content typ, received'),
+          types.identifier('contentType'),
         ])
       ),
     ])
@@ -68,6 +97,7 @@ export const generateCallbackExpression = (
 
   return types.arrowFunctionExpression(
     [types.identifier('data'), types.identifier('contentType')],
-    types.blockStatement([types.switchStatement(types.identifier('contentType'), switchCases)])
+    types.blockStatement([types.switchStatement(types.identifier('contentType'), switchCases)]),
+    true
   )
 }


### PR DESCRIPTION
Adds better error logging for handling revalidate end-points

```js
import { revalidate } from '@teleporthq/cms-mappers/wordpress/revalidate'

export default async function handler(req, res) {
  try {
    if (process.env.RANDOM_SECRET !== req.query['RANDOM_SECRET']) {
      return res.status(401).json({
        revalidated: false,
      })
    }

    await revalidate(req, async (data, contentType) => {
      switch (contentType) {
        case 'bogpost': {
          try {
            await res.revalidate(`/bogpost/${data.id}`)
            await res.revalidate(`/bogpost`)
          } catch (error) {
            console.log('Failed in clearing cache')
            console.log(error)
          }

          break
        }

        case 'page': {
          try {
            await res.revalidate(`/page`)
            await res.revalidate(`/page/${data.id}`)
          } catch (error) {
            console.log('Failed in clearing cache')
            console.log(error)
          }

          break
        }

        case 'book': {
          try {
            await res.revalidate(`/book/${data.id}`)
            await res.revalidate(`/book`)
          } catch (error) {
            console.log('Failed in clearing cache')
            console.log(error)
          }

          break
        }

        default:
          throw new Error('Invalid content typ, received', contentType)
      }
    })
    return res.status(200).json({
      revalidated: true,
    })
  } catch (error) {
    console.log(error)
    return res.status(500).json({
      revalidated: false,
    })
  }
}

```