### PR TITLE
(fix): Missing project style imports when using project styles in css-in-js flavours and fix static-classes on node.

### DIFF
--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -106,17 +106,21 @@ export const addDynamicAttributeToJSXTag = (
 export const addMultipleDynamicAttributesToJSXTag = (
   jsxASTNode: types.JSXElement,
   name: string,
-  attrValues: Array<types.MemberExpression | types.Identifier> = [],
+  attrValues: Array<types.MemberExpression | types.Identifier | types.StringLiteral> = [],
   t = types
 ) => {
-  const memberExpressions: Array<types.Identifier | types.MemberExpression> = []
+  const memberExpressions: Array<types.Identifier | types.MemberExpression | types.StringLiteral> =
+    []
   const templateElements: types.TemplateElement[] = []
-
   if (attrValues.length === 0) {
     return
   }
 
-  let content: types.TemplateLiteral | types.MemberExpression | types.Identifier
+  let content:
+    | types.TemplateLiteral
+    | types.MemberExpression
+    | types.Identifier
+    | types.StringLiteral
   if (attrValues.length === 1) {
     content = attrValues[0]
   } else {
@@ -169,6 +173,17 @@ export const addAttributeToJSXTag = (
       nameOfAttribute,
       getProperAttributeValueAssignment(attrValue)
     )
+  }
+
+  const attribute: types.JSXAttribute = jsxNode.openingElement.attributes.find((attr) => {
+    if (attr.type === 'JSXAttribute') {
+      return attr.name.name === attrName
+    }
+  }) as types.JSXAttribute
+
+  if (attribute && attribute.value && attribute.value.type === 'StringLiteral') {
+    attribute.value.value = `${attribute.value.value} ${attrValue}`
+    return
   }
 
   jsxNode.openingElement.attributes.push(attributeDefinition)

--- a/packages/teleport-plugin-css-modules/__tests__/component-scoped.ts
+++ b/packages/teleport-plugin-css-modules/__tests__/component-scoped.ts
@@ -89,7 +89,7 @@ describe('Component Scoped Styles', () => {
       jsxComponent.meta.nodesLookup.container.openingElement.attributes[0].value.expression
 
     expect(jsxExpressions.quasis.length).toBe(4)
-    expect(jsxExpressions.expressions[0]?.property.name).toBe("'md-8'")
+    expect(jsxExpressions.expressions[0]?.value).toBe('md-8')
     expect(jsxExpressions.expressions[1].property.name).toBe("'primary-navbar'")
     expect(jsxExpressions.expressions[2].property.object.name).toBe('props.')
     expect(jsxExpressions.expressions[2].property.property.name).toBe('variant')

--- a/packages/teleport-plugin-css-modules/src/index.ts
+++ b/packages/teleport-plugin-css-modules/src/index.ts
@@ -107,7 +107,9 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
     UIDLUtils.traverseElements(node, (element) => {
       const { style, key, referencedStyles, dependency, attrs = {} } = element
       const jsxTag = astNodesLookup[key] as types.JSXElement
-      const classNamesToAppend: Set<types.MemberExpression | types.Identifier> = new Set()
+      const classNamesToAppend: Set<
+        types.MemberExpression | types.Identifier | types.StringLiteral
+      > = new Set()
 
       if (dependency?.type === 'local') {
         StyleBuilders.setPropValueForCompStyle({
@@ -150,7 +152,7 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
             StyleBuilders.createDynamicStyleExpression(styleValue, propsPrefix)
           )
 
-          /* If dynamic styles are on nested-styles they are unfortunately lost, 
+          /* If dynamic styles are on nested-styles they are unfortunately lost,
             since inline style does not support that */
           if (Object.keys(inlineStyles).length > 0) {
             ASTUtils.addAttributeToJSXTag(jsxTag, 'style', inlineStyles)
@@ -194,13 +196,7 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
             case 'component-referenced': {
               const classContent = styleRef.content.content
               if (classContent.type === 'static') {
-                classNamesToAppend.add(
-                  types.memberExpression(
-                    types.identifier(styleObjectImportName),
-                    types.identifier(`'${getClassName(String(classContent.content))}'`),
-                    true
-                  )
-                )
+                classNamesToAppend.add(types.stringLiteral(String(classContent.content)))
                 return
               }
 
@@ -223,8 +219,8 @@ export const createCSSModulesPlugin: ComponentPluginFactory<CSSModulesConfig> = 
                 if (!defaultPropValue) {
                   return
                 }
-                /* 
-                  Changing the default value of the prop. 
+                /*
+                  Changing the default value of the prop.
                    When forceScoping is enabled the classnames change. So, we need to change the default prop too. */
                 propDefinitions[classContent.content.id].defaultValue = getClassName(
                   String(defaultPropValue)

--- a/packages/teleport-plugin-react-jss/__tests__/component-referenced.ts
+++ b/packages/teleport-plugin-react-jss/__tests__/component-referenced.ts
@@ -80,7 +80,7 @@ describe('Component Scoped Styles', () => {
 
     expect(attrs.value.expression.quasis.length).toBe(3)
     expect(attrExpressions.length).toBe(2)
-    expect(attrExpressions[0].property.name).toBe("'md-8'")
+    expect(attrExpressions[0].value).toBe('md-8')
     expect(attrExpressions[1].object.name).toBe('classes')
     expect(attrExpressions[1].property.object.name).toBe('props')
     expect(attrExpressions[1].property.property.name).toBe('variant')

--- a/packages/teleport-plugin-react-jss/src/index.ts
+++ b/packages/teleport-plugin-react-jss/src/index.ts
@@ -95,7 +95,9 @@ export const createReactJSSPlugin: ComponentPluginFactory<JSSConfig> = (config) 
       }
 
       const className = getClassName(key)
-      const classNamesToAppend: Set<types.MemberExpression | types.Identifier> = new Set()
+      const classNamesToAppend: Set<
+        types.MemberExpression | types.Identifier | types.StringLiteral
+      > = new Set()
       const nodeStyleIdentifier = types.memberExpression(
         types.identifier(styleObjectImportName),
         types.identifier(`'${className}'`),
@@ -154,13 +156,7 @@ export const createReactJSSPlugin: ComponentPluginFactory<JSSConfig> = (config) 
             case 'component-referenced': {
               const classContent = styleRef.content.content
               if (classContent.type === 'static') {
-                classNamesToAppend.add(
-                  types.memberExpression(
-                    types.identifier(styleObjectImportName),
-                    types.identifier(`'${classContent.content}'`),
-                    true
-                  )
-                )
+                classNamesToAppend.add(types.stringLiteral(String(classContent.content)))
                 return
               }
 
@@ -184,7 +180,7 @@ export const createReactJSSPlugin: ComponentPluginFactory<JSSConfig> = (config) 
                   return
                 }
                 /*
-                  Changing the default value of the prop. 
+                  Changing the default value of the prop.
                   When forceScoping is enabled the classnames change. So, we need to change the default prop too.
                 */
                 propDefinitions[classContent.content.id].defaultValue = getClassName(

--- a/packages/teleport-plugin-react-styled-components/__tests__/component-scoped.ts
+++ b/packages/teleport-plugin-react-styled-components/__tests__/component-scoped.ts
@@ -34,7 +34,7 @@ describe('Component Scoped Styles', () => {
     const variantChunk = chunks.find((chunk) => chunk.name === 'variant')
     const declaration = variantChunk.content.declarations[0].init
 
-    expect(chunks.length).toBe(2)
+    expect(chunks.length).toBe(3)
     expect(declaration.callee.name).toBe('variant')
     expect(declaration.arguments[0].properties.length).toBe(2)
     expect(declaration.arguments[0].properties[0].value.value).toBe('compVariant')

--- a/packages/teleport-plugin-react-styled-components/src/index.ts
+++ b/packages/teleport-plugin-react-styled-components/src/index.ts
@@ -84,17 +84,10 @@ export const createReactStyledComponentsPlugin: ComponentPluginFactory<StyledCom
         })
       }
 
-      if (
-        Object.keys(style || {}).length === 0 &&
-        Object.keys(referencedStyles || {}).length === 0
-      ) {
-        return
-      }
-
       const root = jsxNodesLookup[key]
       let className = StringUtils.dashCaseToUpperCamelCase(key)
 
-      if (style && Object.keys(style).length > 0) {
+      if (style) {
         /* Styled components might create an element that
           clashes with native element (Text, View, Image, etc.) */
         if (
@@ -114,7 +107,7 @@ export const createReactStyledComponentsPlugin: ComponentPluginFactory<StyledCom
         })
       }
 
-      if (referencedStyles && Object.keys(referencedStyles)?.length > 0) {
+      if (referencedStyles) {
         Object.values(referencedStyles).forEach((styleRef) => {
           switch (styleRef.content?.mapType) {
             case 'inlined': {
@@ -171,12 +164,7 @@ export const createReactStyledComponentsPlugin: ComponentPluginFactory<StyledCom
               }
 
               if (styleRef.content.content.type === 'static') {
-                componentStyleReferences.add(componentVariantPropPrefix)
-                ASTUtils.addAttributeToJSXTag(
-                  root,
-                  componentVariantPropKey,
-                  styleRef.content.content.content
-                )
+                ASTUtils.addAttributeToJSXTag(root, 'className', styleRef.content.content.content)
               }
 
               if (
@@ -205,7 +193,7 @@ export const createReactStyledComponentsPlugin: ComponentPluginFactory<StyledCom
                   const usedCompStyle = componentStyleSheet[String(prop.defaultValue)]
                   componentStyleReferences.add(usedCompStyle.type)
                   /*
-                  Changing the default value of the prop. 
+                  Changing the default value of the prop.
                   When forceScoping is enabled the classnames change. So, we need to change the default prop too.
                 */
                   propDefinitions[styleRef.content.content.content.id].defaultValue = getClassName(

--- a/packages/teleport-plugin-react-styled-components/src/utils.ts
+++ b/packages/teleport-plugin-react-styled-components/src/utils.ts
@@ -58,7 +58,7 @@ export const generateStyledComponent = (params: {
       types.identifier(name),
       types.callExpression(
         types.callExpression(types.identifier('styled'), [types.stringLiteral(elementType)]),
-        expressionArguments
+        expressionArguments.length > 0 ? expressionArguments : [types.objectExpression([])]
       )
     ),
   ])
@@ -92,7 +92,7 @@ export const generateStyledComponentStyles = (params: {
       }
 
       if (style.type === 'dynamic' && style.content.referenceType === 'state') {
-        throw new PluginStyledComponent(`Error running transformDynamicStyles in reactStyledComponentsPlugin. 
+        throw new PluginStyledComponent(`Error running transformDynamicStyles in reactStyledComponentsPlugin.
         Unsupported styleValue.content.referenceType value ${style.content.referenceType}`)
       }
 

--- a/packages/teleport-project-generator/src/index.ts
+++ b/packages/teleport-project-generator/src/index.ts
@@ -255,9 +255,12 @@ export class ProjectGenerator implements ProjectGeneratorType {
           projectStyleSet: {
             styleSetDefinitions,
             fileName: this.strategy.projectStyleSheet?.fileName,
-            path: this.strategy.pages.options?.createFolderForEachComponent
-              ? join('..', ...this.strategy.projectStyleSheet.path)
-              : join(...this.strategy.projectStyleSheet?.path),
+            path: generateLocalDependenciesPrefix(
+              this.strategy.pages.path,
+              this.strategy.pages.options?.createFolderForEachComponent
+                ? ['..', ...this.strategy.projectStyleSheet.path]
+                : this.strategy.projectStyleSheet?.path
+            ),
             importFile: this.strategy.projectStyleSheet?.importFile || false,
           },
         }),


### PR DESCRIPTION
When generating projects with any `css-in-js` style of frameworks. The import of the global style sheet file is broken right now.

```js
import projectStyles from 'pagesstyle.module.css'
import styles from './about.module.css'
```

See the `pagesstyle.module.css` should be `./style.module.css`. Instead of calculating the relative path from the component/page w.r.t to the global style sheet location. We are just appending them. This fixes the code to generate

```js
import projectStyles from './style.module.css'
import styles from './about.module.css'
```
