### PR TITLE
(feat): Extract root resources for data fetching from external resources

### DIFF
--- a/examples/uidl-samples/caisy.json
+++ b/examples/uidl-samples/caisy.json
@@ -1281,72 +1281,7 @@
                             "content": {
                               "elementType": "fragment",
                               "children": [
-                                {
-                                  "type": "cms-mixed-type",
-                                  "content": {
-                                    "elementType": "CMSMixedType",
-                                    "attrs": {
-                                      "itemData": {
-                                        "type": "expr",
-                                        "content": "context_91umd.data"
-                                      }
-                                    },
-                                    "dependency": {
-                                      "type": "package",
-                                      "path": "@teleporthq/react-components",
-                                      "version": "latest",
-                                      "meta": {
-                                        "namedImport": true
-                                      }
-                                    },
-                                    "renderPropIdentifier": "cms_mixed_type",
-                                    "nodes": {
-                                      "fallback": {
-                                        "type": "element",
-                                        "content": {
-                                          "elementType": "container",
-                                          "children": [
-                                            { "type": "static", "content": "Fallback for cms-mixed type node"}
-                                          ]
-                                        }
-                                      },
-                                      "error": {
-                                        "type": "element",
-                                        "content": {
-                                          "elementType": "container",
-                                          "children": [
-                                            { "type": "static", "content": "Error for cms-mixed type node"}
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "mappings": {
-                                      "blogPost": {
-                                        "type": "element",
-                                        "content": {
-                                          "elementType": "container",
-                                          "children": [
-                                            {
-                                              "type": "static",
-                                              "content": "Rendering blog-post component"
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      "blogPostExternal": {
-                                        "type": "element",
-                                        "content": {
-                                          "elementType": "component",
-                                          "semanticType": "ExternalComponent",
-                                          "dependency": {
-                                            "type": "local"
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                {
+                               {
                                   "type": "cms-list-repeater",
                                   "content": {
                                     "elementType": "cms-list-repeater",

--- a/packages/teleport-plugin-next-static-props/src/index.ts
+++ b/packages/teleport-plugin-next-static-props/src/index.ts
@@ -41,10 +41,10 @@ export const createStaticPropsPlugin: ComponentPluginFactory<StaticPropsPluginCo
           `Resource ${resource.id} is being used, but missing from the project ressources. Check ${uidl.name} in UIDL for more information`
         )
       }
-      resourceImportName = StringUtils.dashCaseToCamelCase(
-        StringUtils.camelCaseToDashCase(`${usedResource.name}-resource`)
-      )
 
+      resourceImportName = StringUtils.dashCaseToCamelCase(
+        StringUtils.camelCaseToDashCase(usedResource.name + 'Resource')
+      )
       const importPath = `${resources.path}${StringUtils.camelCaseToDashCase(usedResource.name)}`
 
       dependencies[resourceImportName] = {

--- a/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
+++ b/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
@@ -74,14 +74,13 @@ export const createNextComponentInlineFetchPlugin: ComponentPluginFactory<Contex
         let dependencyPath: string
 
         if ('id' in extractedResource) {
-          resourceName = StringUtils.createStateOrPropStoringValue(
-            resources.items[extractedResource.id].name + 'Resource'
-          )
+          resourceName = resources.items[extractedResource.id].name
           const resourcesPath = paths.resources
           const currentPagePath = [...paths.pages, ...uidl.outputOptions.folderPath]
           dependencyPath =
             GenericUtils.generateLocalDependenciesPrefix(currentPagePath, resourcesPath) +
             StringUtils.camelCaseToDashCase(resourceName)
+
           dependencies[resourceName] = {
             type: 'local',
             path: dependencyPath,

--- a/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
+++ b/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
@@ -17,18 +17,13 @@ import {
 import { GenericUtils, StringUtils, UIDLUtils } from '@teleporthq/teleport-shared'
 import * as types from '@babel/types'
 import { ASTUtils } from '@teleporthq/teleport-plugin-common'
+import { FilteredResource } from '.'
 
 interface ContextPluginConfig {
   componentChunkName?: string
   files: Map<string, InMemoryFileRecord>
   dependencies: Record<string, string>
-  extractedResources: Record<
-    string,
-    UIDLLocalResource & {
-      itemValuePath?: string[]
-      valuePath?: string[]
-    }
-  >
+  extractedResources: Record<string, FilteredResource>
   paths: {
     resources: string[]
     pages: string[]
@@ -74,19 +69,28 @@ export const createNextComponentInlineFetchPlugin: ComponentPluginFactory<Contex
       )
 
       if (extractedResources[propKey]) {
-        const usedResource = resources.items[extractedResources[propKey].id]
-        const resourceName = StringUtils.createStateOrPropStoringValue(
-          usedResource.name + 'Resource'
-        )
+        const extractedResource = extractedResources[propKey]
+        let resourceName: string
+        let dependencyPath: string
 
-        const resourcesPath = paths.resources
-        const currentPagePath = [...paths.pages, ...uidl.outputOptions.folderPath]
-
-        dependencies[resourceName] = {
-          type: 'local',
-          path:
+        if ('id' in extractedResource) {
+          resourceName = StringUtils.createStateOrPropStoringValue(
+            resources.items[extractedResource.id].name + 'Resource'
+          )
+          const resourcesPath = paths.resources
+          const currentPagePath = [...paths.pages, ...uidl.outputOptions.folderPath]
+          dependencyPath =
             GenericUtils.generateLocalDependenciesPrefix(currentPagePath, resourcesPath) +
-            StringUtils.camelCaseToDashCase(usedResource.name),
+            StringUtils.camelCaseToDashCase(resourceName)
+          dependencies[resourceName] = {
+            type: 'local',
+            path: dependencyPath,
+          }
+        }
+
+        if ('name' in extractedResource) {
+          resourceName = extractedResource.name
+          dependencies[resourceName] = extractedResource.dependency
         }
 
         extractedResourceDeclerations[propKey] = types.variableDeclaration('const', [
@@ -102,6 +106,20 @@ export const createNextComponentInlineFetchPlugin: ComponentPluginFactory<Contex
                       false,
                       true
                     )
+                  ),
+                  ...Object.keys(extractedResource?.params || {}).reduce(
+                    (acc: types.ObjectProperty[], item) => {
+                      const prop = extractedResource.params[item]
+                      acc.push(
+                        types.objectProperty(
+                          types.stringLiteral(item),
+                          ASTUtils.resolveObjectValue(prop)
+                        )
+                      )
+
+                      return acc
+                    },
+                    []
                   ),
                 ]),
               ])
@@ -301,13 +319,7 @@ export default async function handler(req, res) {
 
 const computeResponseObjectForExtractedResources = (
   extractedResourceDeclerations: Record<string, types.VariableDeclaration>,
-  extractedResources: Record<
-    string,
-    UIDLLocalResource & {
-      itemValuePath?: string[]
-      valuePath?: string[]
-    }
-  >
+  extractedResources: Record<string, FilteredResource>
 ) => {
   return Object.keys(extractedResourceDeclerations).map((key) => {
     const extractedResource = extractedResources[key]

--- a/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
+++ b/packages/teleport-project-plugin-inline-fetch/src/next/utils.ts
@@ -74,12 +74,14 @@ export const createNextComponentInlineFetchPlugin: ComponentPluginFactory<Contex
         let dependencyPath: string
 
         if ('id' in extractedResource) {
-          resourceName = resources.items[extractedResource.id].name
+          resourceName = StringUtils.dashCaseToCamelCase(
+            StringUtils.camelCaseToDashCase(resources.items[extractedResource.id].name + 'Resource')
+          )
           const resourcesPath = paths.resources
           const currentPagePath = [...paths.pages, ...uidl.outputOptions.folderPath]
           dependencyPath =
             GenericUtils.generateLocalDependenciesPrefix(currentPagePath, resourcesPath) +
-            StringUtils.camelCaseToDashCase(resourceName)
+            StringUtils.camelCaseToDashCase(resources.items[extractedResource.id].name)
 
           dependencies[resourceName] = {
             type: 'local',

--- a/packages/teleport-test/src/cms.ts
+++ b/packages/teleport-test/src/cms.ts
@@ -32,8 +32,8 @@ const run = async () => {
     if (packerOptions.publisher === PublisherType.DISK) {
       try {
         rmdirSync('dist', { recursive: true })
+        mkdirSync('dist')
       } catch /* tslint:disable no-empty */ {}
-      mkdirSync('dist')
     }
 
     let result


### PR DESCRIPTION
Till now, we extracted the root resources only for inline fetches. But for integrations which are using external libraries are not. Because we don't clearly know what `process` variables the external functions are using etc. But now, are opting them to extract as well. As currently there is only one integration that is using it. And we know we are not using any external stuff. This improves caisy integration 👍 