### PR TITLE
(refactor): Use optional expressions instead of member expressions

### DIFF
--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -709,26 +709,27 @@ const generateRESTHeadersAST = (headers: UIDLResourceItem['headers']): types.Obj
 }
 
 export const generateMemberExpressionASTFromBase = (
-  base: types.MemberExpression | types.Identifier,
+  base: types.OptionalMemberExpression | types.MemberExpression | types.Identifier,
   path: string[]
-): types.MemberExpression => {
+): types.OptionalMemberExpression => {
   if (path.length === 1) {
-    return types.memberExpression(base, types.identifier(path[0]), false)
+    return types.optionalMemberExpression(base, types.identifier(path[0]), false, true)
   }
 
   const pathClone = [...path]
   pathClone.pop()
 
-  return types.memberExpression(
+  return types.optionalMemberExpression(
     generateMemberExpressionASTFromBase(base, pathClone),
     types.identifier(path[path.length - 1]),
-    false
+    false,
+    true
   )
 }
 
 export const generateMemberExpressionASTFromPath = (
   path: Array<string | number>
-): types.MemberExpression | types.Identifier => {
+): types.OptionalMemberExpression | types.Identifier => {
   const pathClone = [...path]
   if (path.length === 1) {
     return types.identifier(path[0].toString())
@@ -738,19 +739,21 @@ export const generateMemberExpressionASTFromPath = (
 
   const currentPath = path[path.length - 1]
   if (typeof currentPath === 'number') {
-    return types.memberExpression(
+    return types.optionalMemberExpression(
       generateMemberExpressionASTFromPath(pathClone),
       types.numericLiteral(currentPath),
+      false,
       true
     )
   }
 
   const containsSpecial = currentPath.indexOf('.') !== -1 || currentPath.indexOf('-') !== -1
 
-  return types.memberExpression(
+  return types.optionalMemberExpression(
     generateMemberExpressionASTFromPath(pathClone),
     containsSpecial ? types.stringLiteral(currentPath) : types.identifier(currentPath),
-    containsSpecial
+    containsSpecial,
+    true
   )
 }
 

--- a/packages/teleport-plugin-next-static-paths/src/utils.ts
+++ b/packages/teleport-plugin-next-static-paths/src/utils.ts
@@ -139,10 +139,14 @@ const computePropsAST = (
             )
           : types.callExpression(
               types.memberExpression(
-                ASTUtils.generateMemberExpressionASTFromPath([
-                  'response',
-                  ...initialData.exposeAs.valuePath,
-                ]),
+                types.logicalExpression(
+                  '||',
+                  ASTUtils.generateMemberExpressionASTFromPath([
+                    'response',
+                    ...initialData.exposeAs.valuePath,
+                  ]),
+                  types.arrayExpression()
+                ),
                 types.identifier('map'),
                 false
               ),

--- a/packages/teleport-plugin-next-static-props/src/utils.ts
+++ b/packages/teleport-plugin-next-static-props/src/utils.ts
@@ -95,7 +95,7 @@ const computePropsAST = (
         types.callExpression(types.identifier(resourceImportName), [
           types.objectExpression([
             types.spreadElement(
-              types.memberExpression(
+              types.optionalMemberExpression(
                 types.identifier('context'),
                 types.identifier('params'),
                 false,
@@ -116,7 +116,7 @@ const computePropsAST = (
 
   const dataWeNeedAccessorAST =
     isDetailsPage && !pagination
-      ? types.memberExpression(responseMemberAST, types.numericLiteral(0), true)
+      ? types.optionalMemberExpression(responseMemberAST, types.numericLiteral(0), true, true)
       : responseMemberAST
 
   const returnAST = types.returnStatement(
@@ -137,8 +137,8 @@ const computePropsAST = (
               false
             ),
             types.spreadElement(
-              types.memberExpression(
-                types.memberExpression(
+              types.optionalMemberExpression(
+                types.optionalMemberExpression(
                   types.identifier('response'),
                   types.identifier('meta'),
                   false,

--- a/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
+++ b/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
@@ -202,7 +202,7 @@ const computeUseEffectAST = (params: {
     ]
   )
 
-  let responseExpression: types.MemberExpression
+  let responseExpression: types.OptionalMemberExpression
 
   if (node.type === 'cms-item') {
     responseExpression =
@@ -210,10 +210,11 @@ const computeUseEffectAST = (params: {
         ? (ASTUtils.generateMemberExpressionASTFromPath([
             'data',
             ...itemValuePath,
-          ]) as types.MemberExpression)
-        : types.memberExpression(
+          ]) as types.OptionalMemberExpression)
+        : types.optionalMemberExpression(
             types.memberExpression(types.identifier('data'), types.identifier('data'), false),
             types.numericLiteral(0),
+            true,
             true
           )
   }
@@ -222,7 +223,7 @@ const computeUseEffectAST = (params: {
     responseExpression = ASTUtils.generateMemberExpressionASTFromPath([
       'data',
       ...valuePath,
-    ]) as types.MemberExpression
+    ]) as types.OptionalMemberExpression
   }
 
   const resourceAST = types.arrowFunctionExpression(


### PR DESCRIPTION
The response from the mappers is a little bit in-consistent some times. And even the fetch requests to. This is just to make sure we are using optional expressions. So, the `getStaticProps` and `getStaticPaths` won't keep crashing in those conditions. Here is the output from the new AST looks like

```js
export async function getStaticPaths() {
  const response = await authorPageInitialPaths34991Resource({
    content_type: 'author',
    select: 'sys.id',
  })
  return {
    paths: (response?.data || []).map((item) => {
      return {
        params: {
          id: (item?.sys?.id).toString(),
        },
      }
    }),
    fallback: false,
  }
}

export async function getStaticProps(context) {
  const response = await authorPageInitialProps2cfa5Resource({
    ...context?.params,
  })
  return {
    props: {
      authorEntity: response?.data?.[0],
      ...response?.meta?.pagination,
    },
  }
}
```