### PR TITLE
perf(next): load captcha provider script per-page instead of globally

### DIFF
--- a/packages/teleport-code-generator/src/index.ts
+++ b/packages/teleport-code-generator/src/index.ts
@@ -29,7 +29,6 @@ import {
   createNextProjectGenerator,
   NextTemplate,
   NextProjectPlugini18nConfig,
-  NextFormsCaptchaScriptPlugin,
   createNextProjectPlugins,
 } from '@teleporthq/teleport-project-generator-next'
 import {
@@ -180,11 +179,12 @@ export const packProject: PackProjectFunction = async (
 
   if (projectType === ProjectType.NEXT) {
     // packProject calls cleanPlugins() above and rebuilds the NEXT project-plugin
-    // list from scratch, so these two packProject-only plugins (which need the
-    // runtime `generateSitemap` option / inject the forms-captcha script) are
-    // added explicitly here.
+    // list from scratch, so this packProject-only plugin (which needs the
+    // runtime `generateSitemap` option) is added explicitly here.
+    // NOTE: the forms-captcha provider script is no longer injected globally
+    // here — it's loaded per-page by the form ComponentPlugin
+    // (createNextFormSubmissionPlugin), so it only loads on pages with forms.
     projectGeneratorFactory.addPlugin(new NextProjectPlugini18nConfig({ generateSitemap }))
-    projectGeneratorFactory.addPlugin(new NextFormsCaptchaScriptPlugin())
     // Everything else — data-source, workflow/auth, ecommerce, analytics, the
     // interactive-library primitives (calendar / drag-and-drop / kanban /
     // countdown) and the npm-backed widget primitives (incl. motion) — comes

--- a/packages/teleport-project-generator-next/src/forms/captcha-script-plugin.ts
+++ b/packages/teleport-project-generator-next/src/forms/captcha-script-plugin.ts
@@ -1,136 +1,22 @@
-import {
-  ProjectPlugin,
-  ProjectPluginStructure,
-  ProjectUIDL,
-  UIDLScriptAsset,
-  UIDLStaticValue,
-  UIDLENVValue,
-} from '@teleporthq/teleport-types'
+import { ProjectPlugin, ProjectPluginStructure } from '@teleporthq/teleport-types'
 
 /**
- * This plugin injects the captcha provider script into the _document.js file.
- * It adds the script to the globals.assets array as a proper script asset.
- * For reCAPTCHA, it includes the site key as a URL parameter using an inline script
- * to dynamically load the library with the environment variable.
+ * @deprecated The captcha provider script is no longer injected globally into
+ * `_document.js`. It is now loaded per-page by the form ComponentPlugin
+ * (`createNextFormSubmissionPlugin`), which injects a `next/script` <Script>
+ * only into components that actually contain a form. This loads the captcha
+ * (and, for reCAPTCHA v3/enterprise, its badge + background calls) only on
+ * pages with forms instead of on every page.
+ *
+ * This class is kept as a no-op for backwards compatibility — it can be safely
+ * removed from any project plugin pipeline.
  */
 export class NextFormsCaptchaScriptPlugin implements ProjectPlugin {
   async runBefore(structure: ProjectPluginStructure): Promise<ProjectPluginStructure> {
-    const { uidl } = structure
-
-    // Skip if no forms are defined
-    if (!uidl.forms || !uidl.forms.items || Object.keys(uidl.forms.items).length === 0) {
-      return structure
-    }
-
-    // Check if any form has captcha enabled and get the captcha key
-    let captchaKey = null
-    let hasFormSpecificCaptcha = false
-
-    Object.values(uidl.forms.items).forEach((form) => {
-      if (form.security?.captchaPublicKey) {
-        captchaKey = form.security.captchaPublicKey
-        hasFormSpecificCaptcha = true
-      }
-    })
-
-    // If no form-specific captcha, use the global default
-    let usingDefaultCaptcha = false
-    if (!hasFormSpecificCaptcha && uidl.forms.globalConfig?.defaultCaptchaPublicKey) {
-      captchaKey = uidl.forms.globalConfig.defaultCaptchaPublicKey
-      usingDefaultCaptcha = true
-    }
-
-    if (!captchaKey) {
-      return structure
-    }
-
-    // Get the captcha provider (default to recaptcha)
-    const captchaProvider = uidl.forms.globalConfig?.captchaProvider || 'recaptcha'
-
-    // Add to globals.assets
-    if (!uidl.globals.assets) {
-      uidl.globals.assets = []
-    }
-
-    switch (captchaProvider) {
-      case 'hcaptcha':
-        this.addHCaptchaScript(uidl)
-        break
-      case 'turnstile':
-        this.addTurnstileScript(uidl)
-        break
-      case 'recaptcha':
-      default:
-        this.addRecaptchaScript(uidl, captchaKey, usingDefaultCaptcha)
-        break
-    }
-
     return structure
   }
 
   async runAfter(structure: ProjectPluginStructure): Promise<ProjectPluginStructure> {
     return structure
-  }
-
-  private addRecaptchaScript(
-    uidl: ProjectUIDL,
-    captchaKey: UIDLStaticValue | UIDLENVValue,
-    usingDefaultCaptcha: boolean
-  ): void {
-    // Use enterprise API if using the default captcha key
-    const baseUrl = usingDefaultCaptcha
-      ? 'https://www.google.com/recaptcha/enterprise.js'
-      : 'https://www.google.com/recaptcha/api.js'
-
-    if (captchaKey.type === 'static') {
-      // For static keys, add directly to the URL
-      const scriptPath = `${baseUrl}?render=${captchaKey.content}`
-      const scriptAsset: UIDLScriptAsset = {
-        type: 'script',
-        path: scriptPath,
-        options: {
-          async: true,
-          defer: true,
-        },
-      }
-      uidl.globals.assets.push(scriptAsset)
-    } else {
-      // For env variables, use template literal interpolation
-      const envVarName = captchaKey.content
-      const scriptPath = `${baseUrl}?render=\${process.env.${envVarName}}`
-      const scriptAsset: UIDLScriptAsset = {
-        type: 'script',
-        path: scriptPath,
-        options: {
-          async: true,
-          defer: true,
-        },
-      }
-      uidl.globals.assets.push(scriptAsset)
-    }
-  }
-
-  private addHCaptchaScript(uidl: ProjectUIDL): void {
-    const scriptAsset: UIDLScriptAsset = {
-      type: 'script',
-      path: 'https://js.hcaptcha.com/1/api.js',
-      options: {
-        async: true,
-        defer: true,
-      },
-    }
-    uidl.globals.assets.push(scriptAsset)
-  }
-
-  private addTurnstileScript(uidl: ProjectUIDL): void {
-    const scriptAsset: UIDLScriptAsset = {
-      type: 'script',
-      path: 'https://challenges.cloudflare.com/turnstile/v0/api.js',
-      options: {
-        async: true,
-        defer: true,
-      },
-    }
-    uidl.globals.assets.push(scriptAsset)
   }
 }

--- a/packages/teleport-project-generator-next/src/forms/form-submission-handler.ts
+++ b/packages/teleport-project-generator-next/src/forms/form-submission-handler.ts
@@ -5,6 +5,10 @@ import {
   UIDLFormDefinition,
   UIDLFormBehavior,
   UIDLElement,
+  ChunkDefinition,
+  UIDLDependency,
+  UIDLStaticValue,
+  UIDLENVValue,
 } from '@teleporthq/teleport-types'
 import * as types from '@babel/types'
 import { UIDLUtils, GenericUtils } from '@teleporthq/teleport-shared'
@@ -763,10 +767,216 @@ export const createNextFormSubmissionPlugin: ComponentPluginFactory<{}> = () => 
       }
     }
 
+    // Per-page captcha loading: inject the provider <Script> only into
+    // components that actually contain a form. This replaces the global
+    // injection that NextFormsCaptchaScriptPlugin used to push into
+    // globals.assets → _document.js (which loaded the captcha on every page,
+    // including pages with no forms).
+    injectCaptchaScript(chunks, formsInComponent, forms, structure.dependencies)
+
     return structure
   }
 
   return nextFormSubmissionHandler
+}
+
+/**
+ * Injects the captcha provider's loader <Script> (from next/script) into a
+ * single page/component that contains a form. Because the form ComponentPlugin
+ * only runs on components that actually render a form, this guarantees the
+ * captcha script (and, for reCAPTCHA v3/enterprise, its badge + background
+ * calls) is requested only where a form exists — not on every page.
+ *
+ * Key/provider resolution mirrors the old project-level
+ * NextFormsCaptchaScriptPlugin: a form-specific `security.captchaPublicKey`
+ * wins, otherwise the global `defaultCaptchaPublicKey` (enterprise reCAPTCHA).
+ */
+function injectCaptchaScript(
+  chunks: ChunkDefinition[],
+  formsInComponent: Array<{ formId: string; formElement: UIDLElement }>,
+  forms: UIDLForms,
+  dependencies: Record<string, UIDLDependency>
+): void {
+  // Resolve the captcha key from the forms present on THIS page/component
+  let captchaKey: UIDLStaticValue | UIDLENVValue | null = null
+  let hasFormSpecificCaptcha = false
+
+  for (const { formId } of formsInComponent) {
+    const formDefinition = forms.items[formId]
+    if (formDefinition?.security?.captchaPublicKey) {
+      captchaKey = formDefinition.security.captchaPublicKey
+      hasFormSpecificCaptcha = true
+    }
+  }
+
+  let usingDefaultCaptcha = false
+  if (!hasFormSpecificCaptcha && forms.globalConfig?.defaultCaptchaPublicKey) {
+    captchaKey = forms.globalConfig.defaultCaptchaPublicKey
+    usingDefaultCaptcha = true
+  }
+
+  if (!captchaKey) {
+    return
+  }
+
+  const captchaProvider = forms.globalConfig?.captchaProvider || 'recaptcha'
+
+  // Locate the component's JSX chunk and its return statement
+  const jsxChunk = chunks.find(
+    (chunk) =>
+      chunk.name === 'jsx-component' &&
+      typeof chunk.content === 'object' &&
+      'type' in chunk.content &&
+      chunk.content.type === 'VariableDeclaration'
+  )
+
+  if (!jsxChunk || !jsxChunk.content) {
+    return
+  }
+
+  const componentBody = (
+    ((jsxChunk.content as types.VariableDeclaration).declarations[0] as types.VariableDeclarator)
+      .init as types.ArrowFunctionExpression
+  ).body as types.BlockStatement
+
+  const returnStatement = componentBody.body.find(
+    (statement) =>
+      statement.type === 'ReturnStatement' && statement.argument && 'type' in statement.argument
+  ) as types.ReturnStatement | undefined
+
+  if (!returnStatement || !returnStatement.argument) {
+    return
+  }
+
+  const scriptElement = buildCaptchaScriptElement(captchaProvider, captchaKey, usingDefaultCaptcha)
+
+  // Insert the <Script> as a sibling right after the first <form> on the page
+  let inserted = false
+  const insertAfterForm = (node: types.Node, parent: types.Node | null): void => {
+    if (inserted) {
+      return
+    }
+
+    if (node.type === 'JSXElement') {
+      const openingElement = node.openingElement
+      if (
+        openingElement?.name.type === 'JSXIdentifier' &&
+        openingElement.name.name === 'form' &&
+        parent &&
+        'children' in parent &&
+        Array.isArray(parent.children)
+      ) {
+        const formIndex = parent.children.indexOf(node)
+        if (formIndex >= 0) {
+          parent.children.splice(formIndex + 1, 0, scriptElement)
+          inserted = true
+          return
+        }
+      }
+    }
+
+    if ('children' in node && Array.isArray(node.children)) {
+      for (const child of node.children) {
+        insertAfterForm(child as types.Node, node)
+        if (inserted) {
+          return
+        }
+      }
+    }
+    if ('argument' in node && node.argument) {
+      insertAfterForm(node.argument as types.Node, node)
+    }
+    if ('expression' in node && node.expression) {
+      insertAfterForm(node.expression as types.Node, node)
+    }
+  }
+
+  insertAfterForm(returnStatement.argument, null)
+
+  // Fallback: the <form> is the root returned element (no parent to host a
+  // sibling) — wrap the return value in a fragment alongside the <Script>.
+  if (!inserted) {
+    const original = returnStatement.argument
+    const wrappedChild =
+      original.type === 'JSXElement' || original.type === 'JSXFragment'
+        ? original
+        : types.jsxExpressionContainer(original as types.Expression)
+
+    returnStatement.argument = types.jsxFragment(
+      types.jsxOpeningFragment(),
+      types.jsxClosingFragment(),
+      [scriptElement, wrappedChild]
+    )
+  }
+
+  // import Script from 'next/script'
+  if (!dependencies.Script) {
+    dependencies.Script = {
+      type: 'library',
+      path: 'next/script',
+      version: '^12.1.0',
+    }
+  }
+}
+
+/**
+ * Builds the `<Script ... />` JSX element (next/script) that loads the captcha
+ * provider library. reCAPTCHA needs the site key in the URL (`?render=`); the
+ * enterprise endpoint is used when relying on the global default key. hCaptcha
+ * and Turnstile load a static URL and receive the key at execute() time.
+ */
+function buildCaptchaScriptElement(
+  captchaProvider: string,
+  captchaKey: UIDLStaticValue | UIDLENVValue,
+  usingDefaultCaptcha: boolean
+): types.JSXElement {
+  const t = types
+  let srcValue: types.StringLiteral | types.JSXExpressionContainer
+
+  if (captchaProvider === 'recaptcha') {
+    const baseUrl = usingDefaultCaptcha
+      ? 'https://www.google.com/recaptcha/enterprise.js'
+      : 'https://www.google.com/recaptcha/api.js'
+
+    if (captchaKey.type === 'static') {
+      srcValue = t.stringLiteral(`${baseUrl}?render=${captchaKey.content}`)
+    } else {
+      // src={`${baseUrl}?render=${process.env.ENV_VAR}`}
+      srcValue = t.jsxExpressionContainer(
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: `${baseUrl}?render=`, cooked: `${baseUrl}?render=` }, false),
+            t.templateElement({ raw: '', cooked: '' }, true),
+          ],
+          [
+            t.memberExpression(
+              t.memberExpression(t.identifier('process'), t.identifier('env')),
+              t.identifier(captchaKey.content as string)
+            ),
+          ]
+        )
+      )
+    }
+  } else if (captchaProvider === 'hcaptcha') {
+    srcValue = t.stringLiteral('https://js.hcaptcha.com/1/api.js')
+  } else {
+    // turnstile
+    srcValue = t.stringLiteral('https://challenges.cloudflare.com/turnstile/v0/api.js')
+  }
+
+  const attributes = [
+    t.jsxAttribute(t.jsxIdentifier('src'), srcValue),
+    // afterInteractive (not lazyOnload) so grecaptcha/hcaptcha/turnstile is
+    // ready by the time the form is submitted, avoiding a fast-submit race.
+    t.jsxAttribute(t.jsxIdentifier('strategy'), t.stringLiteral('afterInteractive')),
+  ]
+
+  return t.jsxElement(
+    t.jsxOpeningElement(t.jsxIdentifier('Script'), attributes, true),
+    null,
+    [],
+    true
+  )
 }
 
 function createFormSubmitHandler(


### PR DESCRIPTION
The captcha provider script (reCAPTCHA / hCaptcha / Turnstile) was injected into globals.assets -> _document.js, so it loaded on every page of a generated Next.js project, including pages with no forms. For reCAPTCHA v3/enterprise that also meant the floating badge and background calls fired everywhere, plus a Google request on every pageview.

Move script loading into the form ComponentPlugin
(createNextFormSubmissionPlugin), which only runs on components/pages that actually contain a form. It now injects a `next/script` <Script> (with strategy="afterInteractive" so the captcha is ready at submit time) right after the form, scoping the script to the exact set of pages that render a form.

- form-submission-handler.ts: inject <Script> + `import Script from 'next/script'` per component; key/provider resolution mirrors the old plugin (form-specific security.captchaPublicKey wins, else global defaultCaptchaPublicKey -> enterprise reCAPTCHA). Handles static and env-var keys, all three providers, and a fragment fallback when the form is the root element.
- teleport-code-generator/src/index.ts: drop the global NextFormsCaptchaScriptPlugin registration from the Next pipeline.
- captcha-script-plugin.ts: keep NextFormsCaptchaScriptPlugin exported as a deprecated no-op for backwards compatibility.

Identical scripts (same src) are de-duplicated by next/script at runtime, so multiple component instances on a page still trigger a single load.