### PR TITLE
fix: parent node to be of type fragment for slots

### DIFF
--- a/packages/teleport-component-generator-angular/src/angular-mapping.ts
+++ b/packages/teleport-component-generator-angular/src/angular-mapping.ts
@@ -1,5 +1,18 @@
-export const AngularMapping = {
-  elements: {},
+import { Mapping } from '@teleporthq/teleport-types'
+
+export const AngularMapping: Mapping = {
+  elements: {
+    fragment: {
+      elementType: 'div',
+      name: 'custom-fragment',
+      style: {
+        display: {
+          type: 'static',
+          content: 'contents',
+        },
+      },
+    },
+  },
   events: {},
   attributes: {},
 }

--- a/packages/teleport-component-generator-vue/src/vue-mapping.ts
+++ b/packages/teleport-component-generator-vue/src/vue-mapping.ts
@@ -27,6 +27,16 @@ export const VueMapping: Mapping = {
     'lottie-node': {
       elementType: 'lottie-vue-player',
     },
+    fragment: {
+      elementType: 'div',
+      name: 'custom-fragment',
+      style: {
+        display: {
+          type: 'static',
+          content: 'contents',
+        },
+      },
+    },
   },
   events: {},
   attributes: {},

--- a/packages/teleport-project-generator-html/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-html/__tests__/end2end/index.ts
@@ -59,7 +59,7 @@ describe('Html Project Generator', () => {
     expect(aboutCSS?.content).toContain('public/playground_assets/kitten.png')
   })
 
-  it('creates a next project and generates the named-slot for passing components', async () => {
+  it('creates a html project and generates the named-slot for passing components', async () => {
     const generator = createHTMLProjectGenerator()
     const { subFolders, files } = await generator.generateProject(uidlSample)
     const components = subFolders.find((folder) => folder.name === 'components')

--- a/packages/teleport-project-generator-next/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-next/__tests__/end2end/index.ts
@@ -102,7 +102,9 @@ describe('React Next Project Generator', () => {
     const pages = subFolders.find((folder) => folder.name === 'pages')
     const components = subFolders.find((folder) => folder.name === 'components')
     const indexPage = pages?.files.find((file) => file.name === 'index')
-    const heroComponent = components?.files.find((file) => file.name === 'hero')
+    const heroComponent = components?.files.find(
+      (file) => file.name === 'hero' && file.fileType === FileType.JS
+    )
 
     expect(indexPage).toMatchSnapshot()
     expect(heroComponent).toMatchSnapshot()

--- a/packages/teleport-project-generator-next/src/next-project-mapping.ts
+++ b/packages/teleport-project-generator-next/src/next-project-mapping.ts
@@ -101,9 +101,5 @@ export const NextProjectMapping: Mapping = {
         },
       },
     },
-    fragment: {
-      elementType: ' ',
-      semanticType: '',
-    },
   },
 }

--- a/packages/teleport-uidl-resolver/src/resolver.ts
+++ b/packages/teleport-uidl-resolver/src/resolver.ts
@@ -63,7 +63,10 @@ export default class Resolver {
     resolveReferencedStyle(uidl, newOptions)
     resolveHtmlNode(uidl, newOptions)
     // TODO: Rename into apply mappings
-    utils.resolveNode(uidl.node, newOptions)
+    utils.resolveNode(uidl.node, {
+      ...newOptions,
+      propDefinitions: uidl.propDefinitions,
+    })
     utils.resolveNodeInPropDefinitions(uidl, newOptions)
 
     utils.createNodesLookup(uidl, nodesLookup)


### PR DESCRIPTION
This PR, helps in converting the parentNode to of type `Fragment` when the prop is of type `element`. We do this only if the prop's `defaultValue` element is of type `fragment`. This is to make sure, we are not converting the element type for `named-slot`. We do have a prop of type element which we are using for named-slot.
Here is a reference
https://github.com/teleporthq/teleport-code-generators/blob/development/examples/uidl-samples/project.json#L6726

If we don't follow the convention, we will be changing the structure of the layout. So, when you want this behaviour to kick-in. Always pass the root node of defaultValue of the prop to start with `fragment`. 