### PR TITLE
add support for bracket notation path in propDefinitions

### DIFF
--- a/examples/test-samples/component-sample.json
+++ b/examples/test-samples/component-sample.json
@@ -8,7 +8,17 @@
     "items": {
       "type": "array",
       "defaultValue": []
+    },
+    "fields": {
+      "type": "object",
+      "defaultValue": {
+        "custom name": {
+          "bgImage": [{"src": "some url"}]
+        },
+        "alt": "some text"
+      }
     }
+ 
   },
   "stateDefinitions": {
     "isVisible": {
@@ -48,6 +58,13 @@
                 "content": {
                   "referenceType": "prop",
                   "id": "header"
+                }
+              },
+              {
+                "type": "dynamic",
+                "content": {
+                  "referenceType": "prop",
+                  "id": "fields['custom name']['bgImage'][0].src"
                 }
               },
               {

--- a/packages/teleport-uidl-validator/__tests__/validator/index.ts
+++ b/packages/teleport-uidl-validator/__tests__/validator/index.ts
@@ -28,16 +28,23 @@ import { parseProjectJSON } from '../../src/parser'
 
 const uidl = component(
   'Repeat Component',
-  elementNode('container', {}, [
-    repeatNode(
-      elementNode('div', {}, [dynamicNode('local', 'item')]),
-      dynamicNode('prop', 'items'),
-      {
-        useIndex: true,
-      }
-    ),
-  ]),
-  { items: definition('array', ['hello', 'world']) },
+  elementNode(
+    'container',
+    { fields: { type: 'dynamic', content: { referenceType: 'prop', id: 'fields["bg Image"]' } } },
+    [
+      repeatNode(
+        elementNode('div', {}, [dynamicNode('local', 'item')]),
+        dynamicNode('prop', 'items'),
+        {
+          useIndex: true,
+        }
+      ),
+    ]
+  ),
+  {
+    items: definition('array', ['hello', 'world']),
+    fields: definition('object', { 'bg Image': 'test' }),
+  },
   { items: definition('array', ['hello', 'world']) }
 )
 

--- a/packages/teleport-uidl-validator/__tests__/validator/project-sample.json
+++ b/packages/teleport-uidl-validator/__tests__/validator/project-sample.json
@@ -265,6 +265,14 @@
         "items": {
           "type": "array",
           "defaultValue": []
+        },
+        "hero": {
+          "type": "object",
+          "defaultValue": {
+            "bg Image": {
+              "src": "test"
+            }
+          }
         }
       },
       "stateDefinitions": {
@@ -287,6 +295,13 @@
               "content": {
                 "referenceType": "prop",
                 "id": "title"
+              }
+            },
+            "bgImage": {
+              "type": "dynamic",
+              "content": {
+                "referenceType": "prop",
+                "id": "hero['bg Image'].src"
               }
             }
           },


### PR DESCRIPTION
Fixes validator for the case where dynamic prop has a path with bracket notation. For example: previously, the path `fields['test name']` was not supported even if it was defined in propDefinitions. This changes fix that issue