### PR TITLE
(fix): Append `page` and `component` while saving to inMemoryFile record

### DIFF
--- a/packages/teleport-project-generator-html/src/error-page-mapping.ts
+++ b/packages/teleport-project-generator-html/src/error-page-mapping.ts
@@ -14,7 +14,8 @@ class HTMLErrorPageMapping implements ProjectPlugin {
     }
 
     const folder =
-      files.get(fallback.pageOptions?.componentName) || files.get(fallback.pageOptions?.fileName)
+      files.get(`page-${fallback.pageOptions?.componentName}`) ||
+      files.get(`page-${fallback.pageOptions?.fileName}`)
     if (!folder) {
       return structure
     }

--- a/packages/teleport-project-generator-html/src/plugin-home-replace.ts
+++ b/packages/teleport-project-generator-html/src/plugin-home-replace.ts
@@ -32,7 +32,7 @@ class ProjectPluginHomeReplace implements ProjectPlugin {
       }
 
       const component = StringUtils.dashCaseToUpperCamelCase(sanitizedName)
-      const homeFile = files.get(component)
+      const homeFile = files.get(`component-${component}`)
       if (!homeFile) {
         return structure
       }

--- a/packages/teleport-project-generator-nuxt/src/error-page-mapping.ts
+++ b/packages/teleport-project-generator-nuxt/src/error-page-mapping.ts
@@ -14,7 +14,8 @@ class NuxtErrorMappingPlugin implements ProjectPlugin {
     }
 
     const file =
-      files.get(fallback.pageOptions?.componentName) || files.get(fallback.pageOptions?.fileName)
+      files.get(`page-${fallback.pageOptions?.componentName}`) ||
+      files.get(`page-${fallback.pageOptions?.fileName}`)
     if (!file) {
       return structure
     }

--- a/packages/teleport-project-generator/src/index.ts
+++ b/packages/teleport-project-generator/src/index.ts
@@ -376,7 +376,7 @@ export class ProjectGenerator implements ProjectGeneratorType {
 
       const { files, dependencies } = await createPage(pageUIDL, this.pageGenerator, pageOptions)
 
-      inMemoryFilesMap.set(pageUIDL.name, {
+      inMemoryFilesMap.set(`page-${pageUIDL.name}`, {
         path,
         files,
       })
@@ -469,7 +469,7 @@ export class ProjectGenerator implements ProjectGeneratorType {
       const relativePath = UIDLUtils.getComponentFolderPath(componentUIDL)
       const path = this.strategy.components.path.concat(relativePath)
 
-      inMemoryFilesMap.set(componentName, {
+      inMemoryFilesMap.set(`component-${componentName}.`, {
         path,
         files,
       })
@@ -498,7 +498,7 @@ export class ProjectGenerator implements ProjectGeneratorType {
         )
         collectedDependencies = result.dependencies
 
-        inMemoryFilesMap.set(fileName, {
+        inMemoryFilesMap.set(`component-${fileName}`, {
           path: this.strategy.framework.replace.path,
           files: [result.file],
         })

--- a/packages/teleport-project-plugin-styled-components/src/next.ts
+++ b/packages/teleport-project-plugin-styled-components/src/next.ts
@@ -43,7 +43,7 @@ export const nextAfterModifier = async (structure: ProjectPluginStructure) => {
     sheet.collectStyles(<App {...props} />),
   );
   const styleTags = sheet.getStyleElement();
-  
+
   return { ...page, styleTags };
   }\n\n`
   )


### PR DESCRIPTION
This was actually a little complicated that it looked. The main reason the `index` file started to miss is. We had pages like author and then `Auhor1` component. But in the input UIDL we are sending the page name as `/author/Author1`. So, we hae matching page and component names. And the files are being overwritten in the `inMemory` record.

We deduplicate `componentNames` for pages, but we are not doing for components. So, cross comparing both `pages` and `components` is breaking cms pages. Because in `cms` we have same name for multiple pages.

Instead if we change `component` names instead of page names. The names of components changes which breaks imports etc. So, this was the safest way and we don't have external plugins as of now. So, it's safe to go with 👍 