### PR TITLE
Generated sites stop failing to build over a duplicated data loader

### DIFF
--- a/packages/teleport-project-generator-next/src/state-data-source-plugin.ts
+++ b/packages/teleport-project-generator-next/src/state-data-source-plugin.ts
@@ -1059,11 +1059,18 @@ export const createStateDataSourcePlugin: ComponentPluginFactory<{}> = () => {
 
     // Find or create getStaticProps chunk
     let { chunk: getStaticPropsChunk, tryBlock } = findGetStaticPropsChunkAndTryBlock(chunks)
-    if (!getStaticPropsChunk || !tryBlock) {
+    if (!getStaticPropsChunk) {
       const created = createGetStaticPropsChunk()
       getStaticPropsChunk = created.chunk
       tryBlock = created.tryBlock
       chunks.push(getStaticPropsChunk)
+    } else if (!tryBlock) {
+      // The chunk is the minimal fallback stub emitted by the static-paths
+      // plugin (no try block). Replace its content in place — pushing a second
+      // chunk would export getStaticProps twice and break the Next.js build.
+      const created = createGetStaticPropsChunk()
+      getStaticPropsChunk.content = created.chunk.content
+      tryBlock = created.tryBlock
     }
 
     // Compute folder depth for import paths

--- a/packages/teleport-test/src/generate.ts
+++ b/packages/teleport-test/src/generate.ts
@@ -96,11 +96,11 @@ const resolveProjectType = (value: string | undefined): ProjectType => {
   if (!value) {
     return ProjectType.NEXT
   }
-  const normalized = value.toLowerCase()
-  if (!PROJECT_TYPES.includes(normalized)) {
+  const match = PROJECT_TYPES.find((type) => type.toLowerCase() === value.toLowerCase())
+  if (!match) {
     throw new Error(`Unknown --project-type "${value}". Known: ${PROJECT_TYPES.join(', ')}`)
   }
-  return normalized as ProjectType
+  return match as ProjectType
 }
 
 const readUidl = (uidlPath: string): ProjectUIDL => {


### PR DESCRIPTION
- A generated page can no longer end up with two data-loading functions: when one part of the generator had already emitted a minimal data-loading stub, another part added a second full one beside it instead of completing the stub, and the generated site failed to build. The stub is now completed in place.
- The test generator's project-type flag accepts any capitalization.