### PR TITLE
fix/THQ-4192 Replace ReactMarkdown with markdown-to-jsx

### DIFF
--- a/packages/teleport-component-generator-react/src/react-mapping.ts
+++ b/packages/teleport-component-generator-react/src/react-mapping.ts
@@ -45,11 +45,11 @@ export const ReactMapping: Mapping = {
       },
     },
     'markdown-node': {
-      elementType: 'ReactMarkdown',
+      elementType: 'Markdown',
       dependency: {
         type: 'package',
-        path: 'react-markdown',
-        version: '8.0.7',
+        path: 'markdown-to-jsx',
+        version: 'latest',
       },
     },
     'html-node': {


### PR DESCRIPTION
https://linear.app/teleporthq/issue/THQ-4192/use-markdown-to-jsx-instead-of-reactmarkdown