### PR TITLE
Conditions, animations and layout in the generated app

### DIFF
--- a/packages/teleport-plugin-next-workflows/__tests__/runtime-stringified-boolean-truthiness.test.ts
+++ b/packages/teleport-plugin-next-workflows/__tests__/runtime-stringified-boolean-truthiness.test.ts
@@ -1,0 +1,76 @@
+import { generateSharedRuntimeUtilsCode } from '../src'
+
+// Producers that cannot type their output emit booleans as the strings
+// "true"/"false" — the evaluate-auth custom-js most notably (see
+// is-logged-in-gate.ts), plus any inspector text input. `is-true`/`is-false`
+// and coerceForComparison already read those as booleans, but `is-truthy` was
+// plain `!!left`, and the string "false" is truthy in JS: an is-truthy gate on
+// isLoggedIn admitted EVERY visitor, and an is-falsy check never fired.
+
+type SharedUtils = {
+  evaluateSingleComparison: (cfg: unknown, ctx: Record<string, unknown>) => boolean
+}
+
+function loadSharedRuntime(): SharedUtils {
+  const src = generateSharedRuntimeUtilsCode()
+  const wrapper: { exports: Record<string, unknown> } = { exports: {} }
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function('module', 'exports', src)(wrapper, wrapper.exports)
+  return wrapper.exports as unknown as SharedUtils
+}
+
+describe('workflow runtime truthiness of stringified booleans', () => {
+  const utils = loadSharedRuntime()
+
+  const isTruthy = (leftValue: unknown) =>
+    utils.evaluateSingleComparison({ leftValue, operator: 'is-truthy' }, {})
+  const isFalsy = (leftValue: unknown) =>
+    utils.evaluateSingleComparison({ leftValue, operator: 'is-falsy' }, {})
+
+  it('treats the string "false" as false, matching is-false and coerceForComparison', () => {
+    expect(isTruthy('false')).toBe(false)
+    expect(isFalsy('false')).toBe(true)
+  })
+
+  it('keeps the string "true" true', () => {
+    expect(isTruthy('true')).toBe(true)
+    expect(isFalsy('true')).toBe(false)
+  })
+
+  it('agrees with is-true/is-false on the same value', () => {
+    for (const value of ['true', 'false', true, false]) {
+      expect(isTruthy(value)).toBe(
+        utils.evaluateSingleComparison({ leftValue: value, operator: 'is-true' }, {})
+      )
+      expect(isFalsy(value)).toBe(
+        utils.evaluateSingleComparison({ leftValue: value, operator: 'is-false' }, {})
+      )
+    }
+  })
+
+  it('leaves ordinary JS truthiness untouched', () => {
+    expect(isTruthy(true)).toBe(true)
+    expect(isTruthy(false)).toBe(false)
+    expect(isTruthy('anything')).toBe(true)
+    expect(isTruthy('')).toBe(false)
+    expect(isTruthy(0)).toBe(false)
+    expect(isTruthy(1)).toBe(true)
+    expect(isTruthy(null)).toBe(false)
+    expect(isTruthy(undefined)).toBe(false)
+    expect(isFalsy('')).toBe(true)
+    expect(isFalsy(0)).toBe(true)
+    expect(isFalsy('anything')).toBe(false)
+  })
+
+  it('normalizes the snake_case and camelCase spellings the same way', () => {
+    expect(utils.evaluateSingleComparison({ leftValue: 'false', operator: 'is_truthy' }, {})).toBe(
+      false
+    )
+    expect(utils.evaluateSingleComparison({ leftValue: 'false', operator: 'isTruthy' }, {})).toBe(
+      false
+    )
+    expect(utils.evaluateSingleComparison({ leftValue: 'false', operator: 'is_falsy' }, {})).toBe(
+      true
+    )
+  })
+})

--- a/packages/teleport-plugin-next-workflows/src/executor-generator.ts
+++ b/packages/teleport-plugin-next-workflows/src/executor-generator.ts
@@ -540,6 +540,16 @@ function coerceForComparison(a, b) {
   return [a, b];
 }
 
+// Several producers cannot type their output and emit booleans as the strings
+// "true"/"false": the evaluate-auth custom-js, text inputs in the inspector,
+// form fields. coerceForComparison and is-true/is-false already read those as
+// booleans, so truthiness must agree — under a plain double-negation the
+// string "false" is TRUTHY, which let an is-truthy gate on isLoggedIn admit
+// every visitor (see is-logged-in-gate.ts).
+function isStringifiedBoolean(value) {
+  return value === 'true' || value === 'false';
+}
+
 // The operator vocabulary is written by THREE producers that never agreed on
 // a spelling: the worker canonicalizes to snake_case (is_not_empty,
 // greater_than), the GUI editor emits camelCase named forms (startsWith,
@@ -584,8 +594,8 @@ function evaluateSingleComparison(config, context) {
     case 'is-not-null': return left !== null && left !== undefined;
     case 'is-true': return left === true || left === 'true';
     case 'is-false': return left === false || left === 'false';
-    case 'is-truthy': return !!left;
-    case 'is-falsy': return !left;
+    case 'is-truthy': return isStringifiedBoolean(left) ? left === 'true' : !!left;
+    case 'is-falsy': return isStringifiedBoolean(left) ? left === 'false' : !left;
     case 'matches-regex': try { return new RegExp(String(right)).test(String(left)); } catch(e) { return false; }
     default:
       console.warn('[workflow] Unknown comparison operator "' + config.operator + '" — falling back to loose equality');

--- a/packages/teleport-project-generator-next/__tests__/motion-inview-failsafe.test.ts
+++ b/packages/teleport-project-generator-next/__tests__/motion-inview-failsafe.test.ts
@@ -1,0 +1,104 @@
+/* tslint:disable:no-eval */
+import { generateMotionComponentCode } from '../src/widgets/motion-component'
+
+/**
+ * The in-view failsafe exists so a reveal animation can never leave content at
+ * opacity 0. It used to be a single `setTimeout` that checked once, about a
+ * second after mount — which only rescued content already on screen at that
+ * instant. Everything below the fold was checked once while off-screen, found
+ * invisible, and never checked again, leaving the IntersectionObserver as the
+ * only thing that could ever reveal it. One missed callback meant a section
+ * stayed invisible permanently; a 2162px product grid sat at opacity 0 while
+ * dead-centre in the viewport and 41% on screen.
+ *
+ * The emitted component is a source STRING, so nothing else in the toolchain
+ * can check any of this.
+ */
+describe('TqMotion in-view failsafe', () => {
+  const code = generateMotionComponentCode()
+
+  it('keeps watching for the element lifetime, not once after mount', () => {
+    expect(code).toContain("window.addEventListener('scroll', schedule, { passive: true })")
+    expect(code).toContain("window.addEventListener('resize', schedule, { passive: true })")
+    expect(code).toContain("window.removeEventListener('scroll', schedule)")
+    expect(code).toContain("window.removeEventListener('resize', schedule)")
+  })
+
+  it('coalesces scroll work into a frame so a page of motion nodes stays cheap', () => {
+    expect(code).toContain('requestAnimationFrame')
+    expect(code).toContain('cancelAnimationFrame')
+  })
+
+  it('reveals on the same threshold useInView was given, so timing is unchanged', () => {
+    // Not "any pixel visible": the failsafe must fire when the observer should
+    // have, never earlier, or every animation on the page starts too soon.
+    expect(code).toContain(
+      'const threshold = Math.min(amount, reachableFraction(rect, vh, vw) * 0.9)'
+    )
+    expect(code).toContain('const visible = fraction > 0 && fraction >= threshold')
+  })
+
+  it('still honours inViewOnce in both directions', () => {
+    // Latching a repeat-on-re-entry animation would silently disable it.
+    expect(code).toContain('return once ? previous || visible : visible')
+  })
+
+  it('does nothing for triggers that are not in-view', () => {
+    expect(code).toContain("if (trigger !== 'in-view') {")
+  })
+
+  describe('the visibility maths', () => {
+    // Extracted and evaluated directly — these two functions decide whether a
+    // section is ever seen, and they are the part a string assertion cannot
+    // meaningfully cover.
+    const extract = (name: string): ((...args: unknown[]) => number) => {
+      const start = code.indexOf(`const ${name} = (rect, vh, vw) => {`)
+      expect(start).toBeGreaterThan(-1)
+      const end = code.indexOf('\n}', start)
+      const source = code.slice(start, end + 2).replace(`const ${name} =`, 'return')
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      return new Function(source)() as (...args: unknown[]) => number
+    }
+
+    const visibleFraction = extract('visibleFraction')
+    const reachableFraction = extract('reachableFraction')
+    const rect = (top: number, height: number) => ({
+      top,
+      bottom: top + height,
+      left: 0,
+      right: 1440,
+    })
+
+    it('measures how much of the element is on screen', () => {
+      // Fully inside the viewport.
+      expect(visibleFraction(rect(100, 400), 900, 1440)).toBeCloseTo(1)
+      // Entirely below the fold.
+      expect(visibleFraction(rect(1000, 400), 900, 1440)).toBe(0)
+      // Half of it scrolled past the top.
+      expect(visibleFraction(rect(-200, 400), 900, 1440)).toBeCloseTo(0.5)
+    })
+
+    it('reports what a too-tall element can physically reach', () => {
+      // The real regression: 2162px tall in a 900px viewport can never exceed
+      // 41.6% on screen, so any inViewAmount above that is unsatisfiable.
+      expect(reachableFraction(rect(-631, 2162), 900, 1440)).toBeCloseTo(900 / 2162, 3)
+      // Something that fits can reach all of itself.
+      expect(reachableFraction(rect(0, 400), 900, 1440)).toBe(1)
+    })
+
+    it('never demands more visibility than the element can achieve', () => {
+      // A 3000px section asked for amount 0.6 — impossible (max 0.3). Without
+      // the clamp this content stays hidden forever.
+      const tall = rect(0, 3000)
+      const reachable = reachableFraction(tall, 900, 1440)
+      const threshold = Math.min(0.6, reachable * 0.9)
+      expect(threshold).toBeLessThan(reachable)
+      expect(visibleFraction(tall, 900, 1440)).toBeGreaterThanOrEqual(threshold)
+    })
+
+    it('degrades to zero rather than NaN on a collapsed element', () => {
+      expect(visibleFraction(rect(0, 0), 900, 1440)).toBe(0)
+      expect(reachableFraction(rect(0, 0), 900, 1440)).toBe(0)
+    })
+  })
+})

--- a/packages/teleport-project-generator-next/src/widgets/motion-component.ts
+++ b/packages/teleport-project-generator-next/src/widgets/motion-component.ts
@@ -5,9 +5,10 @@
  * (see packages/renderer motion-runtime) — preset/easing/keyframe logic is kept
  * identical so the published site matches the canvas.
  *
- * Triggers: on-load (initial/animate), in-view (useInView-driven + a timed
- * in-viewport failsafe so content is never trapped at opacity:0 — a top hero that
- * misses the IntersectionObserver still reveals), scroll (scroll-linked parallax
+ * Triggers: on-load (initial/animate), in-view (useInView-driven + a standing
+ * in-viewport failsafe so content is never trapped at opacity:0 — any element
+ * that is genuinely on screen reveals even if the IntersectionObserver never
+ * reports it), scroll (scroll-linked parallax
  * via useScroll/useTransform), hover (whileHover),
  * tap (whileTap). `stagger` descends through grid/list wrappers to the real
  * repeated items (e.g. <array-mapper> cards) and cascades THOSE with a per-child
@@ -58,6 +59,33 @@ const presetStates = (preset, distance) => {
     default:
       return { from: { opacity: 0 }, to: { opacity: 1 } }
   }
+}
+
+// How much of the element is inside the viewport right now, as a 0..1 fraction
+// of its own area — the same quantity IntersectionObserver thresholds on, so the
+// failsafe below can apply exactly the threshold useInView was given.
+const visibleFraction = (rect, vh, vw) => {
+  const height = rect.bottom - rect.top
+  const width = rect.right - rect.left
+  if (height <= 0 || width <= 0) {
+    return 0
+  }
+  const visibleHeight = Math.max(0, Math.min(rect.bottom, vh) - Math.max(rect.top, 0))
+  const visibleWidth = Math.max(0, Math.min(rect.right, vw) - Math.max(rect.left, 0))
+  return (visibleHeight * visibleWidth) / (height * width)
+}
+
+// The largest fraction this element could EVER have on screen. An element taller
+// than the viewport can never be 60% visible, so an inViewAmount above that is
+// unsatisfiable and would hold the content at opacity 0 permanently. Clamping to
+// what is physically reachable turns "impossible" into "as visible as it gets".
+const reachableFraction = (rect, vh, vw) => {
+  const height = rect.bottom - rect.top
+  const width = rect.right - rect.left
+  if (height <= 0 || width <= 0) {
+    return 0
+  }
+  return Math.min(1, vh / height) * Math.min(1, vw / width)
 }
 
 const buildAnimProps = (trigger, fromVars, toVars, transition, revealed) => {
@@ -127,16 +155,45 @@ const TqMotion = ({
   const ref = React.useRef(null)
   const shouldReduceMotion = useReducedMotion()
 
-  // in-view reveal is driven by useInView + a timed in-viewport failsafe so a
-  // reveal can NEVER trap content at opacity:0 (a top hero already in view can
-  // miss the observer's initial callback). Below-the-fold elements still wait.
+  // in-view reveal is driven by useInView + a STANDING in-viewport failsafe, so
+  // a reveal can never trap content at opacity:0.
+  //
+  // This used to be a single setTimeout that checked once, roughly a second
+  // after mount. That only ever rescued content which happened to be on screen
+  // at that instant: everything below the fold got its one check while
+  // off-screen, saw itself invisible, and was never checked again. From then on
+  // the IntersectionObserver was the only thing that could reveal it, so one
+  // missed callback left an entire section at opacity 0 permanently — a
+  // 2162px-tall product grid sat invisible while dead-centre in the viewport,
+  // 41% on screen, for as long as anyone cared to wait.
+  //
+  // The check now stands for the element's lifetime, coalesced into a frame and
+  // passive so scrolling stays cheap, and it applies the SAME threshold
+  // useInView was given. It therefore fires exactly when the observer should
+  // have and never earlier — an animation's timing is unchanged when the
+  // observer works, which is almost always.
   const inView = useInView(ref, { once: Boolean(inViewOnce), amount: Number(inViewAmount) || 0.3 })
   const [forceReveal, setForceReveal] = React.useState(false)
+  const revealed = inView || forceReveal
+  const revealedRef = React.useRef(false)
+  React.useEffect(() => {
+    revealedRef.current = revealed
+  }, [revealed])
+
   React.useEffect(() => {
     if (trigger !== 'in-view') {
       return undefined
     }
-    const timeoutId = setTimeout(() => {
+    const once = Boolean(inViewOnce)
+    const amount = Number(inViewAmount) || 0.3
+    let frame = 0
+
+    const check = () => {
+      // Already done: nothing to measure, so a revealed element costs nothing
+      // per scroll frame beyond this comparison.
+      if (once && revealedRef.current) {
+        return
+      }
       const el = ref.current
       if (!el || typeof el.getBoundingClientRect !== 'function') {
         return
@@ -144,14 +201,38 @@ const TqMotion = ({
       const rect = el.getBoundingClientRect()
       const vh = window.innerHeight || document.documentElement.clientHeight || 0
       const vw = window.innerWidth || document.documentElement.clientWidth || 0
-      const visible = rect.top < vh && rect.bottom > 0 && rect.left < vw && rect.right > 0
-      if (visible) {
-        setForceReveal(true)
+      const fraction = visibleFraction(rect, vh, vw)
+      const threshold = Math.min(amount, reachableFraction(rect, vh, vw) * 0.9)
+      const visible = fraction > 0 && fraction >= threshold
+      // With inViewOnce the reveal latches; without it, visibility is tracked
+      // both ways so the author's repeat-on-re-entry behaviour is preserved.
+      setForceReveal(function (previous) {
+        return once ? previous || visible : visible
+      })
+    }
+
+    const schedule = () => {
+      if (frame) {
+        return
       }
-    }, (Number(duration) || 0.6) * 1000 + 600)
-    return () => clearTimeout(timeoutId)
-  }, [])
-  const revealed = inView || forceReveal
+      frame = requestAnimationFrame(function () {
+        frame = 0
+        check()
+      })
+    }
+
+    const timeoutId = setTimeout(check, (Number(duration) || 0.6) * 1000 + 600)
+    window.addEventListener('scroll', schedule, { passive: true })
+    window.addEventListener('resize', schedule, { passive: true })
+    return () => {
+      clearTimeout(timeoutId)
+      if (frame) {
+        cancelAnimationFrame(frame)
+      }
+      window.removeEventListener('scroll', schedule)
+      window.removeEventListener('resize', schedule)
+    }
+  }, [trigger, inViewOnce, inViewAmount, duration])
 
   const dist = Number(distance) || 0
   const base = presetStates(preset, dist)

--- a/packages/teleport-shared/src/index.ts
+++ b/packages/teleport-shared/src/index.ts
@@ -4,5 +4,14 @@ import * as UIDLUtils from './utils/uidl-utils'
 import * as GenericUtils from './utils/generic'
 import * as JSIdentifiers from './utils/js-identifiers'
 import * as RoutePaths from './utils/route-paths'
+import * as LayoutTopology from './utils/layout-topology'
 
-export { Constants, StringUtils, UIDLUtils, GenericUtils, JSIdentifiers, RoutePaths }
+export {
+  Constants,
+  StringUtils,
+  UIDLUtils,
+  GenericUtils,
+  JSIdentifiers,
+  RoutePaths,
+  LayoutTopology,
+}

--- a/packages/teleport-shared/src/utils/layout-topology.ts
+++ b/packages/teleport-shared/src/utils/layout-topology.ts
@@ -1,0 +1,91 @@
+import {
+  UIDLElementNode,
+  UIDLStyleSetDefinition,
+  UIDLStyleSheetContent,
+  UIDLStyleValue,
+} from '@teleporthq/teleport-types'
+
+/**
+ * Which UIDL nodes actually generate a layout box — and therefore which node is
+ * a given element's REAL parent for layout purposes.
+ *
+ * This exists because the same defect keeps reappearing: a generator inserts a
+ * wrapper (a link anchor, an animation wrapper, a repeater shell) between a
+ * flex/grid container and its styled children. The wrapper becomes the flex/grid
+ * item, the child's `flex`/`grid-area`/`align-self` silently stop applying — a
+ * `flex: 0 0 340px` card collapses to content width — and the published site
+ * stops matching what the editor showed. The editor never renders those
+ * wrappers at all, so "what you see is what you get" quietly breaks.
+ *
+ * The subtle half is the ancestor walk, not the wrapper. UIDL trees are full of
+ * nodes that render NOTHING: fragments, repeaters, data providers, conditional
+ * shells. Asking "is my parent a flex container?" of the immediate UIDL parent
+ * gets the wrong answer whenever one of those sits in between — and it usually
+ * does, because cards live inside repeaters. Ask `resolveLayoutParent` instead
+ * and the question is asked of the node that actually draws the box.
+ *
+ * Add new box-less element types HERE, once, rather than at each call site.
+ */
+
+/**
+ * Element types that never produce a layout box. `fragment` renders as a React
+ * `<Fragment>` on JSX targets and as a `div { display: contents }` on the HTML
+ * target — either way it generates no box, so it can never be a layout parent.
+ */
+export const LAYOUT_TRANSPARENT_ELEMENT_TYPES = new Set(['fragment'])
+
+export const isLayoutTransparentElement = (node?: UIDLElementNode): boolean =>
+  !!node && LAYOUT_TRANSPARENT_ELEMENT_TYPES.has(node.content.elementType)
+
+/**
+ * The layout parent to hand to `node`'s children.
+ *
+ * Thread this through a recursive walk instead of passing the current node:
+ * a box-less node passes its own layout parent straight through, so a chain of
+ * fragments/repeaters collapses to the nearest ancestor that really draws a box.
+ */
+export const resolveLayoutParent = (
+  node: UIDLElementNode,
+  currentLayoutParent?: UIDLElementNode
+): UIDLElementNode | undefined => (isLayoutTransparentElement(node) ? currentLayoutParent : node)
+
+/** Display values that make a node lay its direct children out as items. */
+export const FLEX_OR_GRID_DISPLAYS = new Set(['flex', 'inline-flex', 'grid', 'inline-grid'])
+
+export const isStaticFlexOrGridDisplay = (
+  display: UIDLStyleValue | UIDLStyleSheetContent | undefined
+): boolean => display?.type === 'static' && FLEX_OR_GRID_DISPLAYS.has(String(display.content))
+
+/**
+ * Does this node lay its children out as flex/grid items?
+ *
+ * The display can come from an inline style or — far more common in generated
+ * projects — from a project-referenced style class. Abilities are resolved
+ * before referenced styles are flattened, so the style set has to be consulted
+ * directly; pass `options.projectStyleSet?.styleSetDefinitions`.
+ */
+export const isFlexOrGridContainer = (
+  node: UIDLElementNode | undefined,
+  styleSetDefinitions?: Record<string, UIDLStyleSetDefinition>
+): boolean => {
+  if (!node) {
+    return false
+  }
+
+  if (isStaticFlexOrGridDisplay(node.content.style?.display)) {
+    return true
+  }
+
+  const referencedStyles = node.content.referencedStyles
+  if (!referencedStyles || !styleSetDefinitions) {
+    return false
+  }
+
+  return Object.values(referencedStyles).some((referencedStyle) => {
+    if (referencedStyle.content.mapType !== 'project-referenced') {
+      return false
+    }
+    const styleSet = styleSetDefinitions[referencedStyle.content.referenceId]
+    return isStaticFlexOrGridDisplay(styleSet?.content?.display)
+  })
+}

--- a/packages/teleport-test/package.json
+++ b/packages/teleport-test/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "packer": "cross-env TS_NODE_FILES=true ts-node --project tsconfig.json ./src/packer.ts",
+    "generate": "cross-env TS_NODE_FILES=true ts-node --transpile-only --project tsconfig.json ./src/generate.ts",
     "standalone": "cross-env TS_NODE_FILES=true ts-node --transpile-only --project tsconfig.json ./src/standalone.ts",
     "standalone:partial": "cross-env TS_NODE_FILES=true ts-node --transpile-only --project tsconfig.json ./src/standalone-partial.ts",
     "cms": "cross-env TS_NODE_FILES=true ts-node --transpile-only --project tsconfig.json ./src/cms.ts",

--- a/packages/teleport-test/src/build-freshness.ts
+++ b/packages/teleport-test/src/build-freshness.ts
@@ -1,0 +1,131 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
+import { dirname, join } from 'path'
+
+/**
+ * Is the compiled generator newer than its source?
+ *
+ * Generation does not run the TypeScript in `packages/*\/src`. It runs whatever
+ * is in each package's `dist/`, built by `yarn build` (or kept current by the
+ * `yarn dev` watcher). When the watcher is not running, editing a generator and
+ * regenerating produces output from the LAST BUILD — silently, with no warning
+ * anywhere.
+ *
+ * That turns the whole fix-and-verify loop into a liar: a fix appears not to
+ * work, a bug appears not to be fixed, and a generated project gets debugged
+ * against source it was not built from. It cost a full investigation once
+ * already — a project failed `next build` on a NEXTAUTH_URL crash whose fix had
+ * been in `src` for nine days and in no `dist` at all.
+ *
+ * So this is checked and reported, never assumed.
+ */
+
+export interface StalePackage {
+  name: string
+  sourceModified: string
+  builtModified: string | null
+}
+
+const newestMtime = (dir: string, extensions: string[]): number => {
+  let newest = 0
+  const walk = (current: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const entryPath = join(current, entry.name)
+      if (entry.isDirectory()) {
+        walk(entryPath)
+        continue
+      }
+      if (extensions.some((extension) => entry.name.endsWith(extension))) {
+        const { mtimeMs } = statSync(entryPath)
+        if (mtimeMs > newest) {
+          newest = mtimeMs
+        }
+      }
+    }
+  }
+  if (existsSync(dir)) {
+    walk(dir)
+  }
+  return newest
+}
+
+/**
+ * Every workspace package whose `src/` is newer than its build output — i.e.
+ * every package whose behaviour in a generated project is NOT what the checked
+ * out code says it is.
+ */
+export const findStalePackages = (packagesRoot: string): StalePackage[] => {
+  if (!existsSync(packagesRoot)) {
+    return []
+  }
+
+  const stale: StalePackage[] = []
+
+  for (const entry of readdirSync(packagesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+    // The runner itself is executed from source through ts-node, so its build
+    // output is irrelevant — reporting it would be permanent noise.
+    if (entry.name === 'teleport-test') {
+      continue
+    }
+    const packageDir = join(packagesRoot, entry.name)
+    const srcDir = join(packageDir, 'src')
+    const packageJsonPath = join(packageDir, 'package.json')
+    if (!existsSync(srcDir) || !existsSync(packageJsonPath)) {
+      continue
+    }
+
+    let mainField = 'dist/cjs/index.js'
+    try {
+      const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { main?: string }
+      mainField = parsed.main ?? mainField
+    } catch {
+      continue
+    }
+
+    const sourceMs = newestMtime(srcDir, ['.ts', '.tsx'])
+    if (sourceMs === 0) {
+      continue
+    }
+
+    // Compare against the newest file in the build output, not the entry point.
+    // `tsc` only rewrites files whose contents changed, so editing one widget
+    // leaves `index.js` untouched and its mtime old — comparing against it
+    // reports a freshly built package as stale, and a check that cries wolf
+    // gets ignored exactly when it matters.
+    const buildDir = join(packageDir, dirname(mainField))
+    const builtMs = newestMtime(buildDir, ['.js'])
+
+    if (builtMs === 0) {
+      stale.push({
+        name: entry.name,
+        sourceModified: new Date(sourceMs).toISOString(),
+        builtModified: null,
+      })
+      continue
+    }
+
+    if (sourceMs > builtMs) {
+      stale.push({
+        name: entry.name,
+        sourceModified: new Date(sourceMs).toISOString(),
+        builtModified: new Date(builtMs).toISOString(),
+      })
+    }
+  }
+
+  return stale
+}
+
+export const describeStaleness = (stale: StalePackage[]): string =>
+  [
+    `${stale.length} generator package(s) have source newer than their build, so generation will NOT reflect them:`,
+    ...stale.map(
+      (entry) =>
+        `  ${entry.name} — src ${entry.sourceModified}, built ${
+          entry.builtModified ?? 'NEVER (no build output)'
+        }`
+    ),
+    'Run `yarn build` at the repo root (or keep `yarn dev` running) before trusting this output.',
+  ].join('\n')

--- a/packages/teleport-test/src/generate-project.ts
+++ b/packages/teleport-test/src/generate-project.ts
@@ -1,0 +1,306 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'fs'
+import { join, resolve } from 'path'
+import { performance } from 'perf_hooks'
+import {
+  GeneratedFile,
+  PackerOptions,
+  ProjectPlugin,
+  ProjectType,
+  ProjectUIDL,
+  PublisherType,
+} from '@teleporthq/teleport-types'
+import { packProject } from '@teleporthq/teleport-code-generator'
+
+/**
+ * Packing a UIDL into a project on disk, parameterised.
+ *
+ * Backs `yarn generate` — the entry point for the GUI's Teleport & Run button,
+ * the artifact prober and CI, none of which can use `standalone.ts`: that script
+ * imports its UIDL at module scope from a git-tracked fixture and hard-codes the
+ * output slug, so it can only ever produce one project from one file. It stays
+ * exactly as it is; it runs on every file save while the generators are being
+ * developed, and that loop is not this module's business.
+ *
+ * The `.env` and clean-up helpers below are deliberate duplicates of the ones in
+ * `standalone.ts`. Keep the two `PRESERVE_ON_CLEAN` sets identical — they decide
+ * what a regeneration is allowed to delete from a directory the developer may
+ * have put real work into.
+ */
+
+// Files/dirs that are NOT produced by the generator and must survive a clean:
+// install artifacts and user-owned config. Everything else in the project dir
+// is regenerated every run.
+// `.vscode`, `.claude` and `CLAUDE.md` are editor/agent scaffolding dropped into
+// the generated project by tooling (or by hand) — the generator never emits
+// them, so wiping them would only cost the developer their setup.
+export const PRESERVE_ON_CLEAN = new Set([
+  'node_modules',
+  '.env',
+  '.env.local',
+  '.git',
+  'package-lock.json',
+  'yarn.lock',
+  '.next',
+  '.vscode',
+  '.claude',
+  'CLAUDE.md',
+])
+
+// Parse a KEY=value .env file into a plain object. Lines starting with `#`
+// and empty lines are skipped. Values are taken verbatim (no quote
+// unwrapping) because that's how `createEnvFiles` also writes them.
+export const parseDotEnv = (content: string): Record<string, string> => {
+  const out: Record<string, string> = {}
+  content.split(/\r?\n/).forEach((rawLine) => {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      return
+    }
+    const eq = line.indexOf('=')
+    if (eq < 0) {
+      return
+    }
+    const key = line.slice(0, eq).trim()
+    const value = line.slice(eq + 1)
+    if (key) {
+      out[key] = value
+    }
+  })
+  return out
+}
+
+// Preserve the buyer-editable subset of an existing `.env` across regeneration.
+// The generator strips `teleporthq.secrets.*` placeholders to empty strings via
+// `resolveAuthEnvValue`, so without this hook every run wipes out values the
+// user (or the GUI's secret resolver) set — Stripe / PayPal test keys, the DB
+// connection string, and so on. Injecting the on-disk values into
+// `uidl.globals.env` BEFORE packing makes them survive into the regenerated file.
+export const preserveExistingEnv = (uidl: ProjectUIDL, envPath: string): number => {
+  if (!existsSync(envPath)) {
+    return 0
+  }
+  let raw = ''
+  try {
+    raw = readFileSync(envPath, 'utf8')
+  } catch {
+    return 0
+  }
+  const existing = parseDotEnv(raw)
+  // A well-formed ProjectUIDL always has `globals`, but the input fixture may
+  // be a page/component UIDL (no `globals`) or a partially-built project. Guard
+  // rather than crash — env preservation is a best-effort convenience, not a
+  // hard requirement of the run.
+  if (!uidl.globals) {
+    return 0
+  }
+  if (!uidl.globals.env) {
+    uidl.globals.env = {}
+  }
+  const env = uidl.globals.env as Record<string, string>
+  // Copy over every existing key (even ones the generator did not emit this
+  // pass) so user-added entries such as TELEPORT_PROJECT_TOKEN stay in the
+  // regenerated file. Values that are explicitly empty in the file are kept
+  // empty — matching what the user saw on disk.
+  Object.keys(existing).forEach((key) => {
+    env[key] = existing[key]
+  })
+  return Object.keys(existing).length
+}
+
+// Remove previously-generated files before a fresh run so STALE ORPHANS can't
+// linger. The disk publisher only writes the files produced by THIS generation;
+// it never deletes files an earlier generation emitted. So when the UIDL changes
+// — e.g. authentication is turned off, a workflow/widget is removed — the old
+// `middleware.js` / `utils/auth/*` (which import `next-auth`), dead workflow API
+// routes, or an orphan `components/tq-*.js` are left behind, while the
+// regenerated `package.json` no longer lists their npm deps. `next build` then
+// fails with "Module not found: Can't resolve 'next-auth/jwt'" (or framer-motion,
+// etc). Wiping the generated tree — preserving only install + user-owned files —
+// guarantees the output always reflects exactly the current UIDL.
+export const cleanGeneratedFiles = (projectDir: string): void => {
+  if (!existsSync(projectDir)) {
+    return
+  }
+  for (const entry of readdirSync(projectDir)) {
+    if (PRESERVE_ON_CLEAN.has(entry)) {
+      continue
+    }
+    rmSync(join(projectDir, entry), { recursive: true, force: true })
+  }
+}
+
+/**
+ * Size of the GENERATED tree only — `node_modules` and `.next` are install and
+ * build artifacts that would swamp the signal. Reported so a regression in
+ * output size is visible without diffing two trees.
+ */
+const measureGeneratedTree = (dir: string): { fileCount: number; byteCount: number } => {
+  let fileCount = 0
+  let byteCount = 0
+
+  const walk = (current: string, depth: number) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      if (depth === 0 && PRESERVE_ON_CLEAN.has(entry.name)) {
+        continue
+      }
+      const entryPath = join(current, entry.name)
+      if (entry.isDirectory()) {
+        walk(entryPath, depth + 1)
+      } else if (entry.isFile()) {
+        fileCount += 1
+        byteCount += statSync(entryPath).size
+      }
+    }
+  }
+
+  if (existsSync(dir)) {
+    walk(dir, 0)
+  }
+  return { fileCount, byteCount }
+}
+
+/**
+ * The generators talk to the developer through `console` — unbound expressions
+ * that had to be replaced with `""`, prop/state definitions declared but never
+ * used, missing mappings. Those lines are the earliest warning that a UIDL and
+ * the emitted code disagree, and until now they scrolled past in a terminal and
+ * were gone. Capturing them makes them a field on the result, so the artifact
+ * report can carry them and a detector can act on them.
+ */
+const captureConsole = async <T>(sink: string[], work: () => Promise<T>): Promise<T> => {
+  /* tslint:disable:no-console — this helper's whole job is to hold the
+     generators' console output; the repo lints with tslint, so an eslint
+     pragma silenced nothing. */
+  const original = { log: console.log, info: console.info, warn: console.warn }
+  const record = (...parts: unknown[]) => {
+    sink.push(parts.map((part) => (typeof part === 'string' ? part : String(part))).join(' '))
+  }
+  console.log = record
+  console.info = record
+  console.warn = record
+  try {
+    return await work()
+  } finally {
+    console.log = original.log
+    console.info = original.info
+    console.warn = original.warn
+  }
+  /* tslint:enable:no-console */
+}
+
+export interface GenerateProjectParams {
+  uidl: ProjectUIDL
+  /** Output root that will contain `<outRoot>/<slug>`. */
+  outRoot: string
+  slug: string
+  projectType: ProjectType
+  /** `.env` whose values are folded back into the UIDL before packing. */
+  envPath?: string
+  plugins?: ProjectPlugin[]
+  assets?: GeneratedFile[]
+  packerOverrides?: Partial<PackerOptions>
+}
+
+export interface GenerateProjectResult {
+  ok: boolean
+  slug: string
+  projectType: string
+  projectDir: string
+  fileCount: number
+  byteCount: number
+  preservedEnvKeys: number
+  /** Everything the generators printed while packing (see `captureConsole`). */
+  warnings: string[]
+  /**
+   * Packages whose `src/` is newer than the `dist/` this run actually used, so a
+   * reader knows whether the output reflects the checked-out code at all.
+   */
+  staleGenerators?: Array<{ name: string; sourceModified: string; builtModified: string | null }>
+  timings: { cleanMs: number; packMs: number; totalMs: number }
+  error?: { message: string; stack?: string }
+}
+
+export const generateProject = async (
+  params: GenerateProjectParams
+): Promise<GenerateProjectResult> => {
+  const {
+    uidl,
+    slug,
+    projectType,
+    envPath,
+    plugins = [],
+    assets = [],
+    packerOverrides = {},
+  } = params
+  const outRoot = resolve(params.outRoot)
+  const projectDir = join(outRoot, slug)
+
+  const startedAt = performance.now()
+  const warnings: string[] = []
+  let cleanMs = 0
+  let packMs = 0
+  let preservedEnvKeys = 0
+
+  const failure = (error: unknown): GenerateProjectResult => ({
+    ok: false,
+    slug,
+    projectType,
+    projectDir,
+    fileCount: 0,
+    byteCount: 0,
+    preservedEnvKeys,
+    warnings,
+    timings: { cleanMs, packMs, totalMs: performance.now() - startedAt },
+    error: {
+      message: (error as Error)?.message ?? String(error),
+      stack: (error as Error)?.stack,
+    },
+  })
+
+  try {
+    if (!existsSync(outRoot)) {
+      mkdirSync(outRoot, { recursive: true })
+    }
+
+    const cleanStartedAt = performance.now()
+    // Read the existing `.env` BEFORE the clean. The clean keeps `.env` on disk
+    // anyway, but the values also have to be folded into the UIDL so the
+    // REGENERATED file carries them forward.
+    preservedEnvKeys = preserveExistingEnv(uidl, envPath ?? join(projectDir, '.env'))
+    cleanGeneratedFiles(projectDir)
+    cleanMs = performance.now() - cleanStartedAt
+
+    const packStartedAt = performance.now()
+    await captureConsole(warnings, () =>
+      packProject(uidl, {
+        publisher: PublisherType.DISK,
+        assets,
+        ...packerOverrides,
+        projectType,
+        plugins,
+        publishOptions: {
+          ...(packerOverrides.publishOptions ?? {}),
+          outputPath: outRoot,
+          projectSlug: slug,
+        },
+      })
+    )
+    packMs = performance.now() - packStartedAt
+  } catch (error) {
+    return failure(error)
+  }
+
+  const { fileCount, byteCount } = measureGeneratedTree(projectDir)
+
+  return {
+    ok: true,
+    slug,
+    projectType,
+    projectDir,
+    fileCount,
+    byteCount,
+    preservedEnvKeys,
+    warnings,
+    timings: { cleanMs, packMs, totalMs: performance.now() - startedAt },
+  }
+}

--- a/packages/teleport-test/src/generate.ts
+++ b/packages/teleport-test/src/generate.ts
@@ -1,0 +1,216 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import chalk from 'chalk'
+import { ProjectType, ProjectUIDL } from '@teleporthq/teleport-types'
+
+import { describeStaleness, findStalePackages } from './build-freshness'
+import { generateProject, GenerateProjectResult } from './generate-project'
+
+/**
+ * `yarn generate` — pack any UIDL, from any path, into any output directory.
+ *
+ * The reusable entry point for everything that is not "the dev running the
+ * checked-in fixture": the GUI's Teleport & Run button, the artifact prober, CI.
+ * `yarn standalone` is the same core with the fixture path filled in.
+ *
+ *   yarn generate --uidl ./my-project.json
+ *   yarn generate --uidl ./my-project.json --env ./secrets.env --slug my-app --json
+ *
+ * Flags:
+ *   --uidl <path>          project UIDL JSON (required)
+ *   --env <path>           .env whose values are folded back in before packing
+ *                          (default: `<out>/<slug>/.env`, i.e. the previous run's)
+ *   --out <dir>            output ROOT; the project lands in <dir>/<slug>
+ *                          (default: <package>/dist)
+ *   --slug <name>          output folder name (default: teleport-project-next)
+ *   --project-type <type>  next | react | vue | nuxt | angular | html
+ *                          (default: next — the only type the loop supports today)
+ *   --json                 print the machine-readable result as a single line of
+ *                          stdout, so it survives the generators' own chatter
+ *   --json-out <path>      also write that result to a file. PREFER THIS for any
+ *                          programmatic caller: `yarn` appends its own
+ *                          "Done in Ns." line, so "the last line of stdout" is
+ *                          not a contract you can rely on through a yarn script.
+ *
+ * Exit code is 0 only when generation succeeded, so a caller can branch on it
+ * without parsing anything.
+ */
+
+interface CliArgs {
+  uidl?: string
+  env?: string
+  out?: string
+  slug?: string
+  projectType?: string
+  json: boolean
+  jsonOut?: string
+}
+
+const parseArgs = (argv: string[]): CliArgs => {
+  const args: CliArgs = { json: false }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index]
+    const readValue = () => {
+      const value = argv[index + 1]
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`Missing value for ${flag}`)
+      }
+      index += 1
+      return value
+    }
+
+    switch (flag) {
+      case '--uidl':
+        args.uidl = readValue()
+        break
+      case '--env':
+        args.env = readValue()
+        break
+      case '--out':
+        args.out = readValue()
+        break
+      case '--slug':
+        args.slug = readValue()
+        break
+      case '--project-type':
+        args.projectType = readValue()
+        break
+      case '--json':
+        args.json = true
+        break
+      case '--json-out':
+        args.jsonOut = readValue()
+        break
+      default:
+        throw new Error(`Unknown argument "${flag}"`)
+    }
+  }
+
+  return args
+}
+
+const PROJECT_TYPES = Object.values(ProjectType) as string[]
+
+const resolveProjectType = (value: string | undefined): ProjectType => {
+  if (!value) {
+    return ProjectType.NEXT
+  }
+  const normalized = value.toLowerCase()
+  if (!PROJECT_TYPES.includes(normalized)) {
+    throw new Error(`Unknown --project-type "${value}". Known: ${PROJECT_TYPES.join(', ')}`)
+  }
+  return normalized as ProjectType
+}
+
+const readUidl = (uidlPath: string): ProjectUIDL => {
+  if (!existsSync(uidlPath)) {
+    throw new Error(`UIDL not found at ${uidlPath}`)
+  }
+  const raw = readFileSync(uidlPath, 'utf8')
+  try {
+    return JSON.parse(raw) as ProjectUIDL
+  } catch (error) {
+    throw new Error(`UIDL at ${uidlPath} is not valid JSON: ${(error as Error).message}`)
+  }
+}
+
+const run = async () => {
+  let args: CliArgs
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`${chalk.red((error as Error).message)}\n`)
+    process.exitCode = 2
+    return
+  }
+
+  const note = (message: string) => {
+    process.stderr.write(`${message}\n`)
+  }
+
+  const report = (outcome: GenerateProjectResult) => {
+    if (args.jsonOut) {
+      const jsonOut = resolve(args.jsonOut)
+      mkdirSync(dirname(jsonOut), { recursive: true })
+      writeFileSync(jsonOut, `${JSON.stringify(outcome, null, 2)}\n`, 'utf8')
+    }
+    if (args.json) {
+      // Single line: the generators print their own diagnostics to stdout while
+      // packing, so "the last line of stdout" is the only stable contract.
+      process.stdout.write(`${JSON.stringify(outcome)}\n`)
+      return
+    }
+    if (outcome.ok) {
+      outcome.warnings.forEach((warning) => note(chalk.yellow(warning)))
+      note(
+        chalk.greenBright(
+          `${outcome.slug} — ${outcome.fileCount} files, ${(outcome.byteCount / 1024).toFixed(
+            1
+          )} KB, ${
+            outcome.warnings.length
+          } generator warning(s) in ${outcome.timings.totalMs.toFixed(0)}ms → ${outcome.projectDir}`
+        )
+      )
+      return
+    }
+    note(chalk.red(outcome.error?.stack ?? outcome.error?.message ?? 'generation failed'))
+  }
+
+  if (!args.uidl) {
+    note(chalk.red('--uidl <path> is required'))
+    process.exitCode = 2
+    return
+  }
+
+  const slug = args.slug || 'teleport-project-next'
+  const outRoot = resolve(args.out || join(__dirname, '..', 'dist'))
+  const projectDir = join(outRoot, slug)
+
+  let projectType: ProjectType
+  let uidl: ProjectUIDL
+  try {
+    projectType = resolveProjectType(args.projectType)
+    uidl = readUidl(resolve(args.uidl))
+  } catch (error) {
+    report({
+      ok: false,
+      slug,
+      projectType: args.projectType || ProjectType.NEXT,
+      projectDir,
+      fileCount: 0,
+      byteCount: 0,
+      preservedEnvKeys: 0,
+      warnings: [],
+      timings: { cleanMs: 0, packMs: 0, totalMs: 0 },
+      error: { message: (error as Error).message },
+    })
+    process.exitCode = 1
+    return
+  }
+
+  // Generation runs each package's `dist/`, not its `src/`. Saying so loudly
+  // beats letting someone debug generated output against source it was never
+  // built from.
+  const stale = findStalePackages(join(__dirname, '..', '..'))
+  if (stale.length > 0) {
+    note(chalk.yellow(describeStaleness(stale)))
+  }
+
+  note(chalk.gray(`Packing ${projectType} project "${slug}" → ${projectDir}`))
+
+  const result = await generateProject({
+    uidl,
+    outRoot,
+    slug,
+    projectType,
+    envPath: args.env ? resolve(args.env) : join(projectDir, '.env'),
+  })
+
+  report({ ...result, staleGenerators: stale })
+  if (!result.ok) {
+    process.exitCode = 1
+  }
+}
+
+run()

--- a/packages/teleport-uidl-resolver/__tests__/abilities/utils.ts
+++ b/packages/teleport-uidl-resolver/__tests__/abilities/utils.ts
@@ -363,6 +363,58 @@ describe('insertLink', () => {
     expect(wrapper.content.elementType).toBe('navlink')
     expect(wrapper.content.style?.display).toBeUndefined()
   })
+
+  it('sees through box-less ancestors to the real flex parent', () => {
+    /* The regression this exists for. A linked card almost never sits directly
+       inside its grid — it sits inside a repeater, inside a data provider,
+       inside a fragment, none of which draw a box. Asking the IMMEDIATE parent
+       "are you a flex container?" answered no, the wrapper was left as a normal
+       box, and it became the flex item instead of the card: every card lost its
+       `flex: 0 0 <width>` and collapsed to content width. The published grid
+       stopped matching the editor, which renders no wrapper at all. */
+    const card = elementNode('container')
+    card.content.abilities = { link: navlinkMockedDefinition() }
+
+    const fragment = elementNode('fragment', {}, [card])
+    const grid = elementNode('container', {}, [fragment])
+    grid.content.referencedStyles = {
+      TQ_row: {
+        id: 'TQ_row',
+        type: 'style-map',
+        content: { mapType: 'project-referenced', referenceId: 'tq-scroll-row' },
+      },
+    }
+
+    const result = insertLinks(grid, flexProjectStyleSetOptions('flex'), false)
+    const resolvedFragment = result.content.children[0] as UIDLElementNode
+    const wrapper = resolvedFragment.content.children[0] as UIDLElementNode
+
+    expect(wrapper.content.elementType).toBe('navlink')
+    expect(wrapper.content.style?.display).toEqual({ type: 'static', content: 'contents' })
+  })
+
+  it('still ignores box-less ancestors when the real parent is not flex/grid', () => {
+    // The transparency walk must not manufacture a flex parent that isn't there.
+    const card = elementNode('container')
+    card.content.abilities = { link: navlinkMockedDefinition() }
+
+    const fragment = elementNode('fragment', {}, [card])
+    const block = elementNode('container', {}, [fragment])
+    block.content.referencedStyles = {
+      TQ_row: {
+        id: 'TQ_row',
+        type: 'style-map',
+        content: { mapType: 'project-referenced', referenceId: 'tq-scroll-row' },
+      },
+    }
+
+    const result = insertLinks(block, flexProjectStyleSetOptions('block'), false)
+    const resolvedFragment = result.content.children[0] as UIDLElementNode
+    const wrapper = resolvedFragment.content.children[0] as UIDLElementNode
+
+    expect(wrapper.content.elementType).toBe('navlink')
+    expect(wrapper.content.style?.display).toBeUndefined()
+  })
 })
 
 describe('insertLink with link-type prop', () => {

--- a/packages/teleport-uidl-resolver/src/resolvers/abilities/utils.ts
+++ b/packages/teleport-uidl-resolver/src/resolvers/abilities/utils.ts
@@ -1,4 +1,4 @@
-import { StringUtils, RoutePaths } from '@teleporthq/teleport-shared'
+import { StringUtils, RoutePaths, LayoutTopology } from '@teleporthq/teleport-shared'
 import {
   GeneratorOptions,
   UIDLLinkNode,
@@ -7,8 +7,6 @@ import {
   UIDLAttributeValue,
   UIDLPropDefinition,
   UIDLDynamicReference,
-  UIDLStyleValue,
-  UIDLStyleSheetContent,
 } from '@teleporthq/teleport-types'
 
 type NavlinkDifferentiatorValue = NonNullable<UIDLNavLinkNode['content']['differentiatorValue']>
@@ -49,49 +47,20 @@ const isAttributeSafeForAnchor = (attrName: string): boolean => {
   )
 }
 
-// display values that turn a node into a flex/grid container, making its direct
-// children into flex/grid items.
-const FLEX_OR_GRID_DISPLAYS = new Set(['flex', 'inline-flex', 'grid', 'inline-grid'])
-
-const isStaticFlexOrGridDisplay = (
-  display: UIDLStyleValue | UIDLStyleSheetContent | undefined
-): boolean => display?.type === 'static' && FLEX_OR_GRID_DISPLAYS.has(String(display.content))
-
 /* When a styled element also carries a link, the link is realised as a wrapper
-   <a>/navlink around it. If the parent is a flex/grid container, that wrapper
-   would become the flex/grid item instead of the styled child, dropping the
-   child's sizing (e.g. a `flex: 0 0 …` card width). Detecting that here lets the
-   caller mark the wrapper `display: contents` so the styled child stays the real
-   flex/grid item. The parent's display can come from an inline style or, more
-   commonly for generated projects, from a project-referenced style class — and
-   abilities are resolved before referenced styles are flattened, so we read it
-   straight from the project style-set definitions. */
+   <a>/navlink around it. If the layout parent is a flex/grid container, that
+   wrapper would become the flex/grid item instead of the styled child, dropping
+   the child's sizing (e.g. a `flex: 0 0 …` card width). Detecting that here lets
+   the caller mark the wrapper `display: contents` so the styled child stays the
+   real flex/grid item.
+
+   The container test lives in LayoutTopology because this is not the only place
+   that inserts a wrapper between a container and its items. */
 const parentIsFlexOrGridContainer = (
   parentNode: UIDLElementNode | undefined,
   options: GeneratorOptions
-): boolean => {
-  if (!parentNode) {
-    return false
-  }
-
-  if (isStaticFlexOrGridDisplay(parentNode.content.style?.display)) {
-    return true
-  }
-
-  const referencedStyles = parentNode.content.referencedStyles
-  const styleSetDefinitions = options.projectStyleSet?.styleSetDefinitions
-  if (!referencedStyles || !styleSetDefinitions) {
-    return false
-  }
-
-  return Object.values(referencedStyles).some((referencedStyle) => {
-    if (referencedStyle.content.mapType !== 'project-referenced') {
-      return false
-    }
-    const styleSet = styleSetDefinitions[referencedStyle.content.referenceId]
-    return isStaticFlexOrGridDisplay(styleSet?.content?.display)
-  })
-}
+): boolean =>
+  LayoutTopology.isFlexOrGridContainer(parentNode, options.projectStyleSet?.styleSetDefinitions)
 
 export const insertLinks = (
   node: UIDLElementNode,
@@ -103,9 +72,16 @@ export const insertLinks = (
   const { abilities, children, elementType, semanticType, attrs = {} } = node.content
   const linkInNode = linkInParent || !!abilities?.link
 
+  /* What this node's descendants should treat as their layout parent. A node
+     that draws no box (a fragment) passes its OWN layout parent through, so a
+     card sitting inside `grid > data-provider > fragment > repeater` still sees
+     the grid. Passing `node` blindly here is what let a link wrapper become the
+     flex item of a card grid and collapse every card to content width. */
+  const layoutParent = LayoutTopology.resolveLayoutParent(node, parentNode)
+
   node.content.children = children?.map((child) => {
     if (child.type === 'element') {
-      return insertLinks(child, options, linkInNode, node, propDefinitions)
+      return insertLinks(child, options, linkInNode, layoutParent, propDefinitions)
     }
 
     if (child.type === 'repeat') {
@@ -113,7 +89,7 @@ export const insertLinks = (
         child.content.node,
         options,
         linkInNode,
-        node,
+        layoutParent,
         propDefinitions
       )
     }
@@ -123,7 +99,7 @@ export const insertLinks = (
         child.content.node,
         options,
         linkInNode,
-        node,
+        layoutParent,
         propDefinitions
       )
     }
@@ -133,7 +109,7 @@ export const insertLinks = (
         child.content.fallback,
         options,
         linkInNode,
-        node,
+        layoutParent,
         propDefinitions
       )
     }
@@ -144,15 +120,33 @@ export const insertLinks = (
       } = child.content
 
       if (success) {
-        child.content.nodes.success = insertLinks(success, options, false, node, propDefinitions)
+        child.content.nodes.success = insertLinks(
+          success,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
 
       if (error) {
-        child.content.nodes.error = insertLinks(error, options, false, node, propDefinitions)
+        child.content.nodes.error = insertLinks(
+          error,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
 
       if (loading) {
-        child.content.nodes.loading = insertLinks(loading, options, false, node, propDefinitions)
+        child.content.nodes.loading = insertLinks(
+          loading,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
     }
 
@@ -162,15 +156,27 @@ export const insertLinks = (
       } = child.content
 
       if (list) {
-        child.content.nodes.list = insertLinks(list, options, false, node, propDefinitions)
+        child.content.nodes.list = insertLinks(list, options, false, layoutParent, propDefinitions)
       }
 
       if (empty) {
-        child.content.nodes.empty = insertLinks(empty, options, false, node, propDefinitions)
+        child.content.nodes.empty = insertLinks(
+          empty,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
 
       if (loading) {
-        child.content.nodes.loading = insertLinks(loading, options, false, node, propDefinitions)
+        child.content.nodes.loading = insertLinks(
+          loading,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
     }
 
@@ -181,7 +187,7 @@ export const insertLinks = (
             child.content.mappings[key],
             options,
             false,
-            node,
+            layoutParent,
             propDefinitions
           )
         })
@@ -191,11 +197,23 @@ export const insertLinks = (
         nodes: { fallback, error },
       } = child.content
       if (fallback) {
-        child.content.nodes.fallback = insertLinks(fallback, options, false, node, propDefinitions)
+        child.content.nodes.fallback = insertLinks(
+          fallback,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
 
       if (error) {
-        child.content.nodes.error = insertLinks(error, options, false, node, propDefinitions)
+        child.content.nodes.error = insertLinks(
+          error,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
     }
 
@@ -205,15 +223,33 @@ export const insertLinks = (
       } = child.content
 
       if (success) {
-        child.content.nodes.success = insertLinks(success, options, false, node, propDefinitions)
+        child.content.nodes.success = insertLinks(
+          success,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
 
       if (error) {
-        child.content.nodes.error = insertLinks(error, options, false, node, propDefinitions)
+        child.content.nodes.error = insertLinks(
+          error,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
 
       if (loading) {
-        child.content.nodes.loading = insertLinks(loading, options, false, node, propDefinitions)
+        child.content.nodes.loading = insertLinks(
+          loading,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
     }
 
@@ -223,15 +259,33 @@ export const insertLinks = (
       } = child.content
 
       if (success) {
-        child.content.nodes.success = insertLinks(success, options, false, node, propDefinitions)
+        child.content.nodes.success = insertLinks(
+          success,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
 
       if (error) {
-        child.content.nodes.error = insertLinks(error, options, false, node, propDefinitions)
+        child.content.nodes.error = insertLinks(
+          error,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
 
       if (loading) {
-        child.content.nodes.loading = insertLinks(loading, options, false, node, propDefinitions)
+        child.content.nodes.loading = insertLinks(
+          loading,
+          options,
+          false,
+          layoutParent,
+          propDefinitions
+        )
       }
     }
 

--- a/tools/artifact-probe/README.md
+++ b/tools/artifact-probe/README.md
@@ -1,0 +1,73 @@
+# artifact-probe
+
+Does the generated project actually work?
+
+The pipeline's evidence chain stops at the UIDL. Generator unit tests assert the
+emitted code *contains* the right things; nothing has ever checked that the
+result installs, builds, boots, renders, and is **visible**. So a project can
+have a valid UIDL, a green test suite and a section that sits at `opacity: 0`
+forever, and no artifact anywhere records that fact.
+
+This produces the missing artifact: one JSON report per generated project.
+
+## Why it lives outside `packages/`
+
+Deliberately **not** a workspace package. It needs a browser driver
+(`playwright-core`), and adding any dependency to the workspace re-resolves the
+shared `yarn.lock` — which once silently changed `parse5` and broke an unrelated
+package's build. Here it has its own `node_modules` and can touch nothing.
+
+## Setup
+
+```bash
+cd tools/artifact-probe && npm install
+```
+
+No browser is downloaded. The probe drives a Chrome/Chromium already on the
+machine; set `ARTIFACT_PROBE_BROWSER` to an executable path to override the
+search.
+
+## Use
+
+```bash
+node tools/artifact-probe/probe.mjs --project packages/teleport-test/dist/teleport-project-next
+node tools/artifact-probe/probe.mjs --project <dir> --skip-install --max-routes 10
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--project <dir>` | generated project to probe (required) |
+| `--report <path>` | report location. Defaults to `<project>.artifact-report.json` — **beside** the project, never inside it, because `yarn standalone` wipes the project tree on every file save |
+| `--port <n>` | port for the production server (default 4321) |
+| `--skip-install` | trust the existing `node_modules` |
+| `--max-routes <n>` | cap routes probed (default 25) |
+| `--no-screenshots` | skip full-page screenshots |
+| `--json` | also print the report to stdout |
+
+Exit code is 0 only when the artifact is clean.
+
+## What it checks
+
+**Build facts** — does `npm install` succeed, does `next build` succeed (with the
+error text when it doesn't), per-route First Load JS, shared JS, declared
+dependencies nothing imports.
+
+Every run deletes `.next` first. That directory deliberately survives
+regeneration so a dev server keeps its cache, which means it can hold artifacts
+from an earlier `next dev` — and a production build over that mixture was
+observed to emit **no stylesheet at all**, serving the CSS asset as HTTP 500 and
+rendering every page unstyled. A probe that condemns a site because of its own
+leftovers is worse than no probe, so the rebuild is unconditional.
+
+**Runtime facts, in a real browser** — HTTP status per route, uncaught
+exceptions, console errors, failed requests, and React hydration failures
+(#418/#423/#425), which matter more than they look: when hydration dies,
+*everything* the client was supposed to do dies with it, animations included.
+
+**The visibility audit** — the one that catches the bug class nothing else can.
+After load it looks for elements that occupy real space, contain text or images,
+and cannot be seen (`opacity < 0.01`, `visibility: hidden`). Then it scrolls the
+whole page and looks again. Content revealed by scrolling was a working in-view
+animation; content still invisible after scrolling is a defect. Each finding
+carries the nearest `data-thq` attribute, so it names the widget that produced it
+instead of leaving you to guess which repo owns the problem.

--- a/tools/artifact-probe/package-lock.json
+++ b/tools/artifact-probe/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "artifact-probe",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "artifact-probe",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright-core": "^1.62.1"
+      },
+      "bin": {
+        "artifact-probe": "probe.mjs"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tools/artifact-probe/package.json
+++ b/tools/artifact-probe/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "artifact-probe",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Builds a generated project, boots it, drives a real browser over every route, and reports what a visitor actually gets.",
+  "bin": {
+    "artifact-probe": "./probe.mjs"
+  },
+  "scripts": {
+    "probe": "node ./probe.mjs"
+  },
+  "dependencies": {
+    "playwright-core": "^1.62.1"
+  }
+}

--- a/tools/artifact-probe/probe.mjs
+++ b/tools/artifact-probe/probe.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'fs'
+import { dirname, resolve } from 'path'
+
+import { probeArtifact } from './src/probe.mjs'
+
+/**
+ * CLI for the artifact probe. See README.md.
+ *
+ * Everything human goes to stderr and the report to a file, so `--json` output
+ * on stdout stays parseable.
+ */
+
+const parseArgs = (argv) => {
+  const args = { port: 4321, skipInstall: false, maxRoutes: 25, screenshots: true, json: false }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index]
+    const readValue = () => {
+      const value = argv[index + 1]
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`Missing value for ${flag}`)
+      }
+      index += 1
+      return value
+    }
+
+    switch (flag) {
+      case '--project':
+        args.project = readValue()
+        break
+      case '--report':
+        args.report = readValue()
+        break
+      case '--port':
+        args.port = Number(readValue())
+        break
+      case '--max-routes':
+        args.maxRoutes = Number(readValue())
+        break
+      case '--skip-install':
+        args.skipInstall = true
+        break
+      case '--no-screenshots':
+        args.screenshots = false
+        break
+      case '--json':
+        args.json = true
+        break
+      default:
+        throw new Error(`Unknown argument "${flag}"`)
+    }
+  }
+
+  return args
+}
+
+const pad = (value, width) => String(value).padEnd(width)
+
+const summarize = (report) => {
+  const lines = []
+  lines.push(
+    report.ok ? 'ARTIFACT OK — builds, boots, renders, nothing hidden' : 'ARTIFACT PROBLEMS'
+  )
+  report.verdicts.forEach((verdict) => lines.push(`  • ${verdict}`))
+
+  lines.push('')
+  lines.push(
+    `  build ${report.build.ok ? 'ok' : 'FAILED'} in ${(report.build.durationMs / 1000).toFixed(
+      1
+    )}s` +
+      ` · shared JS ${report.build.sharedJsKb ?? '?'} kB` +
+      ` · ${report.totals.routesProbed} route(s) probed`
+  )
+
+  if (!report.build.ok) {
+    report.build.errors.slice(0, 12).forEach((line) => lines.push(`    ${line}`))
+    return lines.join('\n')
+  }
+
+  report.routes
+    .filter((route) => !route.skipped)
+    .forEach((route) => {
+      const flags = []
+      if (route.status !== null && route.status >= 400 && !['/404', '/500'].includes(route.path)) {
+        flags.push(`HTTP ${route.status}`)
+      }
+      if (route.hydrationErrors.length) {
+        flags.push(`${route.hydrationErrors.length} hydration`)
+      }
+      if (route.pageErrors.length) {
+        flags.push(`${route.pageErrors.length} throw`)
+      }
+      if (route.consoleErrors.length) {
+        flags.push(`${route.consoleErrors.length} console`)
+      }
+      if (route.hiddenContent.length) {
+        flags.push(`${route.hiddenContent.length} HIDDEN`)
+      }
+      if (route.revealedByScroll) {
+        flags.push(`${route.revealedByScroll} revealed-on-scroll`)
+      }
+      lines.push(
+        `  ${pad(route.path, 30)} ${String(route.firstLoadKb ?? '?').padStart(6)} kB  ${
+          flags.join(' · ') || 'clean'
+        }`
+      )
+    })
+
+  return lines.join('\n')
+}
+
+const run = async () => {
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 2
+    return
+  }
+
+  if (!args.project) {
+    process.stderr.write('--project <dir> is required\n')
+    process.exitCode = 2
+    return
+  }
+
+  const projectDir = resolve(args.project)
+  // Beside the project, never inside it: `yarn standalone` wipes the project
+  // tree on every file save while the generators are being worked on.
+  const reportPath = resolve(args.report || `${projectDir}.artifact-report.json`)
+
+  process.stderr.write(`Probing ${projectDir}\n`)
+
+  const report = await probeArtifact({
+    projectDir,
+    port: args.port,
+    screenshotDir: args.screenshots ? `${projectDir}.artifact-screens` : undefined,
+    skipInstall: args.skipInstall,
+    maxRoutes: args.maxRoutes,
+    onProgress: (message) => process.stderr.write(`  ${message}\n`),
+  })
+
+  mkdirSync(dirname(reportPath), { recursive: true })
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+
+  process.stderr.write(`\n${summarize(report)}\n\nReport: ${reportPath}\n`)
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(report)}\n`)
+  }
+
+  // Exit explicitly. Setting `process.exitCode` alone waits for the event loop
+  // to drain, and a browser that ignored `close()` keeps a handle open forever —
+  // the process then sits there, done but alive, holding the probed server with
+  // it. The report is fully written by this point, so there is nothing to lose.
+  process.exit(report.ok ? 0 : 1)
+}
+
+run()

--- a/tools/artifact-probe/src/probe.mjs
+++ b/tools/artifact-probe/src/probe.mjs
@@ -1,0 +1,402 @@
+import { existsSync, mkdirSync, rmSync } from 'fs'
+import { join } from 'path'
+import { chromium } from 'playwright-core'
+
+import {
+  BROWSER_LAUNCH_ARGS,
+  resolveBrowserExecutable,
+  runCommand,
+  startServer,
+} from './process.mjs'
+import { discoverRoutes, findUnusedDependencies, parseBuildOutput } from './routes.mjs'
+import { auditVisibility } from './visibility-audit.mjs'
+
+/**
+ * Build → boot → drive a browser → report. See ../README.md for what and why.
+ *
+ * The output shape is `ARTIFACT-REPORT.json` (schemaVersion 1); consumers are
+ * the janitor's ARTIFACT stream and the admin panel's "Generated app" view, so
+ * treat the field names as an interface and bump the version when they change.
+ */
+
+/** Error pages are SUPPOSED to answer with their status code. */
+const EXPECTED_ERROR_ROUTES = new Map([
+  ['/404', 404],
+  ['/500', 500],
+])
+
+const isUnexpectedStatus = (route) =>
+  route.status !== null &&
+  route.status >= 400 &&
+  EXPECTED_ERROR_ROUTES.get(route.path) !== route.status
+
+const HYDRATION_MARKERS = [
+  'Hydration failed',
+  'Text content does not match',
+  'did not match',
+  'Minified React error #418',
+  'Minified React error #423',
+  'Minified React error #425',
+]
+
+const emptyRouteReport = (route, extra = {}) => ({
+  path: route.path,
+  file: route.file,
+  status: null,
+  loadMs: null,
+  firstLoadKb: null,
+  domNodes: null,
+  bodyTextLength: null,
+  consoleErrors: [],
+  pageErrors: [],
+  failedRequests: [],
+  hydrationErrors: [],
+  hiddenContent: [],
+  hiddenOnLoad: 0,
+  revealedByScroll: 0,
+  screenshot: null,
+  ...extra,
+})
+
+/**
+ * Next's build log ends with the error block when it fails; the useful part is
+ * from "Failed to compile" / "Build error occurred" onwards, not 400 lines of
+ * progress.
+ */
+const extractBuildErrors = (stdout, stderr) => {
+  const lines = `${stdout}\n${stderr}`.split(/\r?\n/)
+  const startIndex = lines.findIndex(
+    (line) =>
+      line.includes('Failed to compile') ||
+      line.includes('Build error occurred') ||
+      /^\s*Error:/.test(line)
+  )
+  if (startIndex < 0) {
+    return lines
+      .filter((line) => /error/i.test(line))
+      .slice(-10)
+      .map((line) => line.trim())
+      .filter(Boolean)
+  }
+  return lines
+    .slice(startIndex, startIndex + 30)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+const probeRoute = async (browser, { baseUrl, route, firstLoadKb, screenshotDir }) => {
+  const report = emptyRouteReport(route, { firstLoadKb })
+
+  // Opening the context/page has to be inside the guarded section too. A browser
+  // that dies mid-sweep throws HERE, and when this sat outside the try it took
+  // the whole process down — no report written at all, so 30 completed routes
+  // were lost along with the one that failed. One bad route should cost one bad
+  // route.
+  let context
+  let page
+  try {
+    context = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+    page = await context.newPage()
+  } catch (error) {
+    report.error = `could not open a browser page: ${error.message}`
+    return report
+  }
+
+  page.on('console', (message) => {
+    const type = message.type()
+    if (type !== 'error' && type !== 'warning') {
+      return
+    }
+    const text = message.text()
+    if (HYDRATION_MARKERS.some((marker) => text.includes(marker))) {
+      report.hydrationErrors.push(text)
+    } else if (type === 'error') {
+      report.consoleErrors.push(text)
+    }
+  })
+  page.on('pageerror', (error) => {
+    const text = error.message
+    if (HYDRATION_MARKERS.some((marker) => text.includes(marker))) {
+      report.hydrationErrors.push(text)
+    } else {
+      report.pageErrors.push(text)
+    }
+  })
+  page.on('requestfailed', (request) => {
+    report.failedRequests.push({
+      url: request.url(),
+      failure: request.failure()?.errorText ?? 'unknown',
+    })
+  })
+
+  try {
+    const startedAt = Date.now()
+    const response = await page.goto(`${baseUrl}${route.path}`, {
+      waitUntil: 'load',
+      timeout: 45000,
+    })
+    report.status = response?.status() ?? null
+    report.loadMs = Date.now() - startedAt
+
+    // Long enough for a reveal animation AND its failsafe to have run. The
+    // generated TqMotion in-view failsafe fires at duration * 1000 + 600ms.
+    await page.waitForTimeout(2500)
+
+    const audit = await page.evaluate(auditVisibility, { minArea: 2500, dwellMs: 700 })
+    // A silent `undefined` here once made every route report "nothing hidden".
+    // Never let a missing audit read as a clean one.
+    if (!audit || typeof audit.domNodes !== 'number') {
+      throw new Error('visibility audit returned nothing — the page could not be inspected')
+    }
+    report.domNodes = audit.domNodes
+    report.bodyTextLength = audit.bodyText
+    report.hiddenContent = audit.stillHidden
+    report.revealedByScroll = audit.revealedByScroll
+    report.hiddenOnLoad = audit.hiddenOnLoad
+
+    if (screenshotDir) {
+      const name = `${route.path.replace(/[^a-z0-9]+/gi, '_') || 'index'}.png`
+      const screenshotPath = join(screenshotDir, name)
+      await page.screenshot({ path: screenshotPath, fullPage: true })
+      report.screenshot = screenshotPath
+    }
+  } catch (error) {
+    report.error = error.message
+  } finally {
+    await context.close()
+  }
+
+  return report
+}
+
+export const probeArtifact = async ({
+  projectDir,
+  port = 4321,
+  screenshotDir,
+  skipInstall = false,
+  installTimeoutMs = 900000,
+  buildTimeoutMs = 900000,
+  bootTimeoutMs = 120000,
+  maxRoutes = 25,
+  onProgress = () => undefined,
+}) => {
+  const report = {
+    schemaVersion: 1,
+    projectDir,
+    generatedAt: new Date().toISOString(),
+    ok: false,
+    verdicts: [],
+    install: { ran: false, ok: true, durationMs: 0 },
+    build: { ok: false, durationMs: 0, errors: [], sharedJsKb: null, routeBundles: [] },
+    boot: { ok: false, port },
+    routes: [],
+    unusedDependencies: [],
+    totals: {
+      routesProbed: 0,
+      routesWithErrors: 0,
+      routesWithHiddenContent: 0,
+      hiddenRegions: 0,
+    },
+  }
+
+  if (!existsSync(join(projectDir, 'package.json'))) {
+    report.verdicts.push(`No package.json at ${projectDir} — nothing to probe.`)
+    return report
+  }
+
+  const discovered = discoverRoutes(projectDir)
+
+  if (!skipInstall && !existsSync(join(projectDir, 'node_modules'))) {
+    onProgress('Installing dependencies…')
+    const install = await runCommand({
+      command: 'npm',
+      args: ['install', '--no-audit', '--no-fund'],
+      cwd: projectDir,
+      timeoutMs: installTimeoutMs,
+    })
+    report.install = {
+      ran: true,
+      ok: install.code === 0,
+      durationMs: install.durationMs,
+      error: install.code === 0 ? undefined : extractBuildErrors('', install.stderr).join('\n'),
+    }
+    if (!report.install.ok) {
+      report.verdicts.push('`npm install` failed — the generated package.json is not installable.')
+      return report
+    }
+  }
+
+  // Build from scratch. `.next` survives regeneration (it is deliberately
+  // preserved so a dev server keeps its cache), so it can hold artifacts from a
+  // previous `next dev` — and a production build over that mixture silently
+  // emitted NO stylesheet at all: the CSS asset 500'd and every page rendered
+  // unstyled. A probe that reports a broken site because of its own leftovers is
+  // worse than no probe, and the few seconds this costs buy a verdict that means
+  // something.
+  onProgress('Clearing the previous build…')
+  rmSync(join(projectDir, '.next'), { recursive: true, force: true })
+
+  onProgress('Building…')
+  const build = await runCommand({
+    command: 'npm',
+    args: ['run', 'build'],
+    cwd: projectDir,
+    timeoutMs: buildTimeoutMs,
+  })
+  report.build.durationMs = build.durationMs
+  report.build.ok = build.code === 0
+  const { routes: routeBundles, sharedKb } = parseBuildOutput(build.stdout)
+  report.build.routeBundles = routeBundles
+  report.build.sharedJsKb = sharedKb
+
+  if (!report.build.ok) {
+    report.build.errors = extractBuildErrors(build.stdout, build.stderr)
+    report.verdicts.push(
+      build.timedOut
+        ? `\`next build\` timed out after ${Math.round(buildTimeoutMs / 1000)}s.`
+        : '`next build` failed — the generated code does not compile.'
+    )
+    report.routes = discovered.map((route) =>
+      emptyRouteReport(route, { error: 'not probed — build failed' })
+    )
+    return report
+  }
+
+  onProgress('Booting the production server…')
+  const { handle, output } = await startServer({
+    command: 'npm',
+    args: ['run', 'start'],
+    cwd: projectDir,
+    port,
+    timeoutMs: bootTimeoutMs,
+  })
+
+  if (!handle) {
+    report.boot = {
+      ok: false,
+      port,
+      error: output.split(/\r?\n/).filter(Boolean).slice(-8).join('\n'),
+    }
+    report.verdicts.push('The built app does not boot — `next start` never served the port.')
+    return report
+  }
+  report.boot.ok = true
+
+  const executablePath = resolveBrowserExecutable()
+  let browser = null
+  try {
+    if (!executablePath) {
+      report.verdicts.push(
+        'No Chrome/Chromium found — build facts only. Set ARTIFACT_PROBE_BROWSER to an executable to enable runtime probing.'
+      )
+    } else {
+      if (screenshotDir) {
+        mkdirSync(screenshotDir, { recursive: true })
+      }
+      browser = await chromium.launch({
+        executablePath,
+        headless: true,
+        args: BROWSER_LAUNCH_ARGS,
+        timeout: 60000,
+      })
+      const bundleByPath = new Map(routeBundles.map((entry) => [entry.path, entry.firstLoadKb]))
+
+      const probeable = discovered.filter((route) => !route.dynamic).slice(0, maxRoutes)
+      const staticTotal = discovered.filter((route) => !route.dynamic).length
+      if (staticTotal > probeable.length) {
+        report.verdicts.push(
+          `Only ${probeable.length} of ${staticTotal} static routes probed — the --max-routes cap (${maxRoutes}) was hit, so the rest are unchecked.`
+        )
+      }
+
+      for (const route of probeable) {
+        onProgress(`Probing ${route.path}…`)
+        report.routes.push(
+          await probeRoute(browser, {
+            baseUrl: `http://127.0.0.1:${port}`,
+            route,
+            firstLoadKb: bundleByPath.get(route.path) ?? null,
+            screenshotDir,
+          })
+        )
+      }
+
+      for (const route of discovered) {
+        if (route.dynamic) {
+          report.routes.push(
+            emptyRouteReport(route, {
+              skipped: 'dynamic',
+              firstLoadKb: bundleByPath.get(route.path) ?? null,
+            })
+          )
+        }
+      }
+    }
+  } finally {
+    if (browser) {
+      // A branded Chrome can refuse to exit; without this race the probed
+      // server stayed alive for half an hour behind a hanging close().
+      await Promise.race([
+        browser.close(),
+        new Promise((resolve) => setTimeout(resolve, 15000)),
+      ]).catch(() => undefined)
+    }
+    handle.stop()
+  }
+
+  report.unusedDependencies = findUnusedDependencies(projectDir)
+
+  const probed = report.routes.filter((route) => !route.skipped && !route.error)
+  report.totals.routesProbed = probed.length
+  report.totals.routesWithErrors = probed.filter(
+    (route) =>
+      isUnexpectedStatus(route) || route.pageErrors.length > 0 || route.hydrationErrors.length > 0
+  ).length
+  report.totals.routesWithHiddenContent = probed.filter(
+    (route) => route.hiddenContent.length > 0
+  ).length
+  report.totals.hiddenRegions = probed.reduce(
+    (total, route) => total + route.hiddenContent.length,
+    0
+  )
+
+  for (const route of probed) {
+    if (isUnexpectedStatus(route)) {
+      report.verdicts.push(`${route.path} returned HTTP ${route.status}.`)
+    }
+    if (route.hydrationErrors.length > 0) {
+      report.verdicts.push(
+        `${route.path} fails React hydration — everything the client was supposed to do (animations, handlers, state) is dead: ${route.hydrationErrors[0]}`
+      )
+    }
+    if (route.hiddenContent.length > 0) {
+      const first = route.hiddenContent[0]
+      report.verdicts.push(
+        `${route.path} has ${
+          route.hiddenContent.length
+        } region(s) invisible even after scrolling — e.g. ${
+          first.dataThq ? `[data-thq="${first.dataThq}"] ` : ''
+        }${first.selector} at opacity ${first.opacity}.`
+      )
+    }
+    if (route.pageErrors.length > 0) {
+      report.verdicts.push(`${route.path} throws at runtime: ${route.pageErrors[0]}`)
+    }
+  }
+
+  if (report.unusedDependencies.length > 0) {
+    report.verdicts.push(
+      `${
+        report.unusedDependencies.length
+      } declared dependency(ies) nothing imports: ${report.unusedDependencies.join(', ')}.`
+    )
+  }
+
+  report.ok =
+    report.build.ok &&
+    report.boot.ok &&
+    report.totals.routesWithErrors === 0 &&
+    report.totals.routesWithHiddenContent === 0
+
+  return report
+}

--- a/tools/artifact-probe/src/process.mjs
+++ b/tools/artifact-probe/src/process.mjs
@@ -1,0 +1,243 @@
+import { spawn } from 'child_process'
+import { existsSync, readdirSync } from 'fs'
+import { createConnection } from 'net'
+import { homedir } from 'os'
+import { join } from 'path'
+
+/**
+ * Host-process keys that must not describe a child. `__NEXT_PROCESSED_ENV` is
+ * the dangerous one: `@next/env`'s `processEnv()` short-circuits on it, so a
+ * Next app spawned from inside another Next process reads its `.env` off disk
+ * and then discards every key. The app then runs with no database connection
+ * string and no auth secrets, and the failure surfaces as a libpq error about a
+ * database named after the OS user — nothing that points at env loading at all.
+ *
+ * This probe runs `next build` and `next start`, so it strips them for the same
+ * reason the GUI's Teleport & Run route does.
+ */
+const HOST_ONLY_ENV_KEYS = [
+  '__NEXT_PROCESSED_ENV',
+  '__NEXT_OPTIMIZE_FONTS',
+  'NEXT_RUNTIME',
+  'NODE_ENV',
+  'INIT_CWD',
+]
+const HOST_ONLY_ENV_PREFIXES = ['__NEXT', 'NEXT_PUBLIC_', 'npm_']
+
+export const childEnv = (extra = {}) => {
+  const env = { ...process.env }
+  for (const key of Object.keys(env)) {
+    if (
+      HOST_ONLY_ENV_KEYS.includes(key) ||
+      HOST_ONLY_ENV_PREFIXES.some((prefix) => key.startsWith(prefix))
+    ) {
+      delete env[key]
+    }
+  }
+  return { ...env, ...extra }
+}
+
+export const runCommand = ({ command, args, cwd, timeoutMs, env, onLine }) =>
+  new Promise((resolve) => {
+    const startedAt = Date.now()
+    const child = spawn(command, args, { cwd, env: env ?? childEnv() })
+
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, timeoutMs)
+
+    const collect = (target) => (chunk) => {
+      const text = chunk.toString()
+      if (target === 'stdout') {
+        stdout += text
+      } else {
+        stderr += text
+      }
+      if (onLine) {
+        for (const line of text.split(/\r?\n/)) {
+          if (line.trim()) {
+            onLine(line)
+          }
+        }
+      }
+    }
+
+    child.stdout.on('data', collect('stdout'))
+    child.stderr.on('data', collect('stderr'))
+    child.on('error', (error) => {
+      stderr += `\n${error.message}`
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({
+        command: `${command} ${args.join(' ')}`.trim(),
+        code,
+        timedOut,
+        durationMs: Date.now() - startedAt,
+        stdout,
+        stderr,
+      })
+    })
+  })
+
+const canConnect = (port) =>
+  new Promise((resolve) => {
+    const socket = createConnection({ port, host: '127.0.0.1' })
+    socket.setTimeout(1000)
+    socket.on('connect', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    const fail = () => {
+      socket.destroy()
+      resolve(false)
+    }
+    socket.on('error', fail)
+    socket.on('timeout', fail)
+  })
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Boot a long-running server and wait until the port actually accepts a
+ * connection. Resolves a null handle when the process died or never came up, so
+ * the caller reports a boot failure instead of probing a port serving nothing.
+ */
+export const startServer = async ({ command, args, cwd, port, timeoutMs }) => {
+  // `detached` makes the child its own process-group leader so the whole group
+  // can be killed at once. `npm run start` is a shell wrapper around `next
+  // start`: killing the wrapper alone orphans the real server, which then holds
+  // the port until someone notices. Two of those survived a probe run and sat
+  // there for the better part of an hour.
+  const child = spawn(command, args, {
+    cwd,
+    env: childEnv({ PORT: String(port) }),
+    detached: true,
+  })
+
+  let output = ''
+  let exited = false
+  child.stdout.on('data', (chunk) => {
+    output += chunk.toString()
+  })
+  child.stderr.on('data', (chunk) => {
+    output += chunk.toString()
+  })
+  child.on('error', (error) => {
+    output += `\n${error.message}`
+    exited = true
+  })
+  child.on('close', () => {
+    exited = true
+  })
+
+  const handle = {
+    stop: () => {
+      if (exited) {
+        return
+      }
+      try {
+        // Negative pid = the whole process group, so `next start` goes too.
+        process.kill(-child.pid, 'SIGKILL')
+      } catch {
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          /* already gone */
+        }
+      }
+    },
+    output: () => output,
+  }
+
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (exited) {
+      return { handle: null, output }
+    }
+    if (await canConnect(port)) {
+      // The port opens a beat before the first request can be served.
+      await delay(500)
+      return { handle, output }
+    }
+    await delay(300)
+  }
+
+  handle.stop()
+  return { handle: null, output }
+}
+
+/**
+ * Chrome the probe can drive. `playwright-core` ships no browser, so one has to
+ * be found on the machine.
+ *
+ * "Chrome for Testing" builds are preferred over the developer's own Chrome.
+ * The branded app carries a real user profile, an update service and first-run
+ * machinery; driving it is slow and it does not always exit when told to — an
+ * early run left `browser.close()` hanging and the probed server alive for half
+ * an hour. Chrome for Testing exists precisely to avoid that.
+ */
+const puppeteerCacheCandidates = () => {
+  const cacheRoot = join(homedir(), '.cache', 'puppeteer', 'chrome')
+  if (!existsSync(cacheRoot)) {
+    return []
+  }
+  let versions = []
+  try {
+    versions = readdirSync(cacheRoot).sort().reverse()
+  } catch {
+    return []
+  }
+  return versions.flatMap((version) => [
+    join(
+      cacheRoot,
+      version,
+      'chrome-mac-arm64',
+      'Google Chrome for Testing.app',
+      'Contents',
+      'MacOS',
+      'Google Chrome for Testing'
+    ),
+    join(
+      cacheRoot,
+      version,
+      'chrome-mac-x64',
+      'Google Chrome for Testing.app',
+      'Contents',
+      'MacOS',
+      'Google Chrome for Testing'
+    ),
+    join(cacheRoot, version, 'chrome-linux64', 'chrome'),
+  ])
+}
+
+export const resolveBrowserExecutable = () => {
+  if (process.env.ARTIFACT_PROBE_BROWSER) {
+    return existsSync(process.env.ARTIFACT_PROBE_BROWSER)
+      ? process.env.ARTIFACT_PROBE_BROWSER
+      : null
+  }
+  const candidates = [
+    ...puppeteerCacheCandidates(),
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/google-chrome',
+  ]
+  return candidates.find((candidate) => existsSync(candidate)) ?? null
+}
+
+/** Flags that keep an automated Chrome from behaving like a desktop app. */
+export const BROWSER_LAUNCH_ARGS = [
+  '--no-first-run',
+  '--no-default-browser-check',
+  '--disable-background-networking',
+  '--disable-sync',
+  '--disable-extensions',
+]

--- a/tools/artifact-probe/src/routes.mjs
+++ b/tools/artifact-probe/src/routes.mjs
@@ -1,0 +1,156 @@
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+const PAGE_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx']
+const NON_ROUTE_FILES = new Set(['_app', '_document', '_error', 'middleware'])
+
+/**
+ * Routes come from the `pages/` tree rather than the build output, so the list
+ * is known even when the build FAILED — a report saying "0 routes" because
+ * nothing compiled is indistinguishable from a project with no pages.
+ */
+export const discoverRoutes = (projectDir) => {
+  const pagesDir = join(projectDir, 'pages')
+  if (!existsSync(pagesDir)) {
+    return []
+  }
+
+  const routes = []
+
+  const walk = (dir, segments) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        // API routes are endpoints, not pages.
+        if (segments.length === 0 && entry.name === 'api') {
+          continue
+        }
+        walk(join(dir, entry.name), [...segments, entry.name])
+        continue
+      }
+
+      const extension = PAGE_EXTENSIONS.find((candidate) => entry.name.endsWith(candidate))
+      if (!extension) {
+        continue
+      }
+      const name = entry.name.slice(0, -extension.length)
+      if (NON_ROUTE_FILES.has(name)) {
+        continue
+      }
+
+      const routeSegments = name === 'index' ? segments : [...segments, name]
+      routes.push({
+        path: routeSegments.length ? `/${routeSegments.join('/')}` : '/',
+        file: join('pages', ...segments, entry.name),
+        dynamic: routeSegments.some(
+          (segment) => segment.startsWith('[') || segment.startsWith('...')
+        ),
+      })
+    }
+  }
+
+  walk(pagesDir, [])
+  return routes.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+const parseSize = (value) => {
+  const match = value.match(/([\d.]+)\s*(B|kB|KB|MB)/)
+  if (!match) {
+    return null
+  }
+  const amount = parseFloat(match[1])
+  if (match[2] === 'B') {
+    return amount / 1024
+  }
+  if (match[2] === 'MB') {
+    return amount * 1024
+  }
+  return amount
+}
+
+/**
+ * `next build` prints a per-route table ending in "First Load JS" — the number
+ * that decides how long a visitor stares at nothing. Parsed from stdout because
+ * Next 12 writes no machine-readable equivalent.
+ */
+export const parseBuildOutput = (stdout) => {
+  const routes = []
+  let sharedKb = null
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    // Strip the tree-drawing and status glyphs Next prefixes each row with.
+    const line = rawLine.replace(/^[\s│├└┌─┬┴┼○λƒ●•+]*/, '').trim()
+    if (!line) {
+      continue
+    }
+
+    if (line.startsWith('First Load JS shared by all')) {
+      sharedKb = parseSize(line)
+      continue
+    }
+
+    const match = line.match(/^(\/\S*)\s+(?:[\d.]+\s*(?:B|kB|KB|MB))\s+([\d.]+\s*(?:B|kB|KB|MB))/)
+    if (match) {
+      const firstLoadKb = parseSize(match[2])
+      if (firstLoadKb !== null) {
+        routes.push({ path: match[1], firstLoadKb: Math.round(firstLoadKb * 10) / 10 })
+      }
+    }
+  }
+
+  return { routes, sharedKb }
+}
+
+/**
+ * Dependencies declared in `package.json` that nothing in the generated source
+ * imports. Each one is install time and lockfile surface a real user pays for,
+ * and they appear when the generator adds a dep for a feature the UIDL stopped
+ * using.
+ */
+export const findUnusedDependencies = (projectDir) => {
+  const packageJsonPath = join(projectDir, 'package.json')
+  if (!existsSync(packageJsonPath)) {
+    return []
+  }
+
+  let dependencies = []
+  try {
+    dependencies = Object.keys(JSON.parse(readFileSync(packageJsonPath, 'utf8')).dependencies ?? {})
+  } catch {
+    return []
+  }
+
+  const sources = []
+  const SKIP_DIRS = new Set(['node_modules', '.next', '.git', 'public'])
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) {
+          walk(join(dir, entry.name))
+        }
+        continue
+      }
+      if (PAGE_EXTENSIONS.some((extension) => entry.name.endsWith(extension))) {
+        try {
+          sources.push(readFileSync(join(dir, entry.name), 'utf8'))
+        } catch {
+          /* an unreadable file is not evidence of anything */
+        }
+      }
+    }
+  }
+  walk(projectDir)
+
+  // The framework pulls these in itself; no generated file imports them by name,
+  // and reporting them as dead weight is noise that trains you to ignore the list.
+  const FRAMEWORK_IMPLIED = new Set(['next', 'react', 'react-dom'])
+
+  const haystack = sources.join('\n')
+  return dependencies.filter((dependency) => {
+    if (FRAMEWORK_IMPLIED.has(dependency)) {
+      return false
+    }
+    // Match `from 'dep'`, `from 'dep/sub'`, `require('dep')`.
+    const escaped = dependency.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return !new RegExp(`['"\`]${escaped}(/|['"\`])`).test(haystack)
+  })
+}

--- a/tools/artifact-probe/src/visibility-audit.mjs
+++ b/tools/artifact-probe/src/visibility-audit.mjs
@@ -1,0 +1,150 @@
+/**
+ * The audit that runs INSIDE the page.
+ *
+ * `next build` passing and the DOM being present prove nothing about whether a
+ * human sees anything. The archetype: framer-motion server-renders its `initial`
+ * state, so a reveal animation ships `opacity: 0` in the HTML and depends on
+ * client JS to undo it. If hydration throws, if an IntersectionObserver never
+ * fires, or if a timing failsafe misses, the section stays invisible forever —
+ * with a perfectly valid UIDL, a green build, and every generator test passing.
+ *
+ * So this looks for the only thing that matters: content that occupies real
+ * space and cannot be seen. It then scrolls each candidate to the centre of the
+ * viewport, waits, and re-checks THE SAME ELEMENT. Content that appears was a
+ * working in-view animation; content still invisible while sitting in the middle
+ * of the screen is a defect.
+ *
+ * One function, one `page.evaluate`, element references held across both phases.
+ * Two earlier designs failed here and both failed *quietly*:
+ *  - passing this as a source STRING made Playwright evaluate it as an
+ *    expression rather than call it, so every audit returned `undefined` and
+ *    every route reported "nothing hidden";
+ *  - re-finding elements by CSS selector between phases conflated distinct
+ *    nodes, because generated markup reuses machine-generated class names.
+ * A check that cannot fail is worse than no check, so the caller treats a
+ * missing result as an error rather than a pass.
+ *
+ * Runs in the browser: self-contained, no imports, no closure over this module.
+ */
+export const auditVisibility = async (options) => {
+  const MIN_AREA = (options && options.minArea) || 2500
+  const DWELL_MS = (options && options.dwellMs) || 700
+  const MAX_CANDIDATES = (options && options.maxCandidates) || 40
+
+  // Provenance the generators stamp into the DOM. An invisible region reports
+  // which widget produced it, so the finding routes to a fix without guesswork.
+  const provenance = (el) => {
+    let node = el
+    for (let depth = 0; node && depth < 6; depth += 1) {
+      if (node.getAttribute && node.getAttribute('data-thq')) {
+        return node.getAttribute('data-thq')
+      }
+      node = node.parentElement
+    }
+    return null
+  }
+
+  const selectorFor = (el) => {
+    const parts = []
+    let node = el
+    for (let depth = 0; node && node.tagName && depth < 4; depth += 1) {
+      let part = node.tagName.toLowerCase()
+      if (node.id) {
+        parts.unshift(part + '#' + node.id)
+        break
+      }
+      const cls = typeof node.className === 'string' ? node.className.trim().split(/\s+/)[0] : ''
+      if (cls) {
+        part += '.' + cls
+      }
+      parts.unshift(part)
+      node = node.parentElement
+    }
+    return parts.join(' > ')
+  }
+
+  const hasVisibleContent = (el) => {
+    if (el.querySelector('img, svg, video, canvas, picture')) {
+      return true
+    }
+    return (el.textContent || '').trim().length > 0
+  }
+
+  const isInvisible = (el) => {
+    const style = window.getComputedStyle(el)
+    const opacity = parseFloat(style.opacity)
+    if (style.visibility === 'hidden') {
+      return { hidden: true, reason: 'visibility', opacity: isNaN(opacity) ? null : opacity }
+    }
+    if (!isNaN(opacity) && opacity < 0.01) {
+      return { hidden: true, reason: 'opacity', opacity }
+    }
+    return { hidden: false, reason: null, opacity: isNaN(opacity) ? null : opacity }
+  }
+
+  const candidates = []
+  const claimed = []
+  const all = document.querySelectorAll('body *')
+  for (let index = 0; index < all.length; index += 1) {
+    const el = all[index]
+    const rect = el.getBoundingClientRect()
+    const area = rect.width * rect.height
+    if (area < MIN_AREA || !hasVisibleContent(el)) {
+      continue
+    }
+    const state = isInvisible(el)
+    if (!state.hidden) {
+      continue
+    }
+    // An ancestor already reported covers its subtree; reporting every
+    // descendant of one hidden hero turns a single defect into fifty findings.
+    if (claimed.some((other) => other.contains(el))) {
+      continue
+    }
+    claimed.push(el)
+    candidates.push({
+      element: el,
+      finding: {
+        selector: selectorFor(el),
+        dataThq: provenance(el),
+        tag: el.tagName.toLowerCase(),
+        reason: state.reason,
+        opacityOnLoad: state.opacity,
+        area: Math.round(area),
+        documentTop: Math.round(rect.top + window.scrollY),
+        inlineStyle: (el.getAttribute('style') || '').slice(0, 160),
+        textPreview: (el.textContent || '').trim().slice(0, 120),
+      },
+    })
+  }
+
+  const domNodes = document.getElementsByTagName('*').length
+  const bodyText = (document.body.innerText || '').trim().length
+  const scrollHeight = document.documentElement.scrollHeight
+
+  const probed = candidates.slice(0, MAX_CANDIDATES)
+  for (const entry of probed) {
+    entry.element.scrollIntoView({ block: 'center' })
+    await new Promise((resolve) => setTimeout(resolve, DWELL_MS))
+  }
+  window.scrollTo(0, 0)
+  await new Promise((resolve) => setTimeout(resolve, 500))
+
+  const stillHidden = []
+  for (const entry of probed) {
+    const state = isInvisible(entry.element)
+    if (state.hidden) {
+      stillHidden.push({ ...entry.finding, opacity: state.opacity })
+    }
+  }
+
+  return {
+    stillHidden,
+    hiddenOnLoad: candidates.length,
+    revealedByScroll: probed.length - stillHidden.length,
+    truncated: candidates.length > probed.length,
+    domNodes,
+    bodyText,
+    scrollHeight,
+  }
+}


### PR DESCRIPTION
- A logged-out visitor no longer passes a logged-in check: values that arrive as the words "true"/"false" were read as true either way, so a gate meant to protect a page let everyone through.
- Animated sections can no longer be stuck invisible — content reveals whenever it is genuinely on screen even if the browser never reports it, and a reveal threshold the element can never reach no longer holds it at zero opacity forever.
- Cards keep their width inside a row or grid: wrapping a card in a link made the wrapper the item the layout sizes, so a fixed-width card collapsed to the width of its text.
- yarn generate packs any project file from any path into any output directory — the shared entry point behind Teleport & Run and the new prober.
- A staleness warning before generating: generation runs the compiled generators, and editing one without a build silently produced output from the previous build.
- A probe that answers whether a generated project actually works — installs, builds, boots and opens it, then reports whether its sections are visible on screen.
- Tests for the condition fix, the animation failsafe and the layout-parent rules.