### PR TITLE
(feat): Support expressions for resource params

### DIFF
--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -568,6 +568,15 @@ export const generateRemoteResourceASTs = (resource: UIDLResourceItem) => {
       acc.push(types.objectProperty(types.stringLiteral(item), ASTUtils.resolveObjectValue(prop)))
     }
 
+    if (prop.type === 'expr') {
+      acc.push(
+        types.objectProperty(
+          types.stringLiteral(item),
+          ASTUtils.getExpressionFromUIDLExpressionNode(prop)
+        )
+      )
+    }
+
     if (prop.type === 'dynamic') {
       acc.push(
         types.spreadElement(
@@ -776,7 +785,7 @@ export const generateMemberExpressionASTFromPath = (
 }
 
 export const generateURLParamsAST = (
-  urlParams: Record<string, UIDLStaticValue | UIDLStateValue | UIDLPropValue>
+  urlParams: Record<string, UIDLStaticValue | UIDLStateValue | UIDLPropValue | UIDLExpressionValue>
 ): types.TemplateLiteral | null => {
   if (!urlParams) {
     return null
@@ -797,13 +806,12 @@ export const generateURLParamsAST = (
 }
 
 const resolveDynamicValuesFromUrlParams = (
-  field: UIDLStaticValue | UIDLPropValue | UIDLStateValue,
+  field: UIDLStaticValue | UIDLPropValue | UIDLStateValue | UIDLExpressionValue,
   query: Record<string, types.Expression>,
   prefix: string = null
 ) => {
   if (field.type === 'dynamic' || field.type === 'static') {
     query[prefix] = resolveUrlParamsValue(field)
-    return
   }
 }
 

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -51,7 +51,7 @@ export interface UIDLResourceItem {
   }
   method?: 'GET' | 'POST'
   body?: Record<string, UIDLStaticValue>
-  params?: Record<string, UIDLStaticValue | UIDLPropValue | UIDLStateValue>
+  params?: Record<string, UIDLStaticValue | UIDLPropValue | UIDLStateValue | UIDLExpressionValue>
   mappers?: string[]
   response?: {
     type: 'headers' | 'text' | 'json' | 'none'

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -162,7 +162,16 @@ export const resourceItemDecoder: Decoder<UIDLResourceItem> = object({
   method: withDefault('GET', union(constant('GET'), constant('POST'))),
   body: optional(dict(staticValueDecoder)),
   mappers: withDefault([], array(string())),
-  params: optional(dict(union(staticValueDecoder, dyamicFunctionParam, dyamicFunctionStateParam))),
+  params: optional(
+    dict(
+      union(
+        staticValueDecoder,
+        dyamicFunctionParam,
+        dyamicFunctionStateParam,
+        expressionValueDecoder
+      )
+    )
+  ),
   response: optional(
     object({
       type: withDefault(


### PR DESCRIPTION
Helps, in passing expressions to the resource params
Example

```js
export default async function (params = {}) {
  const urlParams = {
    content_type: 'blogPost',
    limit: 2,
    ...(params['skip'] && {
      skip: params['skip'],
    }),
    filters: JSON.stringify({
      [params?.id]: {
        type: 'equals',
        filter: params.id,
      },
    }),
  }
  .....
}
```