### PR TITLE
Add support for new prop types

### DIFF
--- a/examples/uidl-samples/component.json
+++ b/examples/uidl-samples/component.json
@@ -103,14 +103,16 @@
           "type": "dynamic",
           "content": {
             "referenceType": "prop",
-            "id": "company.name"
+            "id": "company",
+            "refPath": ["name"]
           }
         },
         {
           "type": "dynamic",
           "content": {
             "referenceType": "prop",
-            "id": "company.location.city"
+            "id": "company",
+            "refPath": ["location", "city"]
           }
         },
         {
@@ -122,14 +124,16 @@
                 "type": "dynamic",
                 "content": {
                   "referenceType": "prop",
-                  "id": "config.height"
+                  "id": "config",
+                  "refPath": ["height"]
                 }
               },
               "width": {
                 "type": "dynamic",
                 "content": {
                   "referenceType": "prop",
-                  "id": "config.width"
+                  "id": "config",
+                  "refPath": ["width"]
                 }
               }
             },

--- a/examples/uidl-samples/tests.json
+++ b/examples/uidl-samples/tests.json
@@ -5386,21 +5386,24 @@
                     "type": "dynamic",
                     "content": {
                       "referenceType": "prop",
-                      "id": "fields.Title"
+                      "id": "fields",
+                      "refPath": ["Title"]
                     }
                   },
                   {
                     "type": "dynamic",
                     "content": {
                       "referenceType": "prop",
-                      "id": "company.name"
+                      "id": "company",
+                      "refPath": ["name"]
                     }
                   },
                   {
                     "type": "dynamic",
                     "content": {
                       "referenceType": "prop",
-                      "id": "company.location"
+                      "id": "company",
+                      "refPath": ["location"]
                     }
                   }
                 ]

--- a/packages/teleport-component-generator-angular/__tests__/integration/company-with-object-prop.ts
+++ b/packages/teleport-component-generator-angular/__tests__/integration/company-with-object-prop.ts
@@ -16,6 +16,8 @@ describe('declares a propDefinitions with type object and use it', () => {
       city: 'Cluj',
     },
   }`)
-    expect(htmlFile?.content).toContain('{{ company.name }}{{ company.location.city }}')
+    expect(htmlFile?.content).toContain(
+      "{{ company?.['name'] }}{{ company?.['location']?.['city'] }}"
+    )
   })
 })

--- a/packages/teleport-component-generator-react/__tests__/integration/component-with-object-prop.ts
+++ b/packages/teleport-component-generator-react/__tests__/integration/component-with-object-prop.ts
@@ -10,7 +10,7 @@ describe('declares a propDefinitions with type object and use it', () => {
 
     expect(jsFile).toBeDefined()
     expect(jsFile?.content).toContain('config: PropTypes.object')
-    expect(jsFile?.content).toContain('height: props.config.height')
+    expect(jsFile?.content).toContain("height: props.config?.['height']")
     expect(jsFile?.content).toContain(`config: {
     height: 30,
     width: 30,

--- a/packages/teleport-component-generator-vue/__tests__/integration/component-with-object-prop.ts
+++ b/packages/teleport-component-generator-vue/__tests__/integration/component-with-object-prop.ts
@@ -8,7 +8,9 @@ describe('declares a propDefinitions with type object and use it', () => {
     const result = await generator.generateComponent(componentUIDL)
     const vueFile = result.files.find((file) => file.fileType === FileType.VUE)
 
-    expect(vueFile?.content).toContain('{{ company.name }}{{ company.location.city }}')
+    expect(vueFile?.content).toContain(
+      "{{ company?.['name'] }}{{ company?.['location']?.['city'] }}"
+    )
     expect(vueFile?.content).toContain(`company: {
       type: Object,
       default: () => ({

--- a/packages/teleport-plugin-common/__tests__/node-handlers/node-to-jsx/utils.ts
+++ b/packages/teleport-plugin-common/__tests__/node-handlers/node-to-jsx/utils.ts
@@ -144,10 +144,10 @@ describe('createConditionIdentifier', () => {
   })
 
   it('works on member expressions', () => {
-    const node = dynamicNode('prop', 'fields.title')
+    const node = dynamicNode('prop', 'fields', ['title'])
     const result = createConditionIdentifier(node, params, options)
 
-    expect(result.key).toBe('fields.title')
+    expect(result.key).toBe("fields?.['title']")
     expect(result.prefix).toBe('this.props')
     expect(result.type).toBe('object')
   })

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/utils.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/utils.ts
@@ -5,7 +5,7 @@ import {
   convertToUnaryOperator,
   convertValueToLiteral,
 } from '../../utils/ast-utils'
-import { StringUtils } from '@teleporthq/teleport-shared'
+import { StringUtils, UIDLUtils } from '@teleporthq/teleport-shared'
 import {
   UIDLPropDefinition,
   UIDLAttributeValue,
@@ -25,6 +25,7 @@ import {
   JSXGenerationParams,
   JSXGenerationOptions,
 } from './types'
+import { generateIdWithRefPath } from '@teleporthq/teleport-shared/dist/cjs/utils/uidl-utils'
 
 // Adds all the event handlers and all the instructions for each event handler
 // in case there is more than one specified in the UIDL
@@ -153,12 +154,9 @@ export const createDynamicValueExpression = (
 ) => {
   const identifierContent = identifier.content
   const refPath = identifier.content.refPath || []
-  const { referenceType } = identifierContent
+  const { referenceType, id } = identifierContent
 
-  let id = identifierContent.id
-  refPath?.forEach((pathItem) => {
-    id = id.concat(`?.${pathItem}`)
-  })
+  const idWithPath = generateIdWithRefPath(id, refPath)
 
   if (referenceType === 'attr' || referenceType === 'children' || referenceType === 'token') {
     throw new Error(`Dynamic reference type "${referenceType}" is not supported yet`)
@@ -168,8 +166,8 @@ export const createDynamicValueExpression = (
     options.dynamicReferencePrefixMap[referenceType as 'prop' | 'state' | 'local'] || ''
 
   return prefix === ''
-    ? t.identifier(id)
-    : t.memberExpression(t.identifier(prefix), t.identifier(id))
+    ? t.identifier(idWithPath)
+    : t.memberExpression(t.identifier(prefix), t.identifier(idWithPath))
 }
 
 // Prepares an identifier (from props or state or an expr) to be used as a conditional rendering identifier
@@ -186,22 +184,30 @@ export const createConditionIdentifier = (
     }
   }
 
-  const { id, referenceType } = dynamicReference.content
+  const { id, referenceType, refPath } = dynamicReference.content
 
   // in case the id is a member expression: eg: fields.name
   const referenceRoot = id.split('.')[0]
+  let type = params.propDefinitions[referenceRoot]?.type
+  if (refPath?.length) {
+    let currentValue = params.propDefinitions[referenceRoot].defaultValue as Record<string, unknown>
+    for (const path of refPath) {
+      currentValue = currentValue?.[path] as Record<string, unknown>
+      type = currentValue ? typeof currentValue : params.propDefinitions[referenceRoot]?.type
+    }
+  }
 
   switch (referenceType) {
     case 'prop':
       return {
-        key: id,
-        type: params.propDefinitions[referenceRoot].type,
+        key: UIDLUtils.generateIdWithRefPath(id, refPath),
+        type,
         prefix: options.dynamicReferencePrefixMap.prop,
       }
     case 'state':
       return {
-        key: id,
-        type: params.stateDefinitions[referenceRoot].type,
+        key: UIDLUtils.generateIdWithRefPath(id, refPath),
+        type,
         prefix: options.dynamicReferencePrefixMap.state,
       }
 

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/utils.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/utils.ts
@@ -188,12 +188,17 @@ export const createConditionIdentifier = (
 
   // in case the id is a member expression: eg: fields.name
   const referenceRoot = id.split('.')[0]
-  let type = params.propDefinitions[referenceRoot]?.type
+  const currentType =
+    referenceType === 'prop'
+      ? params.propDefinitions[referenceRoot]?.type
+      : params.stateDefinitions[referenceRoot]?.type
+
+  let type = currentType
   if (refPath?.length) {
     let currentValue = params.propDefinitions[referenceRoot].defaultValue as Record<string, unknown>
     for (const path of refPath) {
       currentValue = currentValue?.[path] as Record<string, unknown>
-      type = currentValue ? typeof currentValue : params.propDefinitions[referenceRoot]?.type
+      type = currentValue ? typeof currentValue : currentType
     }
   }
 

--- a/packages/teleport-plugin-common/src/utils/ast-utils.ts
+++ b/packages/teleport-plugin-common/src/utils/ast-utils.ts
@@ -324,7 +324,10 @@ export const objectToObjectExpression = (
     const value = objectMap[key]
     let computedLiteralValue = null
 
-    if (value instanceof ParsedASTNode || value.constructor.name === 'ParsedASTNode') {
+    // TODO: Is this safe? This is for function props
+    if (value?.constructor?.name === 'Node') {
+      computedLiteralValue = value
+    } else if (value instanceof ParsedASTNode || value.constructor.name === 'ParsedASTNode') {
       computedLiteralValue = (value as ParsedASTNode).ast
     } else if (typeof value === 'boolean') {
       computedLiteralValue = t.booleanLiteral(value)

--- a/packages/teleport-plugin-jsx-proptypes/src/utils.ts
+++ b/packages/teleport-plugin-jsx-proptypes/src/utils.ts
@@ -32,7 +32,7 @@ export const buildDefaultPropsAst = (
             parsedFunction = parseResult.expression
           }
         } catch (err) {
-          // silet fail
+          // silet fail.
         }
 
         acc.values[key] = parsedFunction

--- a/packages/teleport-plugin-jsx-proptypes/src/utils.ts
+++ b/packages/teleport-plugin-jsx-proptypes/src/utils.ts
@@ -1,4 +1,5 @@
 import * as types from '@babel/types'
+import { parse } from '@babel/core'
 import { ASTUtils, ParsedASTNode } from '@teleporthq/teleport-plugin-common'
 import { UIDLPropDefinition } from '@teleporthq/teleport-types'
 
@@ -17,9 +18,24 @@ export const buildDefaultPropsAst = (
       const { defaultValue, type } = propDefinitions[key]
 
       if (type === 'func') {
-        acc.values[key] = new ParsedASTNode(
+        // Initialize with empty function
+        let parsedFunction: unknown = new ParsedASTNode(
           types.arrowFunctionExpression([], types.blockStatement([]))
         )
+
+        try {
+          const options = {
+            sourceType: 'module' as const,
+          }
+          const parseResult = parse(defaultValue.toString(), options)?.program?.body?.[0]
+          if (parseResult.type === 'ExpressionStatement') {
+            parsedFunction = parseResult.expression
+          }
+        } catch (err) {
+          // silet fail
+        }
+
+        acc.values[key] = parsedFunction
         acc.count++
         return acc
       }

--- a/packages/teleport-project-generator/src/index.ts
+++ b/packages/teleport-project-generator/src/index.ts
@@ -167,6 +167,7 @@ export class ProjectGenerator implements ProjectGeneratorType {
     const rootFolder = UIDLUtils.cloneObject(template || DEFAULT_TEMPLATE)
     const schemaValidationResult = this.validator.validateProjectSchema(input)
     const { valid, projectUIDL } = schemaValidationResult
+
     if (valid && projectUIDL) {
       cleanedUIDL = projectUIDL as unknown as Record<string, unknown>
     } else {

--- a/packages/teleport-shared/src/utils/uidl-utils.ts
+++ b/packages/teleport-shared/src/utils/uidl-utils.ts
@@ -818,7 +818,7 @@ export const transformStylesAssignmentsToJson = (
             type,
             content: {
               ...content,
-              id: StringUtils.createStateOrPropStoringValue(content.id),
+              id: generateIdWithRefPath(content.id, content.refPath),
             },
           }
         } else {
@@ -839,6 +839,23 @@ export const transformStylesAssignmentsToJson = (
   }, newStyleObject)
 
   return newStyleObject
+}
+
+export const generateIdWithRefPath = (contentId: string, refPath?: string[]) => {
+  let processedId = contentId
+  if (refPath) {
+    const processedRefPath = refPath.reduce((acc, path) => {
+      return `${acc}?.['${path}']`
+    }, '')
+
+    // This is a bit ugly, but in some cases props are parsed twice or already generated.
+    // To avoid possible bugs, this should be a good safety measure
+    if (!processedId.includes(processedRefPath)) {
+      processedId = `${processedId}${processedRefPath}`
+    }
+  }
+
+  return StringUtils.createStateOrPropStoringValue(processedId)
 }
 
 /*
@@ -902,7 +919,7 @@ export const transformAttributesAssignmentsToJson = (
               type,
               content: {
                 ...content,
-                id: StringUtils.createStateOrPropStoringValue(content.id),
+                id: generateIdWithRefPath(content.id, content.refPath),
               },
             }
           } else {

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -30,6 +30,7 @@ export interface UIDLPropValue {
   type: 'dynamic'
   content: {
     referenceType: 'prop'
+    refPath?: string[]
     id: string
   }
 }
@@ -38,6 +39,7 @@ export interface UIDLStateValue {
   type: 'dynamic'
   content: {
     referenceType: 'state'
+    refPath?: string[]
     id: string
   }
 }
@@ -264,9 +266,18 @@ export interface UIDLComponentSEO {
 
 export type UIDLMetaTag = Record<string, string | UIDLStaticValue | UIDLDynamicReference>
 
+export type PropDefaultValueTypes =
+  | string
+  | number
+  | boolean
+  | unknown[]
+  | object
+  | (() => void)
+  | UIDLElementNode
+
 export interface UIDLPropDefinition {
   type: string
-  defaultValue?: string | number | boolean | unknown[] | object | (() => void) | UIDLElementNode
+  defaultValue?: PropDefaultValueTypes
   isRequired?: boolean
   id?: string
   meta?: {
@@ -349,7 +360,7 @@ export interface UIDLExpressionValue {
 
 export interface UIDLStaticValue {
   type: 'static'
-  content: string | number | boolean | unknown[] // unknown[] for data sources
+  content: string | number | boolean | Record<string, unknown> | unknown[] // unknown[] for data sources
 }
 
 export interface UIDLRawValue {
@@ -762,6 +773,7 @@ export type UIDLCompDynamicReference = {
   type: 'dynamic'
   content: {
     referenceType: 'prop' | 'comp'
+    refPath?: string[]
     id: string
   }
 }

--- a/packages/teleport-uidl-builders/src/component-builders.ts
+++ b/packages/teleport-uidl-builders/src/component-builders.ts
@@ -120,12 +120,17 @@ export const staticNode = (content: string | boolean | number): UIDLStaticValue 
   }
 }
 
-export const dynamicNode = (referenceType: ReferenceType, id: string): UIDLDynamicReference => {
+export const dynamicNode = (
+  referenceType: ReferenceType,
+  id: string,
+  refPath?: string[]
+): UIDLDynamicReference => {
   return {
     type: 'dynamic',
     content: {
       referenceType,
       id,
+      refPath,
     },
   }
 }

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -143,7 +143,7 @@ export const expressionValueDecoder: Decoder<UIDLExpressionValue> = object({
 
 export const staticValueDecoder: Decoder<UIDLStaticValue> = object({
   type: constant('static'),
-  content: union(string(), number(), boolean(), array()),
+  content: union(string(), number(), boolean(), array(), object()),
 })
 
 export const rawValueDecoder: Decoder<UIDLRawValue> = object({

--- a/packages/teleport-uidl-validator/src/parser/index.ts
+++ b/packages/teleport-uidl-validator/src/parser/index.ts
@@ -390,6 +390,8 @@ const parseComponentNode = (node: Record<string, unknown>, component: ComponentU
             id: StringUtils.createStateOrPropStoringValue(
               ((content as UIDLURLLinkNode['content']).url as UIDLDynamicReference).content.id
             ),
+            refPath: ((content as UIDLURLLinkNode['content']).url as UIDLDynamicReference).content
+              .refPath,
           }
         }
 
@@ -438,6 +440,7 @@ const parseComponentNode = (node: Record<string, unknown>, component: ComponentU
           id: StringUtils.createStateOrPropStoringValue(
             conditionalNode.content.reference.content.id
           ),
+          refPath: reference.content.refPath,
         }
       }
 
@@ -472,7 +475,10 @@ const parseComponentNode = (node: Record<string, unknown>, component: ComponentU
     case 'dynamic':
       const dyamicNode = node as unknown as UIDLDynamicReference
       if (['state', 'prop'].includes(dyamicNode.content.referenceType)) {
-        dyamicNode.content.id = StringUtils.createStateOrPropStoringValue(dyamicNode.content.id)
+        dyamicNode.content.id = UIDLUtils.generateIdWithRefPath(
+          dyamicNode.content.id,
+          dyamicNode.content.refPath
+        )
       }
       return dyamicNode
     case 'static':


### PR DESCRIPTION
Add support for object and array prop ref path nesting, add support for function props. 

A dynamic node with a refPath that has id `someValue` and refPath `[1,2,'b']` will generate something like `someValue?.['1']?.['2']?.['b']`. 

Function prop definitions are attempted to be parsed from a string with babel. If that fails, default to the previous () => {}. Prop attribute overrides are of type `expr` and are already supported.