### PR TITLE
(fix): Generate jsx and templates for all element props even if not used in components

### DIFF
--- a/packages/teleport-component-generator-html/src/index.ts
+++ b/packages/teleport-component-generator-html/src/index.ts
@@ -8,7 +8,6 @@ import {
   ComponentUIDL,
   GeneratorFactoryParams,
   GeneratorOptions,
-  ElementsLookup,
 } from '@teleporthq/teleport-types'
 import { createComponentGenerator } from '@teleporthq/teleport-component-generator'
 import { StringUtils } from '@teleporthq/teleport-shared'
@@ -26,7 +25,6 @@ const createHTMLComponentGenerator: HTMLComponentGeneratorInstance = ({
   const resolver = new Resolver()
   resolver.addMapping(PlainHTMLMapping)
   mappings.forEach((mapping) => resolver.addMapping(mapping))
-  const nodesLookup: ElementsLookup = {}
 
   const prettierHTML = createPrettierHTMLPostProcessor({
     strictHtmlWhitespaceSensitivity,
@@ -46,7 +44,7 @@ const createHTMLComponentGenerator: HTMLComponentGeneratorInstance = ({
           externals[uidlKey] as unknown as Record<string, unknown>
         )
 
-        const resolvedUIDL = resolver.resolveUIDL(componentUIDL, { assets }, nodesLookup)
+        const resolvedUIDL = resolver.resolveUIDL(componentUIDL, { assets })
         componentUIDLs[
           StringUtils.dashCaseToUpperCamelCase(resolvedUIDL.outputOptions.componentClassName)
         ] = resolvedUIDL
@@ -56,7 +54,7 @@ const createHTMLComponentGenerator: HTMLComponentGeneratorInstance = ({
     },
   })
 
-  const { htmlComponentPlugin, addExternals } = createHTMLBasePlugin({ nodesLookup })
+  const { htmlComponentPlugin, addExternals } = createHTMLBasePlugin()
   generator.addPlugin(htmlComponentPlugin)
   generator.addPlugin(
     createCSSPlugin({

--- a/packages/teleport-component-generator-react/src/react-mapping.ts
+++ b/packages/teleport-component-generator-react/src/react-mapping.ts
@@ -2,6 +2,18 @@ import { Mapping } from '@teleporthq/teleport-types'
 
 export const ReactMapping: Mapping = {
   elements: {
+    fragment: {
+      elementType: 'Fragment',
+      semanticType: 'Fragment',
+      dependency: {
+        type: 'library',
+        path: 'react',
+        version: '^17.0.2',
+        meta: {
+          namedImport: true,
+        },
+      },
+    },
     group: {
       elementType: 'Fragment',
       dependency: {

--- a/packages/teleport-plugin-css/src/index.ts
+++ b/packages/teleport-plugin-css/src/index.ts
@@ -127,7 +127,7 @@ const createCSSPlugin: ComponentPluginFactory<CSSPluginConfig> = (config) => {
             element,
             null,
             2
-          )} \n with key ${key} is missing from the template chunk`
+          )} \n with key ${key} is missing from the template chunk of component ${uidl.name}`
         )
       }
 

--- a/packages/teleport-plugin-html-base-component/src/index.ts
+++ b/packages/teleport-plugin-html-base-component/src/index.ts
@@ -5,16 +5,16 @@ import {
   HastNode,
   ComponentDefaultPluginParams,
   ComponentUIDL,
-  ElementsLookup,
+  HastText,
+  UIDLElementNode,
 } from '@teleporthq/teleport-types'
 import { HASTBuilders, HASTUtils } from '@teleporthq/teleport-plugin-common'
 import { DEFAULT_COMPONENT_CHUNK_NAME } from './constants'
-import { generateHtmlSynatx } from './node-handlers'
+import { generateHtmlSyntax } from './node-handlers'
 import { StringUtils, UIDLUtils } from '@teleporthq/teleport-shared'
 
 interface HtmlPluginConfig {
   componentChunkName: string
-  nodesLookup: ElementsLookup
   wrapComponent?: boolean
 }
 
@@ -26,11 +26,7 @@ interface HtmlPlugin {
 type HtmlPluginFactory<T> = (config?: Partial<T & ComponentDefaultPluginParams>) => HtmlPlugin
 
 export const createHTMLBasePlugin: HtmlPluginFactory<HtmlPluginConfig> = (config) => {
-  const {
-    componentChunkName = DEFAULT_COMPONENT_CHUNK_NAME,
-    wrapComponent = false,
-    nodesLookup = {},
-  } = config || {}
+  const { componentChunkName = DEFAULT_COMPONENT_CHUNK_NAME, wrapComponent = false } = config || {}
   let externals: Record<string, ComponentUIDL> = {}
   let plugins: ComponentPlugin[] = []
 
@@ -49,30 +45,55 @@ export const createHTMLBasePlugin: HtmlPluginFactory<HtmlPluginConfig> = (config
     const { uidl, chunks = [], dependencies, options } = structure
     const { propDefinitions = {}, stateDefinitions = {}, outputOptions } = uidl
 
-    const templatesLookUp: Record<string, unknown> = { ...nodesLookup }
+    const nodesLookup: Record<string, HastNode | HastText> = {}
     const compBase = wrapComponent
       ? HASTBuilders.createHTMLNode('body')
       : HASTBuilders.createHTMLNode('div')
 
-    const bodyContent = await generateHtmlSynatx(
+    const subComponents = {
+      externals: Object.values(externals).reduce(
+        (acc: Record<string, ComponentUIDL>, comp: ComponentUIDL) => {
+          UIDLUtils.setFriendlyOutputOptions(comp)
+          comp.name = StringUtils.removeIllegalCharacters(comp.name) || 'AppComponent'
+          comp.name = UIDLUtils.getComponentClassName(comp)
+          acc[comp.name] = comp
+          return acc
+        },
+        {}
+      ),
+      plugins,
+    }
+    const templateOptions = { chunks, dependencies, options, outputOptions }
+
+    /*
+      We need to generate jsx structure of every node that is defined in the UIDL.
+      If we use these nodes in the later stage of the code-generation depends on the usage of these nodes.
+    */
+    for (const propKey of Object.keys(propDefinitions)) {
+      const prop = propDefinitions[propKey]
+      if (
+        prop.type === 'element' &&
+        prop.defaultValue !== undefined &&
+        typeof prop.defaultValue === 'object'
+      ) {
+        await generateHtmlSyntax(
+          prop.defaultValue as UIDLElementNode,
+          nodesLookup,
+          propDefinitions,
+          stateDefinitions,
+          subComponents,
+          templateOptions
+        )
+      }
+    }
+
+    const bodyContent = await generateHtmlSyntax(
       uidl.node,
-      templatesLookUp,
+      nodesLookup,
       propDefinitions,
       stateDefinitions,
-      {
-        externals: Object.values(externals).reduce(
-          (acc: Record<string, ComponentUIDL>, comp: ComponentUIDL) => {
-            UIDLUtils.setFriendlyOutputOptions(comp)
-            comp.name = StringUtils.removeIllegalCharacters(comp.name) || 'AppComponent'
-            comp.name = UIDLUtils.getComponentClassName(comp)
-            acc[comp.name] = comp
-            return acc
-          },
-          {}
-        ),
-        plugins,
-      },
-      { chunks, dependencies, options, outputOptions }
+      subComponents,
+      templateOptions
     )
 
     HASTUtils.addChildNode(compBase, bodyContent as HastNode)
@@ -84,7 +105,7 @@ export const createHTMLBasePlugin: HtmlPluginFactory<HtmlPluginConfig> = (config
       content: compBase,
       linkAfter: [],
       meta: {
-        nodesLookup: templatesLookUp,
+        nodesLookup,
       },
     })
 

--- a/packages/teleport-plugin-vue-base-component/src/index.ts
+++ b/packages/teleport-plugin-vue-base-component/src/index.ts
@@ -5,8 +5,13 @@ import {
   FileType,
   ChunkType,
   UIDLEventHandlerStatement,
+  UIDLElementNode,
 } from '@teleporthq/teleport-types'
-import { createHTMLTemplateSyntax } from '@teleporthq/teleport-plugin-common'
+import {
+  createHTMLTemplateSyntax,
+  HTMLTemplateGenerationParams,
+  HTMLTemplateSyntax,
+} from '@teleporthq/teleport-plugin-common'
 import { UIDLUtils } from '@teleporthq/teleport-shared'
 
 import {
@@ -35,34 +40,52 @@ export const createVueComponentPlugin: ComponentPluginFactory<VueComponentConfig
     const dataObject: Record<string, unknown> = {}
     const methodsObject: Record<string, UIDLEventHandlerStatement[]> = {}
 
-    const templateContent = createHTMLTemplateSyntax(
-      uidl.node,
-      {
-        templateLookup,
-        dependencies,
-        dataObject,
-        methodsObject,
-        propDefinitions,
-        stateDefinitions,
+    const params: HTMLTemplateGenerationParams = {
+      templateLookup,
+      dependencies,
+      dataObject,
+      methodsObject,
+      propDefinitions,
+      stateDefinitions,
+    }
+    const templateSyntaxOptions: HTMLTemplateSyntax = {
+      interpolation: (value) => `{{ ${value} }}`,
+      eventBinding: (value) => `@${value}`,
+      valueBinding: (value) => `:${value}`,
+      eventEmmitter: (value) => `this.$emit('${value}')`,
+      conditionalAttr: 'v-if',
+      repeatAttr: 'v-for',
+      repeatIterator: (iteratorName, iteratedCollection, useIndex) => {
+        const iterator = useIndex ? `(${iteratorName}, index)` : iteratorName
+        return `${iterator} in ${iteratedCollection}`
       },
-      {
-        interpolation: (value) => `{{ ${value} }}`,
-        eventBinding: (value) => `@${value}`,
-        valueBinding: (value) => `:${value}`,
-        eventEmmitter: (value) => `this.$emit('${value}')`,
-        conditionalAttr: 'v-if',
-        repeatAttr: 'v-for',
-        repeatIterator: (iteratorName, iteratedCollection, useIndex) => {
-          const iterator = useIndex ? `(${iteratorName}, index)` : iteratorName
-          return `${iterator} in ${iteratedCollection}`
-        },
-        customElementTagName: (value) => UIDLUtils.createWebComponentFriendlyName(value),
-        dependencyHandling: 'import',
-        domHTMLInjection: `v-html`,
-        slotBinding: `v-slot`,
-        slotTagName: 'template',
+      customElementTagName: (value) => UIDLUtils.createWebComponentFriendlyName(value),
+      dependencyHandling: 'import',
+      domHTMLInjection: `v-html`,
+      slotBinding: `v-slot`,
+      slotTagName: 'template',
+    }
+
+    /*
+      We need to generate jsx structure of every node that is defined in the UIDL.
+      If we use these nodes in the later stage of the code-generation depends on the usage of these nodes.
+    */
+    for (const propKey of Object.keys(propDefinitions)) {
+      const prop = propDefinitions[propKey]
+      if (
+        prop.type === 'element' &&
+        prop.defaultValue !== undefined &&
+        typeof prop.defaultValue === 'object'
+      ) {
+        createHTMLTemplateSyntax(
+          prop.defaultValue as UIDLElementNode,
+          params,
+          templateSyntaxOptions
+        )
       }
-    )
+    }
+
+    const templateContent = createHTMLTemplateSyntax(uidl.node, params, templateSyntaxOptions)
 
     chunks.push({
       type: ChunkType.HAST,

--- a/packages/teleport-plugin-vue-base-component/src/utils.ts
+++ b/packages/teleport-plugin-vue-base-component/src/utils.ts
@@ -114,8 +114,7 @@ const createVuePropsDefinition = (
         break
 
       case 'element':
-        mappedType = String
-        break
+        return acc
 
       default:
         throw new Error(

--- a/packages/teleport-uidl-resolver/src/html-mapping.ts
+++ b/packages/teleport-uidl-resolver/src/html-mapping.ts
@@ -199,6 +199,16 @@ export const HTMLMapping: Mapping = {
     separator: {
       elementType: 'hr',
     },
+    fragment: {
+      elementType: 'div',
+      name: 'custom-fragment',
+      style: {
+        display: {
+          type: 'static',
+          content: 'contents',
+        },
+      },
+    },
   },
   events: {},
   attributes: {},

--- a/packages/teleport-uidl-resolver/src/utils.ts
+++ b/packages/teleport-uidl-resolver/src/utils.ts
@@ -126,6 +126,10 @@ export const resolveElement = (element: UIDLElement, options: GeneratorOptions) 
   // Semantic type has precedence as it is dictated by the user
   originalElement.elementType = originalElement.semanticType || mappedElement.elementType
 
+  if (mappedElement.style) {
+    originalElement.style = deepmerge(mappedElement.style, originalElement.style || {})
+  }
+
   if (mappedElement.selfClosing) {
     originalElement.selfClosing = mappedElement.selfClosing
   }


### PR DESCRIPTION
This PR fixes #911 for all the other frameworks like `HTML`, `Vue` and `Angular`
I see now the playground is generating `fragment` as wrapper for these attrs. But fragment is not a valid html element. So, added a mapping. so, in non jsx projects it generates.

```html
<div class="app-custom-fragment">
</div>
```

```css
.app-custom-fragment {
  display: contents
}
```

And for jsx, it directly imports from `React`

PS: It is mandatory not to pass `semanticType` for `fragment` nodes. Or else these mappings don't work for react. You need to pass only `elementType`.

```json
{
  "type": "element",
  "content": {
    "elementType": "fragment",
    "referencedStyles": {},
    "abilities": {},
    "children": [
      {
        "type": "element",
        "content": {
          "elementType": "text",
          "semanticType": "h1",
          "referencedStyles": {},
          "abilities": {},
          "children": [
            {
              "type": "static",
              "content": "Heading"
            }
          ]
        }
      }
    ]
  }
}
```
