### PR TITLE
fix: If root node has a link add display contents to the link-node that is wrapped

### DIFF
--- a/packages/teleport-uidl-resolver/src/resolvers/abilities/utils.ts
+++ b/packages/teleport-uidl-resolver/src/resolvers/abilities/utils.ts
@@ -151,7 +151,7 @@ export const insertLinks = (
     const linkNode = createLinkNode(abilities.link, options)
     linkNode.content.children.push(node)
 
-    if (parentNode?.content.style?.display?.content === 'flex') {
+    if (parentNode === undefined || parentNode?.content.style?.display?.content === 'flex') {
       linkNode.content.style = {
         ...linkNode.content.style,
         display: { type: 'static', content: 'contents' },

--- a/scripts/watcher.mjs
+++ b/scripts/watcher.mjs
@@ -30,14 +30,18 @@ watcher.on('change', async (filePath) => {
       log(chalk.greenBright(`${splitPath[1]}'s types was successfully re-built`))
       log(chalk.blueBright(`Generating code....`))
 
-      exec(`yarn standalone`, { cwd: 'packages/teleport-test' }, (err, stdout, stderr) => {
-        if (err) {
-          console.error(err)
-        }
-        console.log(stderr)
+      exec(
+        `yarn standalone && yarn comp`,
+        { cwd: 'packages/teleport-test' },
+        (err, stdout, stderr) => {
+          if (err) {
+            console.error(err)
+          }
+          console.log(stderr)
 
-        console.log(stdout)
-      })
+          console.log(stdout)
+        }
+      )
     } else {
       log(err, stdout, stderr)
     }


### PR DESCRIPTION
We are only marking the `linkNode` with display `contents` only if the parent node is of type `flex`. But in cases where there is root node. We still need to wrap it with `contents`