### PR TITLE
(chore): Revert to client side sandboxes

### DIFF
--- a/packages/teleport-publisher-codesandbox/src/constants.ts
+++ b/packages/teleport-publisher-codesandbox/src/constants.ts
@@ -1,3 +1,3 @@
 export const BASE_URL = 'https://codesandbox.io/api/v1/sandboxes/define'
 
-export const BASE_SANDBOX_URL = 'https://codesandbox.io/p/sandbox/'
+export const BASE_SANDBOX_URL = 'https://codesandbox.io/s/'

--- a/packages/teleport-publisher-codesandbox/src/index.ts
+++ b/packages/teleport-publisher-codesandbox/src/index.ts
@@ -38,7 +38,7 @@ export const createCodesandboxPublisher: PublisherFactory<
         'Content-Type': 'application/json',
       },
       method: 'POST',
-      body: JSON.stringify({ files: flatProject, environment: 'server' }),
+      body: JSON.stringify({ files: flatProject }),
     })
 
     if (response.status >= 500) {


### PR DESCRIPTION
Reverting to v1 version of sandboxes.

We switched to `v2` sandboxes before https://github.com/teleporthq/teleport-code-generators/pull/735 