### PR TITLE
(fix): Missing links for nodes in the default values for propDefinitions

### DIFF
--- a/packages/teleport-plugin-react-base-component/src/index.ts
+++ b/packages/teleport-plugin-react-base-component/src/index.ts
@@ -11,6 +11,7 @@ import {
   ComponentPlugin,
   ChunkType,
   FileType,
+  UIDLElementNode,
 } from '@teleporthq/teleport-types'
 import * as types from '@babel/types'
 
@@ -67,6 +68,17 @@ export const createReactComponentPlugin: ComponentPluginFactory<ReactPluginConfi
       stateHandling: 'hooks',
       slotHandling: 'props',
       domHTMLInjection: (content: string) => ASTBuilders.createDOMInjectionNode(content),
+    }
+
+    /*
+      We need to generate jsx structure of every node that is defined in the UIDL.
+      If we use these nodes in the later stage of the code-generation depends on the usage of these nodes.
+    */
+    for (const propKey of Object.keys(propDefinitions)) {
+      const prop = propDefinitions[propKey]
+      if (prop.type === 'element' && typeof prop.defaultValue === 'object') {
+        createJSXSyntax(prop.defaultValue as UIDLElementNode, jsxParams, jsxOptions)
+      }
     }
 
     const jsxTagStructure = createJSXSyntax(uidl.node, jsxParams, jsxOptions)

--- a/packages/teleport-plugin-react-styled-components/src/index.ts
+++ b/packages/teleport-plugin-react-styled-components/src/index.ts
@@ -87,6 +87,16 @@ export const createReactStyledComponentsPlugin: ComponentPluginFactory<StyledCom
       }
 
       const root = jsxNodesLookup[key]
+      if (root === undefined) {
+        throw new PluginStyledComponent(
+          `Element \n ${JSON.stringify(
+            element,
+            null,
+            2
+          )} \n with key ${key} is missing from the template chunk`
+        )
+      }
+
       let className = StringUtils.dashCaseToUpperCamelCase(key)
 
       if (style) {

--- a/packages/teleport-uidl-resolver/src/resolvers/abilities/index.ts
+++ b/packages/teleport-uidl-resolver/src/resolvers/abilities/index.ts
@@ -1,6 +1,17 @@
-import { ComponentUIDL, GeneratorOptions } from '@teleporthq/teleport-types'
+import { ComponentUIDL, GeneratorOptions, UIDLElementNode } from '@teleporthq/teleport-types'
 import { insertLinks } from './utils'
 
 export const resolveAbilities = (uidl: ComponentUIDL, options: GeneratorOptions) => {
+  if (uidl.propDefinitions) {
+    for (const propKey of Object.keys(uidl.propDefinitions)) {
+      const prop = uidl.propDefinitions[propKey]
+      if (prop.type === 'element' && typeof prop.defaultValue === 'object') {
+        uidl.propDefinitions[propKey].defaultValue = insertLinks(
+          prop.defaultValue as UIDLElementNode,
+          options
+        )
+      }
+    }
+  }
   uidl.node = insertLinks(uidl.node, options)
 }


### PR DESCRIPTION
When the nodes in `defaultValue` for prop is using nodes. They are missing from the code that is generated at the end.