### PR TITLE
Use fallback: blocking on CMS pages for non-tiny datasets to work

### DIFF
--- a/packages/teleport-plugin-next-static-paths/src/utils.ts
+++ b/packages/teleport-plugin-next-static-paths/src/utils.ts
@@ -183,7 +183,12 @@ const computePropsAST = (
         false,
         false
       ),
-      types.objectProperty(types.identifier('fallback'), types.booleanLiteral(false), false, false),
+      types.objectProperty(
+        types.identifier('fallback'),
+        types.stringLiteral('blocking'),
+        false,
+        false
+      ),
     ])
   )
 


### PR DESCRIPTION
Change getStaticPaths generation a tiny bit to use `fallback: 'blocking'` instead of `fallback: false`