### PR TITLE
(feat): pass `locale` to params inside getStaticProps to load content based on locale

### DIFF
--- a/packages/teleport-plugin-next-static-props/src/utils.ts
+++ b/packages/teleport-plugin-next-static-props/src/utils.ts
@@ -14,6 +14,12 @@ export const generateInitialPropsAST = (
       types.catchClause(
         types.identifier('error'),
         types.blockStatement([
+          types.expressionStatement(
+            types.callExpression(
+              types.memberExpression(types.identifier('console'), types.identifier('log')),
+              [types.identifier('error')]
+            )
+          ),
           types.returnStatement(
             types.objectExpression([
               types.objectProperty(types.identifier('notFound'), types.booleanLiteral(true)),
@@ -95,6 +101,23 @@ const computePropsAST = (
                 types.identifier('params'),
                 false,
                 true
+              )
+            ),
+            types.spreadElement(
+              types.logicalExpression(
+                '&&',
+                types.optionalMemberExpression(
+                  types.identifier('context'),
+                  types.identifier('locale'),
+                  false,
+                  true
+                ),
+                types.objectExpression([
+                  types.objectProperty(
+                    types.identifier('locale'),
+                    types.memberExpression(types.identifier('context'), types.identifier('locale'))
+                  ),
+                ])
               )
             ),
             ...funcParams,


### PR DESCRIPTION
NextJS has a default support for loading content using `locale`. Which means we don't need to manually add the `[locale]` route to get it from the URL and pass it to the data fetchers. You can read it more about it here.
https://nextjs.org/docs/pages/building-your-application/routing/internationalization#sub-path-routing

```js
module.exports = {
  i18n: {
    locales: ['en', 'ro'],
    defaultLocale: 'en',
  },
}
```

You can directly get the `locale from the `context` inside `getStaticProps`. 
```js
export async function getStaticProps(context) {
  try {
    const response = await blogpostsPageInitialPropsTqRZResource({
      ...context?.params,
      ...(context?.locale && {
        locale: context.locale,
      }),
    })
    if (!response) {
      return {
        notFound: true,
      }
    }
    return {
      props: {
        blogpostsEntities: response,
        ...response?.meta,
      },
      revalidate: 60,
    }
  } catch (error) {
    console.log(error)
    return {
      notFound: true,
    }
  }
}
```

So, we are going to pass the `locale` field to all the data-fetchers by default. This PR only adds support to load content using the `locale` for cms-pages. If the projects are using `cms-list` or `cms-item` which uses `DataProvider` to fetch the data. Then we need to take the locale from the route using `useRouter` from nextjs. Which we can discuss further when needed.

This `locale` field is used by different cms platforms in their own way, as passing as query-params, post body, gql query etc.