### PR TITLE
(fix): Add `authToken` header only when defined in the UIDL

### DIFF
--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -50,7 +50,7 @@ export interface UIDLResourceItem {
     route: UIDLStaticValue
   }
   method?: 'GET' | 'POST'
-  body?: Record<string, UIDLStaticValue>
+  body?: Record<string, UIDLStaticValue | UIDLExpressionValue>
   params?: Record<string, UIDLStaticValue | UIDLPropValue | UIDLStateValue | UIDLExpressionValue>
   mappers?: string[]
   response?: {

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -162,7 +162,7 @@ export const resourceItemDecoder: Decoder<UIDLResourceItem> = object({
     route: staticValueDecoder,
   }),
   method: withDefault('GET', union(constant('GET'), constant('POST'))),
-  body: optional(dict(staticValueDecoder)),
+  body: optional(dict(union(staticValueDecoder, expressionValueDecoder))),
   mappers: withDefault([], array(string())),
   params: optional(
     dict(


### PR DESCRIPTION
- fixes crashing bug, when the `authToken` is missing from the UIDL.
- Adds support for `body` parameters for `POST` methods.