### PR TITLE
fix/THQ-2815 Replace MarkdownToJsx with ReactMarkdown

### DIFF
--- a/packages/teleport-component-generator-react/src/react-mapping.ts
+++ b/packages/teleport-component-generator-react/src/react-mapping.ts
@@ -33,11 +33,11 @@ export const ReactMapping: Mapping = {
       },
     },
     'markdown-node': {
-      elementType: 'Markdown',
+      elementType: 'ReactMarkdown',
       dependency: {
         type: 'package',
-        path: 'markdown-to-jsx',
-        version: '7.2.0',
+        path: 'react-markdown',
+        version: '8.0.7',
       },
     },
     'html-node': {


### PR DESCRIPTION
https://linear.app/teleporthq/issue/THQ-2815/[strapi]-empty-richtext-content-values-break-deploy-builds