### PR TITLE
fix/THQ-4207 Asset path not computed correctly when page lives inside a nested folder structure and src is dynamic via prop

### DIFF
--- a/packages/teleport-plugin-html-base-component/src/node-handlers.ts
+++ b/packages/teleport-plugin-html-base-component/src/node-handlers.ts
@@ -958,11 +958,18 @@ const handleAttributes = (
           content.referenceType === 'prop' ? propDefinitions : stateDefinitions
         )
 
-        HASTUtils.addAttributeToNode(
-          htmlNode,
-          attrKey,
-          String(extractDefaultValueFromRefPath(value.defaultValue, content.refPath))
+        const extractedValue = String(
+          extractDefaultValueFromRefPath(value.defaultValue, content.refPath)
         )
+
+        if ((elementType === 'img' || elementType === 'video') && attrKey === 'src') {
+          const path = join(relative(join(...outputOptions.folderPath), './'), extractedValue)
+
+          HASTUtils.addAttributeToNode(htmlNode, attrKey, path)
+          break
+        }
+
+        HASTUtils.addAttributeToNode(htmlNode, attrKey, extractedValue)
         break
       }
 


### PR DESCRIPTION
https://linear.app/teleporthq/issue/THQ-4207/[code-generators-html]-asset-path-not-computed-correctly