### PR TITLE
(fix): Missing default values for nested components

### DIFF
--- a/packages/teleport-plugin-html-base-component/src/node-handlers.ts
+++ b/packages/teleport-plugin-html-base-component/src/node-handlers.ts
@@ -615,11 +615,12 @@ const generateComponentContent = async (
 
 const generateDynamicNode: NodeToHTML<UIDLDynamicReference, Promise<HastNode | HastText>> = async (
   node,
-  /* tslint:disable variable-name */
-  _compName,
+  compName,
   nodesLookup,
   propDefinitions,
-  stateDefinitions
+  stateDefinitions,
+  subComponentOptions,
+  structure
 ): Promise<HastNode | HastText> => {
   if (node.content.referenceType === 'locale') {
     const localeTag = HASTBuilders.createHTMLNode('span')
@@ -650,20 +651,25 @@ const generateDynamicNode: NodeToHTML<UIDLDynamicReference, Promise<HastNode | H
     }
   }
 
-  if (usedReferenceValue.type === 'element' && usedReferenceValue.defaultValue) {
+  if (usedReferenceValue.type === 'element') {
     const elementNode = usedReferenceValue.defaultValue as UIDLElementNode
-
-    if (elementNode.content.key in nodesLookup) {
-      return nodesLookup[elementNode.content.key]
+    if (elementNode) {
+      if (elementNode.content.key in nodesLookup) {
+        return nodesLookup[elementNode.content.key]
+      } else {
+        const elementTag = await generateHtmlSyntax(
+          elementNode,
+          compName,
+          nodesLookup,
+          propDefinitions,
+          stateDefinitions,
+          subComponentOptions,
+          structure
+        )
+        return elementTag
+      }
     }
 
-    const spanTagWrapper = HASTBuilders.createHTMLNode('span')
-    const commentNode = HASTBuilders.createComment(`Content for slot ${node.content.id}`)
-    HASTUtils.addChildNode(spanTagWrapper, commentNode)
-    return spanTagWrapper
-  }
-
-  if (usedReferenceValue.type === 'element' && usedReferenceValue.defaultValue === undefined) {
     const spanTagWrapper = HASTBuilders.createHTMLNode('span')
     const commentNode = HASTBuilders.createComment(`Content for slot ${node.content.id}`)
     HASTUtils.addChildNode(spanTagWrapper, commentNode)


### PR DESCRIPTION
This PR fixes a bug, when there are nested components passing multiple props. HTML misses some of them if they are referring to the same one.

### Current Behaviour

```html
<body>
    <link rel="stylesheet" href="../style.css" />
    <div>
      <link href="./first-level.css" rel="stylesheet" />
      <div class="first-level-container first-level">
        <second-level-wrapper
          class="second-level-wrapper"
          rootclassname="second-levelundefined"
        >
          <!--SecondLevel component-->
          <div class="second-levelroot-class-name">
            <button type="button" class="button">
              <span>
                <span><!--Content for slot label--></span>
              </span>
            </button>
          </div>
        </second-level-wrapper>
      </div>
    </div>
  </body>
```

### After fixing

```html
<body>
    <link rel="stylesheet" href="../style.css" />
    <div>
      <link href="./first-level.css" rel="stylesheet" />
      <div class="first-level-container first-level">
        <second-level-wrapper
          class="second-level-wrapper"
          rootclassname="second-levelundefined"
        >
          <!--SecondLevel component-->
          <div class="second-levelroot-class-name">
            <button type="button" class="button">
              <span>
                <fragment class="second-level-fragment">
                  <span>Button</span>
                </fragment>
              </span>
            </button>
          </div>
        </second-level-wrapper>
      </div>
    </div>
  </body>
```

You can see the default value for the node inside the `SecondLevel` component is missing. This is fixed now in this PR.


[nested-components.json](https://github.com/user-attachments/files/17817962/nested-components.json)
