### PR TITLE
Fix some prop bugs

### DIFF
--- a/packages/teleport-plugin-common/src/node-handlers/node-to-html/index.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-html/index.ts
@@ -124,7 +124,8 @@ const generateNode: NodeToHTML<UIDLNode, HastNode | HastText | string> = (
 
     case 'expr':
       return 'Expression nodes are not supported'
-
+    case 'cms-list-repeater':
+      return 'CMS repeater nodes are not supported'
     default:
       throw new Error(
         `generateHTMLSyntax encountered a node of unsupported type: ${JSON.stringify(

--- a/packages/teleport-plugin-html-base-component/src/node-handlers.ts
+++ b/packages/teleport-plugin-html-base-component/src/node-handlers.ts
@@ -144,7 +144,7 @@ export const generateHtmlSyntax: NodeToHTML<UIDLNode, Promise<HastNode | HastTex
       }
 
       const {
-        content: { referenceType, id, refPath },
+        content: { referenceType, id, refPath = [] },
       } = reference
 
       switch (referenceType) {
@@ -203,7 +203,8 @@ export const generateHtmlSyntax: NodeToHTML<UIDLNode, Promise<HastNode | HastTex
 
     case 'expr':
       return HASTBuilders.createComment('Expressions are not supported in HTML')
-
+    case 'cms-list-repeater':
+      return HASTBuilders.createComment('CMS Repeater/Array Mapper nodes are not supported in HTML')
     default:
       throw new HTMLComponentGeneratorError(
         `generateHtmlSyntax encountered a node of unsupported type: ${JSON.stringify(
@@ -448,7 +449,8 @@ const generateComponentContent = async (
   const statesForInstance = Object.keys(combinedStates).reduce(
     (acc: Record<string, UIDLStateDefinition>, propKey) => {
       const attr = attrs[propKey]
-      if (attr.type === 'object') {
+
+      if (attr?.type === 'object') {
         throw new Error(`Object attributes are not supported in html exports`)
       }
 
@@ -501,6 +503,9 @@ const generateComponentContent = async (
           break
         case 'state':
           propsForInstance[propKey] = combinedStates[propKey]
+          break
+        case 'expr':
+          // Ignore expr type attributes in html for the time being.
           break
         default:
           throw new Error(

--- a/packages/teleport-project-generator-react/src/react-project-mapping.ts
+++ b/packages/teleport-project-generator-react/src/react-project-mapping.ts
@@ -16,5 +16,16 @@ export const ReactProjectMapping: Mapping = {
         to: { type: 'dynamic', content: { referenceType: 'attr', id: 'transitionTo' } },
       },
     },
+    'cms-list-repeater': {
+      elementType: 'Repeater',
+      dependency: {
+        type: 'package',
+        path: '@teleporthq/react-components',
+        version: 'latest',
+        meta: {
+          namedImport: true,
+        },
+      },
+    },
   },
 }

--- a/packages/teleport-uidl-validator/src/parser/index.ts
+++ b/packages/teleport-uidl-validator/src/parser/index.ts
@@ -384,11 +384,14 @@ const parseComponentNode = (node: Record<string, unknown>, component: ComponentU
         }
 
         if (type === 'url' && (content as UIDLURLLinkNode['content']).url.type === 'dynamic') {
+          const refPath = ((content as UIDLURLLinkNode['content']).url as UIDLDynamicReference)
+            ?.content?.refPath
           ;(content as UIDLURLLinkNode['content']).url.content = {
             referenceType: ((content as UIDLURLLinkNode['content']).url as UIDLDynamicReference)
               .content.referenceType,
-            id: StringUtils.createStateOrPropStoringValue(
-              ((content as UIDLURLLinkNode['content']).url as UIDLDynamicReference).content.id
+            id: UIDLUtils.generateIdWithRefPath(
+              ((content as UIDLURLLinkNode['content']).url as UIDLDynamicReference).content.id,
+              refPath
             ),
             refPath: ((content as UIDLURLLinkNode['content']).url as UIDLDynamicReference).content
               .refPath,


### PR DESCRIPTION
- Add support for CMS List repeater (CMS in the name is bad as it supports non-cms as well) in React
- Fix HTML generation bugs related to new props: expr nodes are ignored, CMS repeater nodes are ignored, small fix for states
- Fix dynamic link generation when link is bound to prop with ref path