### PR TITLE
(fix): Use Redirect and Switch to define fallback route in react

### DIFF
--- a/packages/teleport-plugin-react-app-routing/src/utils.ts
+++ b/packages/teleport-plugin-react-app-routing/src/utils.ts
@@ -5,7 +5,7 @@ import { ASTBuilders, ASTUtils } from '@teleporthq/teleport-plugin-common'
 export const createRouteRouterTag = (routeJSXDefinitions: types.JSXElement[]) => {
   const routerTag = ASTBuilders.createJSXTag('Router')
 
-  const divContainer = ASTBuilders.createJSXTag('div')
+  const divContainer = ASTBuilders.createJSXTag('Switch')
   ASTUtils.addChildJSXTag(routerTag, divContainer)
   routeJSXDefinitions.forEach((route) => ASTUtils.addChildJSXTag(divContainer, route))
 
@@ -51,6 +51,15 @@ export const registerReactRouterDeps = (dependencies: Record<string, UIDLDepende
   }
 
   dependencies.Route = {
+    type: 'library',
+    path: 'react-router-dom',
+    version: '^5.2.0',
+    meta: {
+      namedImport: true,
+    },
+  }
+
+  dependencies.Switch = {
     type: 'library',
     path: 'react-router-dom',
     version: '^5.2.0',

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs'
+import { readFileSync, rmdirSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import chalk from 'chalk'
 import { packProject } from '@teleporthq/teleport-code-generator'
@@ -72,8 +72,8 @@ const log = async (cb: () => Promise<string>) => {
 const run = async () => {
   try {
     if (packerOptions.publisher === PublisherType.DISK) {
-      // rmdirSync('dist', { recursive: true })
-      // mkdirSync('dist')
+      rmdirSync('dist', { recursive: true })
+      mkdirSync('dist')
     }
 
     let result

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -1,4 +1,4 @@
-import { readFileSync, rmdirSync, mkdirSync } from 'fs'
+import { readFileSync } from 'fs'
 import { join } from 'path'
 import chalk from 'chalk'
 import { packProject } from '@teleporthq/teleport-code-generator'
@@ -72,8 +72,8 @@ const log = async (cb: () => Promise<string>) => {
 const run = async () => {
   try {
     if (packerOptions.publisher === PublisherType.DISK) {
-      rmdirSync('dist', { recursive: true })
-      mkdirSync('dist')
+      // rmdirSync('dist', { recursive: true })
+      // mkdirSync('dist')
     }
 
     let result


### PR DESCRIPTION
The fallback route works only when `Switch` and `Redirect` are used in react. So, this fix now generates the routes to 
```jsx
const App = () => {
  return (
    <Router>
      <Switch>
        <Route component={Home} exact path="/" />
        <Route component={About} exact path="/about" />
        <Route component={Fallback} path="**" />
        <Redirect to="**" />
      </Switch>
    </Router>
  )
}
```