### PR TITLE
fix: Remove i18n params from CMS calls if there is no i18n

### DIFF
--- a/packages/teleport-plugin-next-static-props/src/index.ts
+++ b/packages/teleport-plugin-next-static-props/src/index.ts
@@ -64,7 +64,8 @@ export const createStaticPropsPlugin: ComponentPluginFactory<StaticPropsPluginCo
     const getStaticPropsAST = generateInitialPropsAST(
       uidl.outputOptions.initialPropsData,
       resourceImportName,
-      resources.cache
+      resources.cache,
+      options.skipI18n
     )
 
     chunks.push({

--- a/packages/teleport-project-generator-next/__tests__/end2end/__snapshots__/index.ts.snap
+++ b/packages/teleport-project-generator-next/__tests__/end2end/__snapshots__/index.ts.snap
@@ -81,17 +81,6 @@ const Home = (props) => {
 }
 
 export default Home
-
-export async function getStaticProps(context) {
-  const messages = (await import('/locales/' + context.locale + '.json'))
-    .default
-  return {
-    props: {
-      messages,
-      ...context,
-    },
-  }
-}
 ",
   "fileType": "js",
   "name": "index",

--- a/packages/teleport-project-generator-next/src/internationalization/locale-fetcher-component.ts
+++ b/packages/teleport-project-generator-next/src/internationalization/locale-fetcher-component.ts
@@ -14,6 +14,10 @@ import * as types from '@babel/types'
 export const createNextLocaleFetcherPlugin: ComponentPluginFactory<{}> = () => {
   const nextLocaleFetcher: ComponentPlugin = async (structure) => {
     const { chunks } = structure
+    if (structure.options.skipI18n) {
+      return structure
+    }
+
     const jsxComponent = chunks.find((chunk) => chunk.name === 'jsx-component')
     if (!jsxComponent) {
       return structure

--- a/packages/teleport-project-generator/__tests__/index.ts
+++ b/packages/teleport-project-generator/__tests__/index.ts
@@ -127,6 +127,7 @@ describe('Generic Project Generator', () => {
           extractedResources: {},
           mapping: {},
           skipValidation: true,
+          skipI18n: true,
         }
       )
       expect(generator.pageGenerator.generateComponent).toBeCalledTimes(3)
@@ -147,6 +148,7 @@ describe('Generic Project Generator', () => {
           extractedResources: {},
           mapping: {},
           skipValidation: true,
+          skipI18n: true,
         }
       )
 
@@ -204,6 +206,7 @@ describe('Generic Project Generator', () => {
           projectRouteDefinition: uidl.root.stateDefinitions.route,
           mapping: {},
           skipValidation: true,
+          skipI18n: true,
         }
       )
 

--- a/packages/teleport-project-generator/src/index.ts
+++ b/packages/teleport-project-generator/src/index.ts
@@ -272,6 +272,7 @@ export class ProjectGenerator implements ProjectGeneratorType {
       mapping,
       extractedResources: {},
       skipValidation: true,
+      skipI18n: !uidl.internationalization,
       ...(uidl.resources &&
         this.strategy?.resources?.path && {
           resources: {

--- a/packages/teleport-types/src/generators.ts
+++ b/packages/teleport-types/src/generators.ts
@@ -127,6 +127,7 @@ export interface GeneratorOptions {
   skipValidation?: boolean
   isRootComponent?: boolean
   skipNavlinkResolver?: boolean
+  skipI18n?: boolean
   projectRouteDefinition?: UIDLRouteDefinitions
   strategy?: ProjectStrategy
   moduleComponents?: Record<string, ComponentUIDL>


### PR DESCRIPTION
i18n params in CMS calls can actually cause the calls to return an error, leading to CMS integrations not being usable. This aims to fix the issue.