### PR TITLE
(fix): add more checks for root component uidl and fix the existing one

### DIFF
--- a/packages/teleport-project-generator/__tests__/index.ts
+++ b/packages/teleport-project-generator/__tests__/index.ts
@@ -64,6 +64,7 @@ describe('Generic Project Generator', () => {
 
       const routerUIDL = {
         ...uidl.root,
+        styleSetDefinitions: {},
         outputOptions: {
           fileName: 'index',
         },
@@ -150,6 +151,7 @@ describe('Generic Project Generator', () => {
 
       const routerUIDL = {
         ...uidl.root,
+        styleSetDefinitions: {},
         outputOptions: {
           fileName: strategy.router.fileName,
         },
@@ -207,6 +209,7 @@ describe('Generic Project Generator', () => {
 
       const routerUIDL = {
         ...uidl.root,
+        styleSetDefinitions: {},
         outputOptions: {
           fileName: 'index',
         },

--- a/packages/teleport-types/src/vuidl.ts
+++ b/packages/teleport-types/src/vuidl.ts
@@ -46,7 +46,6 @@ import {
   UIDLExternalResource,
   UIDLInjectValue,
   UIDLStateValueDetails,
-  UIDLRouteDefinitions,
   UIDLStateDefinition,
   UIDLCMSMixedTypeNode,
   UIDLDependency,
@@ -183,7 +182,7 @@ export type VUIDLElement = Modify<
     }
     events: UIDLElement['events']
     dependency?: UIDLDependency
-    children?: VUIDLNode[]
+    children: VUIDLNode[]
     style?: Record<string, UIDLAttributeValue | string | number>
     attrs?: Record<string, UIDLAttributeValue | string | number>
     referencedStyles: Record<
@@ -232,14 +231,13 @@ export type VRootComponentUIDL = Modify<
     seo?: VUIDLComponentSEO
     styleSetDefinitions: Record<string, VUIDLStyleSetDefnition>
     node: VUIDLElementNode
-    stateDefinitions: {
-      route: Modify<
-        UIDLRouteDefinitions,
-        {
-          values: VUIDLStateValueDetails[]
-        }
-      >
-      [x: string]: UIDLStateDefinition
+    stateDefinitions?: {
+      route: {
+        type: string
+        defaultValue: string
+        values: VUIDLStateValueDetails[]
+      }
+      [x: string]: UIDLStateDefinition & { values?: VUIDLStateValueDetails[] }
     }
     designLanguage: {
       tokens: VUIDLDesignTokens

--- a/packages/teleport-uidl-validator/src/decoders/component-decoder.ts
+++ b/packages/teleport-uidl-validator/src/decoders/component-decoder.ts
@@ -49,7 +49,7 @@ export const rootComponentUIDLDecoder: Decoder<VRootComponentUIDL> = object({
   propDefinitions: optional(dict(propDefinitionsDecoder)),
   importDefinitions: optional(dict(externaldependencyDecoder)),
   peerDefinitions: optional(dict(peerDependencyDecoder)),
-  styleSetDefinitions: optional(dict(styleSetDefinitionDecoder)),
+  styleSetDefinitions: withDefault({}, dict(styleSetDefinitionDecoder)),
   outputOptions: optional(outputOptionsDecoder),
   seo: optional(componentSeoDecoder),
   designLanguage: optional(

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -672,7 +672,7 @@ export const elementDecoder: Decoder<VUIDLElement> = object({
       link: optional(anyJson()),
     })
   ),
-  children: optional(array(lazy(() => uidlNodeDecoder))),
+  children: withDefault([], array(lazy(() => uidlNodeDecoder))),
   referencedStyles: optional(
     dict(
       union(


### PR DESCRIPTION
While designing the UIDL. We assumed the nodes can have a children or cannot. But over time, this is becoming too much to maintain the typescript checks. And using `?.` every time we read/write children to the UIDL.
With this, the decoder will add a empty `[]` by default. And the types also assume that the children exists all the time once the `Record<string, unknown>` passes through it and returns a `VComponentUIDL`.