### PR TITLE
(feat): Allow to send prop and state values to resource fetchers

### DIFF
--- a/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/index.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/index.ts
@@ -354,6 +354,18 @@ const generateCMSNode: NodeToJSX<UIDLCMSListNode | UIDLCMSItemNode, types.JSXEle
           acc.push(types.objectProperty(types.stringLiteral(attrKey), expression))
         }
 
+        if (
+          property.type === 'dynamic' &&
+          (property.content.referenceType === 'state' || property.content.referenceType === 'prop')
+        ) {
+          acc.push(
+            types.objectProperty(
+              types.stringLiteral(attrKey),
+              types.identifier(property.content.id)
+            )
+          )
+        }
+
         return acc
       },
       []

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/index.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/index.ts
@@ -354,14 +354,18 @@ const generateCMSNode: NodeToJSX<UIDLCMSListNode | UIDLCMSItemNode, types.JSXEle
           acc.push(types.objectProperty(types.stringLiteral(attrKey), expression))
         }
 
-        if (
-          property.type === 'dynamic' &&
-          (property.content.referenceType === 'state' || property.content.referenceType === 'prop')
-        ) {
+        if (property.type === 'dynamic') {
           acc.push(
             types.objectProperty(
               types.stringLiteral(attrKey),
-              types.identifier(property.content.id)
+              property.content.referenceType === 'prop'
+                ? types.memberExpression(
+                    types.identifier(
+                      options.dynamicReferencePrefixMap[property.content.referenceType]
+                    ),
+                    types.identifier(property.content.id)
+                  )
+                : types.identifier(property.content.id)
             )
           )
         }

--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -975,23 +975,33 @@ const resolveResourceValue = (value: UIDLStaticValue | UIDLENVValue) => {
   return `process.env.${value.content}`
 }
 
-export const resolveObjectValue = (prop: UIDLStaticValue | UIDLPropValue | UIDLExpressionValue) => {
-  if (prop.type === 'expr') {
-    return types.identifier(prop.content)
+export const resolveObjectValue = (
+  prop: UIDLStaticValue | UIDLExpressionValue
+):
+  | types.Identifier
+  | types.StringLiteral
+  | types.NumericLiteral
+  | types.BooleanLiteral
+  | types.ObjectExpression
+  | types.Expression => {
+  if (prop.type === 'static') {
+    const value =
+      typeof prop.content === 'string'
+        ? types.stringLiteral(prop.content)
+        : typeof prop.content === 'boolean'
+        ? types.booleanLiteral(prop.content)
+        : typeof prop.content === 'number'
+        ? types.numericLiteral(prop.content)
+        : typeof prop.content === 'object'
+        ? objectToObjectExpression(prop.content as unknown as Record<string, unknown>)
+        : types.identifier(String(prop.content))
+
+    return value
   }
 
-  const value =
-    typeof prop.content === 'string'
-      ? types.stringLiteral(prop.content)
-      : typeof prop.content === 'boolean'
-      ? types.booleanLiteral(prop.content)
-      : typeof prop.content === 'number'
-      ? types.numericLiteral(prop.content)
-      : typeof prop.content === 'object'
-      ? objectToObjectExpression(prop.content as unknown as Record<string, unknown>)
-      : types.identifier(String(prop.content))
-
-  return value
+  if (prop.type === 'expr') {
+    return getExpressionFromUIDLExpressionNode(prop)
+  }
 }
 
 export const getExpressionFromUIDLExpressionNode = (

--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -515,7 +515,7 @@ export const createStateHookAST = (
   return t.variableDeclaration('const', [
     t.variableDeclarator(
       t.arrayPattern([
-        t.identifier(StringUtils.createStateOrPropStoringValue(stateKey)),
+        t.identifier(stateKey),
         t.identifier(StringUtils.createStateStoringFunction(stateKey)),
       ]),
       t.callExpression(t.identifier('useState'), [defaultValueArgument])

--- a/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
+++ b/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
@@ -8,12 +8,10 @@ import {
   UIDLCMSItemNodeContent,
   UIDLCMSListNode,
   UIDLCMSListNodeContent,
-  UIDLExpressionValue,
   UIDLLocalResource,
   UIDLNode,
-  UIDLPropValue,
   UIDLResourceItem,
-  UIDLStaticValue,
+  UIDLResourceLink,
 } from '@teleporthq/teleport-types'
 import { StringUtils, UIDLUtils } from '@teleporthq/teleport-shared'
 import * as types from '@babel/types'
@@ -50,16 +48,13 @@ export const createNextComponentInlineFetchPlugin: ComponentPluginFactory<Contex
         return
       }
 
-      const isLocalResource = 'id' in resource
-      const isExternalResource = 'name' in resource
-
       let resourceFileName: string
       let resourceImportVariable: string
       let importPath: string
       let funcParams = ''
       let isNamedImport = false
 
-      if (isLocalResource) {
+      if ('id' in resource) {
         const { id = null, params = {} } = (resource as UIDLLocalResource) || {}
         if (!id) {
           return
@@ -97,7 +92,7 @@ export const createNextComponentInlineFetchPlugin: ComponentPluginFactory<Contex
         })
       }
 
-      if (isExternalResource) {
+      if ('name' in resource) {
         const { name, dependency } = resource
         resourceImportVariable = dependency.meta?.originalName || name
         importPath = dependency?.meta?.importAlias || dependency.path
@@ -156,7 +151,7 @@ const computeUseEffectAST = (params: {
   resourceType: UIDLResourceItem['method']
   node: UIDLCMSItemNode | UIDLCMSListNode
   componentChunk: ChunkDefinition
-  params: Record<string, UIDLStaticValue | UIDLPropValue | UIDLExpressionValue>
+  params: UIDLResourceLink['params']
 }) => {
   const { node, fileName, componentChunk, resourceType } = params
   if (node.type !== 'cms-item' && node.type !== 'cms-list') {

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -339,13 +339,13 @@ export type UIDLResourceLink = UIDLLocalResource | UIDLExternalResource
 
 export interface UIDLLocalResource {
   id: string
-  params?: Record<string, UIDLStaticValue | UIDLPropValue | UIDLExpressionValue>
+  params?: Record<string, UIDLStaticValue | UIDLPropValue | UIDLExpressionValue | UIDLStateValue>
 }
 
 export interface UIDLExternalResource {
   name: string
   dependency: UIDLExternalDependency
-  params?: Record<string, UIDLStaticValue | UIDLPropValue | UIDLExpressionValue>
+  params?: Record<string, UIDLStaticValue | UIDLPropValue | UIDLExpressionValue | UIDLStateValue>
 }
 
 export interface UIDLCMSListNodeContent {

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -178,13 +178,23 @@ export interface ComponentUIDL {
 }
 
 export type UIDLDesignTokens = Record<string, UIDLStaticValue>
+
 export interface UIDLInitialPropsData {
   exposeAs: {
     name: string
     valuePath?: string[]
     itemValuePath?: string[]
   }
-  resource: UIDLResourceLink
+  resource:
+    | {
+        id: string
+        params?: Record<string, UIDLStaticValue | UIDLExpressionValue>
+      }
+    | {
+        name: string
+        dependency: UIDLExternalDependency
+        params?: Record<string, UIDLStaticValue | UIDLExpressionValue>
+      }
   /*
     We allow the configuration of cache strategy globally for the whole project under
     uidl.resources.cache
@@ -206,7 +216,16 @@ export interface UIDLInitialPathsData {
     valuePath?: string[]
     itemValuePath?: string[]
   }
-  resource: UIDLResourceLink
+  resource:
+    | {
+        id: string
+        params?: Record<string, UIDLStaticValue | UIDLExpressionValue>
+      }
+    | {
+        name: string
+        dependency: UIDLExternalDependency
+        params?: Record<string, UIDLStaticValue | UIDLExpressionValue>
+      }
 }
 
 export interface UIDLComponentOutputOptions {

--- a/packages/teleport-uidl-resolver/src/utils.ts
+++ b/packages/teleport-uidl-resolver/src/utils.ts
@@ -502,7 +502,7 @@ export const prefixAssetURLs = <
 
             /*
               background image such as gradient shouldn't be urls
-              we prevent that by checking if the value is actually an asset or not (same check as in the prefixAssetsPath function 
+              we prevent that by checking if the value is actually an asset or not (same check as in the prefixAssetsPath function
               but we don't compute and generate a url)
             */
             if (!asset.startsWith('/')) {

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -182,47 +182,23 @@ export const resourceItemDecoder: Decoder<UIDLResourceItem> = object({
   ),
 })
 
-export const uidlLocalResourcerDecpder: Decoder<UIDLLocalResource> = object({
-  id: string(),
-  params: optional(
-    dict(
-      union(
-        staticValueDecoder,
-        dyamicFunctionParam,
-        expressionValueDecoder,
-        lazy(() => dyamicFunctionStateParam)
-      )
-    )
-  ),
-})
-
-export const uidlExternalResourceDecoder: Decoder<UIDLExternalResource> = object({
-  name: string(),
-  dependency: lazy(() => externaldependencyDecoder),
-  params: optional(
-    dict(
-      union(
-        staticValueDecoder,
-        dyamicFunctionParam,
-        expressionValueDecoder,
-        lazy(() => dyamicFunctionStateParam)
-      )
-    )
-  ),
-})
-
-export const uidlResourceLinkDecoder: Decoder<UIDLResourceLink> = union(
-  uidlLocalResourcerDecpder,
-  uidlExternalResourceDecoder
-)
-
 export const initialPropsDecoder: Decoder<UIDLInitialPropsData> = object({
   exposeAs: object({
     name: string(),
     valuePath: optional(array(string())),
     itemValuePath: optional(array(string())),
   }),
-  resource: uidlResourceLinkDecoder,
+  resource: union(
+    object({
+      id: string(),
+      params: optional(dict(union(staticValueDecoder, expressionValueDecoder))),
+    }),
+    object({
+      name: string(),
+      dependency: lazy(() => externaldependencyDecoder),
+      params: optional(dict(union(staticValueDecoder, expressionValueDecoder))),
+    })
+  ),
   cache: optional(object({ revalidate: number() })),
 })
 
@@ -232,7 +208,17 @@ export const initialPathsDecoder: Decoder<UIDLInitialPathsData> = object({
     valuePath: optional(array(string())),
     itemValuePath: optional(array(string())),
   }),
-  resource: uidlResourceLinkDecoder,
+  resource: union(
+    object({
+      id: string(),
+      params: optional(dict(union(staticValueDecoder, expressionValueDecoder))),
+    }),
+    object({
+      name: string(),
+      dependency: lazy(() => externaldependencyDecoder),
+      params: optional(dict(union(staticValueDecoder, expressionValueDecoder))),
+    })
+  ),
 })
 
 export const injectValueDecoder: Decoder<UIDLInjectValue> = object({
@@ -754,6 +740,40 @@ export const dateTimeNodeDecoder: Decoder<VUIDLDateTimeNode> = object({
   content: elementDecoder,
 })
 
+export const uidlLocalResourcerDecpder: Decoder<UIDLLocalResource> = object({
+  id: string(),
+  params: optional(
+    dict(
+      union(
+        staticValueDecoder,
+        dyamicFunctionParam,
+        expressionValueDecoder,
+        lazy(() => dyamicFunctionStateParam)
+      )
+    )
+  ),
+})
+
+export const uidlExternalResourceDecoder: Decoder<UIDLExternalResource> = object({
+  name: string(),
+  dependency: lazy(() => externaldependencyDecoder),
+  params: optional(
+    dict(
+      union(
+        staticValueDecoder,
+        dyamicFunctionParam,
+        expressionValueDecoder,
+        lazy(() => dyamicFunctionStateParam)
+      )
+    )
+  ),
+})
+
+export const uidlResourceLinkDecoder: Decoder<UIDLResourceLink> = union(
+  uidlLocalResourcerDecpder,
+  uidlExternalResourceDecoder
+)
+
 export const cmsItemNodeDecoder: Decoder<VCMSItemUIDLElementNode> = object({
   type: constant('cms-item'),
   content: object({
@@ -770,21 +790,8 @@ export const cmsItemNodeDecoder: Decoder<VCMSItemUIDLElementNode> = object({
     renderPropIdentifier: string(),
     valuePath: optional(array(string())),
     itemValuePath: optional(array(string())),
-    resource: optional(union(uidlLocalResourcerDecpder, uidlExternalResourceDecoder)),
+    resource: optional(uidlResourceLinkDecoder),
     initialData: optional(lazy(() => dyamicFunctionParam)),
-  }),
-})
-
-export const cmsListRepeaterNodeDecoder: Decoder<VCMSListRepeaterElementNode> = object({
-  type: constant('cms-list-repeater'),
-  content: object({
-    elementType: string(),
-    name: withDefault('cms-list-repeater', string()),
-    nodes: object({
-      list: lazy(() => elementNodeDecoder),
-      empty: optional(lazy(() => elementNodeDecoder)),
-    }),
-    renderPropIdentifier: string(),
   }),
 })
 
@@ -805,8 +812,21 @@ export const cmsListNodeDecoder: Decoder<VCMSListUIDLElementNode> = object({
     renderPropIdentifier: string(),
     itemValuePath: optional(array(string())),
     valuePath: optional(array(string())),
-    resource: optional(union(uidlLocalResourcerDecpder, uidlExternalResourceDecoder)),
+    resource: optional(uidlResourceLinkDecoder),
     initialData: optional(lazy(() => dyamicFunctionParam)),
+  }),
+})
+
+export const cmsListRepeaterNodeDecoder: Decoder<VCMSListRepeaterElementNode> = object({
+  type: constant('cms-list-repeater'),
+  content: object({
+    elementType: string(),
+    name: withDefault('cms-list-repeater', string()),
+    nodes: object({
+      list: lazy(() => elementNodeDecoder),
+      empty: optional(lazy(() => elementNodeDecoder)),
+    }),
+    renderPropIdentifier: string(),
   }),
 })
 

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -184,13 +184,31 @@ export const resourceItemDecoder: Decoder<UIDLResourceItem> = object({
 
 export const uidlLocalResourcerDecpder: Decoder<UIDLLocalResource> = object({
   id: string(),
-  params: optional(dict(union(staticValueDecoder, dyamicFunctionParam, expressionValueDecoder))),
+  params: optional(
+    dict(
+      union(
+        staticValueDecoder,
+        dyamicFunctionParam,
+        expressionValueDecoder,
+        lazy(() => dyamicFunctionStateParam)
+      )
+    )
+  ),
 })
 
 export const uidlExternalResourceDecoder: Decoder<UIDLExternalResource> = object({
   name: string(),
   dependency: lazy(() => externaldependencyDecoder),
-  params: optional(dict(union(staticValueDecoder, dyamicFunctionParam, expressionValueDecoder))),
+  params: optional(
+    dict(
+      union(
+        staticValueDecoder,
+        dyamicFunctionParam,
+        expressionValueDecoder,
+        lazy(() => dyamicFunctionStateParam)
+      )
+    )
+  ),
 })
 
 export const uidlResourceLinkDecoder: Decoder<UIDLResourceLink> = union(

--- a/packages/teleport-uidl-validator/src/parser/index.ts
+++ b/packages/teleport-uidl-validator/src/parser/index.ts
@@ -152,6 +152,7 @@ const parseComponentNode = (node: Record<string, unknown>, component: ComponentU
       const {
         initialData,
         nodes: { success, error, loading },
+        resource,
       } = (node as unknown as UIDLCMSItemNode).content
 
       if (initialData) {
@@ -181,6 +182,17 @@ const parseComponentNode = (node: Record<string, unknown>, component: ComponentU
             loading as unknown as Record<string, unknown>,
             component
           ) as UIDLElementNode
+      }
+
+      if (resource?.params) {
+        Object.values(resource?.params || {}).forEach((param) => {
+          if (
+            param.type === 'dynamic' &&
+            (param.content.referenceType === 'state' || param.content.referenceType === 'prop')
+          ) {
+            param.content.id = StringUtils.createStateOrPropStoringValue(param.content.id)
+          }
+        })
       }
 
       return node as unknown as UIDLNode

--- a/packages/teleport-uidl-validator/src/validator/utils.ts
+++ b/packages/teleport-uidl-validator/src/validator/utils.ts
@@ -121,6 +121,19 @@ export const checkDynamicDefinitions = (input: Record<string, unknown>) => {
       }
     }
 
+    if (node.type === 'cms-item' || node.type === 'cms-list') {
+      Object.values(node.content?.resource?.params || {}).forEach((param) => {
+        if (
+          param.type === 'dynamic' &&
+          (param.content.referenceType === 'state' || param.content.referenceType === 'prop')
+        ) {
+          param.content.referenceType === 'prop'
+            ? usedPropKeys.push(param.content.id)
+            : usedStateKeys.push(param.content.id)
+        }
+      })
+    }
+
     if (node.type === 'element') {
       Object.keys(node.content?.events || {}).forEach((eventKey) => {
         node.content.events[eventKey].forEach((event) => {


### PR DESCRIPTION
@TudorCe this will have a little impact on the #840. So, let's discuss once before merging 👍 

This PR will allow passing `state` and `prop` values to the `cms-list` and `cms-item`

```json
"resource": {
  "id": "7b9c1f5d-6012-4953-8041-c869482735f1",
  "params": {
    "skip": {
      "type": "expr",
      "content": "(parseInt(router.query?.['cPage-el1ez7'] ?? 1) - 1) * 2"
    },
    "author": {
      "type": "dynamic",
      "content": {
        "referenceType": "state",
        "id": "author_state"
      }
    },
    "author_prop": {
      "type": "dynamic",
      "content": {
        "referenceType": "prop",
        "id": "author_prop"
      }
    }
  }
```