### PR TITLE
Fix e-commerce email rendering, cart resurrection after checkout, and…

### DIFF
--- a/packages/teleport-plugin-next-data-source/__tests__/ecommerce-product-variant-availability.test.ts
+++ b/packages/teleport-plugin-next-data-source/__tests__/ecommerce-product-variant-availability.test.ts
@@ -1,0 +1,264 @@
+import { generateEcommerceProductTransformationCode } from '../src/transformations/ecommerce-product'
+import { generateSharedTransformationCode } from '../src/transformations/shared-utils'
+import { getTransformWrapperCode } from '../src/transformations'
+
+/**
+ * A product whose variant combinations are ALL out of stock — or whose axes have
+ * no combinations behind them at all — must reach the storefront saying so, in
+ * two ways the picker and the buy button read directly:
+ *
+ *   - every value carries `isDead: 'true'`, so the picker strikes them through;
+ *   - `hasPurchasableVariant: 'false'`, so the Add to Cart button is replaced by
+ *     the "select an available option" notice instead of adding a cart line with
+ *     no variant at all (`data-default-variant-id` is empty in that state).
+ *
+ * The hinge is knowing the difference between "we looked and there are none" and
+ * "we could not look": `options.variantsByProductId` is NULL for the latter, and
+ * a null must stay permissive — a missing table or a failed query must never
+ * make a whole catalogue unbuyable.
+ */
+
+const evalBuildProduct = (): ((r: unknown, o?: unknown) => Record<string, unknown>) => {
+  const code =
+    generateSharedTransformationCode() + '\n' + generateEcommerceProductTransformationCode()
+  return new Function(code + '\nreturn buildEcommerceProduct;')() as (
+    r: unknown,
+    o?: unknown
+  ) => Record<string, unknown>
+}
+
+type Axis = { key: string; values: Array<Record<string, unknown>> }
+
+const buildEcommerceProduct = evalBuildProduct()
+
+const SIZE_AXIS = JSON.stringify([
+  {
+    key: 'size',
+    name: 'Size',
+    type: 'text',
+    values: [
+      { value: 'xs', label: 'XS' },
+      { value: 's', label: 'S' },
+    ],
+  },
+])
+
+const variantProduct = (overrides: Record<string, unknown> = {}) => ({
+  id: 'p1',
+  name: 'Tee',
+  slug: 'tee',
+  price: 20,
+  currency: 'USD',
+  variant_options: SIZE_AXIS,
+  ...overrides,
+})
+
+const values = (product: Record<string, unknown>): Array<Record<string, unknown>> =>
+  (product.variantOptions as Axis[])[0].values
+
+describe('ecommerce product transform — variant availability', () => {
+  it('combinations UNKNOWN (no map at all): nothing dead, still purchasable', () => {
+    const product = buildEcommerceProduct(variantProduct())
+    expect(values(product).every((v) => v.isDead === 'false')).toBe(true)
+    expect(product.hasPurchasableVariant).toBe('true')
+  })
+
+  it('combinations UNKNOWN (the lookup failed → null map): unchanged', () => {
+    const product = buildEcommerceProduct(variantProduct(), { variantsByProductId: null })
+    expect(values(product).every((v) => v.isDead === 'false')).toBe(true)
+    expect(product.hasPurchasableVariant).toBe('true')
+  })
+
+  it('looked up and there are NO combinations: every value dead, not purchasable', () => {
+    const product = buildEcommerceProduct(variantProduct(), { variantsByProductId: {} })
+    expect(values(product).every((v) => v.isDead === 'true')).toBe(true)
+    expect(product.hasPurchasableVariant).toBe('false')
+    expect(product.defaultVariantId).toBe('')
+  })
+
+  it('every combination sold out: every value dead, not purchasable', () => {
+    const product = buildEcommerceProduct(variantProduct(), {
+      variantsByProductId: {
+        p1: [
+          { id: 'v-xs', options: { size: 'xs' }, quantity: 0 },
+          { id: 'v-s', options: { size: 's' }, quantity: 0 },
+        ],
+      },
+    })
+    expect(values(product).every((v) => v.isDead === 'true')).toBe(true)
+    expect(product.hasPurchasableVariant).toBe('false')
+    expect(product.defaultVariantId).toBe('')
+  })
+
+  it('one combination in stock: only the sold-out value is dead, and it is purchasable', () => {
+    const product = buildEcommerceProduct(variantProduct(), {
+      variantsByProductId: {
+        p1: [
+          { id: 'v-xs', options: { size: 'xs' }, quantity: 0 },
+          { id: 'v-s', options: { size: 's' }, quantity: 4 },
+        ],
+      },
+    })
+    expect(values(product)[0].isDead).toBe('true')
+    expect(values(product)[1].isDead).toBe('false')
+    expect(values(product)[1].isDefault).toBe('true')
+    expect(product.hasPurchasableVariant).toBe('true')
+    expect(product.defaultVariantId).toBe('v-s')
+  })
+
+  it('unlimited stock (null quantity) counts as in stock', () => {
+    const product = buildEcommerceProduct(variantProduct(), {
+      variantsByProductId: { p1: [{ id: 'v-xs', options: { size: 'xs' }, quantity: null }] },
+    })
+    expect(product.hasPurchasableVariant).toBe('true')
+    expect(values(product)[0].isDead).toBe('false')
+    // The value with no combination behind it is still dead.
+    expect(values(product)[1].isDead).toBe('true')
+  })
+
+  it('a FLAT product is always purchasable — outOfStock governs its stock', () => {
+    const flat = buildEcommerceProduct(
+      { id: 'f', name: 'Mug', slug: 'mug', price: 9, currency: 'USD', quantity: 0 },
+      { variantsByProductId: {} }
+    )
+    expect(flat.hasPurchasableVariant).toBe('true')
+    expect(flat.outOfStock).toBe('true')
+  })
+
+  it('always emits hasPurchasableVariant as a STRING (never boolean/undefined)', () => {
+    for (const options of [undefined, { variantsByProductId: null }, { variantsByProductId: {} }]) {
+      const product = buildEcommerceProduct(variantProduct(), options)
+      expect(typeof product.hasPurchasableVariant).toBe('string')
+      expect(['true', 'false']).toContain(product.hasPurchasableVariant)
+    }
+  })
+
+  it('a related product inherits the same known/unknown answer as its parent', () => {
+    const built = buildEcommerceProduct(variantProduct({ related_product_ids: '["p2"]' }), {
+      // Unknown for everybody — the nested build must NOT read this as "none".
+      variantsByProductId: null,
+      relatedProductsById: { p2: variantProduct({ id: 'p2', slug: 'p2' }) },
+    })
+    const related = (built.relatedProducts as Array<Record<string, unknown>>)[0]
+    expect(related.hasPurchasableVariant).toBe('true')
+  })
+})
+
+/**
+ * Runs the EMITTED `transformRecords` against a stub pg client, which is the only
+ * way to prove the wrapper's control flow — the order of the two lookups, and
+ * which ids reach the combinations query — rather than its text.
+ */
+describe('transform wrapper — executed end to end', () => {
+  interface StubQuery {
+    sql: string
+    params: unknown[]
+  }
+
+  const runWrapper = async (
+    records: Array<Record<string, unknown>>,
+    rows: {
+      related?: Array<Record<string, unknown>>
+      variants?: Array<Record<string, unknown>>
+      failVariantsQuery?: boolean
+    }
+  ): Promise<{ out: Array<Record<string, unknown>>; queries: StubQuery[] }> => {
+    const bundle =
+      generateSharedTransformationCode() +
+      '\n' +
+      generateEcommerceProductTransformationCode() +
+      '\n' +
+      getTransformWrapperCode('teleport_products')
+    const transformRecords = new Function(bundle + '\nreturn transformRecords;')() as (
+      r: unknown,
+      getClient: unknown,
+      q: unknown
+    ) => Promise<Array<Record<string, unknown>>>
+
+    const queries: StubQuery[] = []
+    const query = async (
+      sql: string,
+      params: unknown[] = []
+    ): Promise<{ rows: Array<Record<string, unknown>> }> => {
+      queries.push({ sql, params })
+      if (sql.includes('teleport_assets')) {
+        return { rows: [] }
+      }
+      if (sql.includes('teleport_product_variants')) {
+        if (rows.failVariantsQuery) {
+          throw new Error('relation "teleport_product_variants" does not exist')
+        }
+        return { rows: rows.variants || [] }
+      }
+      if (sql.includes('teleport_products')) {
+        return { rows: rows.related || [] }
+      }
+      return { rows: [] }
+    }
+    const getClientFn = () => ({
+      connect: async (): Promise<void> => undefined,
+      end: async (): Promise<void> => undefined,
+      query,
+    })
+
+    const out = await transformRecords(records, getClientFn, {})
+    return { out, queries }
+  }
+
+  const variantQueryOf = (queries: StubQuery[]): StubQuery | undefined =>
+    queries.find((q) => q.sql.includes('teleport_product_variants'))
+
+  it("asks for the RELATED products' combinations in the same batched query", async () => {
+    const { out, queries } = await runWrapper([variantProduct({ related_product_ids: '["p2"]' })], {
+      related: [variantProduct({ id: 'p2', slug: 'p2' })],
+      variants: [
+        { id: 'v-p1', product_id: 'p1', options: { size: 's' }, quantity: 5 },
+        { id: 'v-p2', product_id: 'p2', options: { size: 'xs' }, quantity: 2 },
+      ],
+    })
+    // Both the page's own product AND the related one.
+    expect(variantQueryOf(queries)?.params[0]).toEqual(['p1', 'p2'])
+
+    const related = (out[0].relatedProducts as Array<Record<string, unknown>>)[0]
+    expect(related.hasPurchasableVariant).toBe('true')
+    expect(related.defaultVariantId).toBe('v-p2')
+  })
+
+  it('a FAILED combinations query leaves every product permissive, not unbuyable', async () => {
+    const { out, queries } = await runWrapper([variantProduct()], { failVariantsQuery: true })
+    expect(variantQueryOf(queries)).toBeTruthy()
+    expect(out[0].hasPurchasableVariant).toBe('true')
+    expect(values(out[0]).every((v) => v.isDead === 'false')).toBe(true)
+  })
+
+  it('a query that RAN and returned nothing marks the product unbuyable', async () => {
+    const { out } = await runWrapper([variantProduct()], { variants: [] })
+    expect(out[0].hasPurchasableVariant).toBe('false')
+    expect(values(out[0]).every((v) => v.isDead === 'true')).toBe(true)
+  })
+})
+
+describe('transform wrapper — the batched combinations query', () => {
+  const wrapper = getTransformWrapperCode('teleport_products')
+
+  it('starts the map at NULL so a failed lookup reads as unknown, not as none', () => {
+    expect(wrapper).toContain('var variantsByProductId = null')
+  })
+
+  it('resolves related items BEFORE variants, and asks for their combinations too', () => {
+    // The details page draws each related product as a real card with its own
+    // picker; fetching only the page's own ids left every one of them looking
+    // like a product with no combinations.
+    expect(wrapper.indexOf('relatedProductsById = await')).toBeGreaterThan(-1)
+    expect(wrapper.indexOf('relatedProductsById = await')).toBeLessThan(
+      wrapper.indexOf('getVariantsMap(')
+    )
+    expect(wrapper).toContain('__variantPids.push(__rrow.id)')
+  })
+
+  it('leaves the blog wrapper without any variant enrichment', () => {
+    const blog = getTransformWrapperCode('teleport_blog_posts')
+    expect(blog).not.toContain('getVariantsMap')
+    expect(blog).toContain('relatedPostsById')
+  })
+})

--- a/packages/teleport-plugin-next-data-source/src/transformations/ecommerce-product.ts
+++ b/packages/teleport-plugin-next-data-source/src/transformations/ecommerce-product.ts
@@ -191,6 +191,12 @@ function buildEcommerceProduct(record, options) {
   // transformRecords and passed in via options.variantsByProductId, keyed by
   // product id. The storefront card/details read these to default-select the
   // first in-stock variant, disable dead options, and resolve the chosen id.
+  //
+  // NULL (not {}) means the lookup could not run — the table is missing, or the
+  // query failed. That is "combinations UNKNOWN", which is NOT "this product has
+  // none": a transient DB failure must never turn every variant product in the
+  // catalogue into an unbuyable one. See hasPurchasableVariant below.
+  var variantsResolved = options.variantsByProductId != null
   var variantsByProductId = options.variantsByProductId || {}
   var rawVariants = variantsByProductId[id] || []
   var variants = []
@@ -227,7 +233,12 @@ function buildEcommerceProduct(record, options) {
       assetMap: assetMap,
       currentLanguage: currentLang,
       mainLanguage: mainLang,
-      variantsByProductId: options.variantsByProductId || {},
+      // Passed through UNCOALESCED so a related product inherits the same
+      // known/unknown answer as its parent — \`|| {}\` here would tell the nested
+      // build "the lookup ran and found nothing" and strike out every related
+      // card's picker. The batched query includes the related ids for exactly
+      // this reason (see getTransformWrapperCode).
+      variantsByProductId: options.variantsByProductId,
     }
     for (var rp = 0; rp < relatedProductIds.length; rp++) {
       var relatedId = relatedProductIds[rp]
@@ -312,7 +323,7 @@ function buildEcommerceProduct(record, options) {
   var variantAxisKeys = []
   for (var ak = 0; ak < variantOptions.length; ak++) { variantAxisKeys.push(variantOptions[ak].key) }
   var firstVariant = pickFirstAvailableVariant(variants, variantAxisKeys)
-  var deadValueKeys = computeDeadVariantKeys(variants, variantOptions)
+  var deadValueKeys = computeDeadVariantKeys(variants, variantOptions, variantsResolved)
   for (var ai = 0; ai < variantOptions.length; ai++) {
     var vax = variantOptions[ai]
     for (var vj = 0; vj < vax.values.length; vj++) {
@@ -332,8 +343,31 @@ function buildEcommerceProduct(record, options) {
       vval.showSwatch = vax.type === 'color' && vval.color ? 'true' : 'false'
     }
   }
-  var defaultVariantId = firstVariant && isVariantInStock(firstVariant) ? firstVariant.id : ''
+  // The combination the picker auto-selects on first paint: the first in-stock
+  // one covering every axis. Absent means there is nothing the shopper could add
+  // without choosing — which is what gates the buy button below.
+  var hasInStockCombination = !!(firstVariant && isVariantInStock(firstVariant))
+  var defaultVariantId = hasInStockCombination ? firstVariant.id : ''
   var defaultVariantPrice = firstVariant ? formatVariantPrice(firstVariant.price, price) : ''
+  // Can this product be added to the cart at all, before the shopper touches the
+  // picker? A STRING, same convention as outOfStock/requiresVariantSelection.
+  //
+  //   flat product         -> 'true'  (stock is governed by outOfStock)
+  //   combinations UNKNOWN -> 'true'  (the lookup could not run; a transient DB
+  //                                    failure must never make a whole catalogue
+  //                                    unbuyable — same permissive rule as
+  //                                    dead-marking)
+  //   otherwise            -> whether an in-stock combination covering every axis
+  //                           exists. 'false' therefore covers BOTH "every
+  //                           combination is sold out" AND "the axes have no
+  //                           combinations at all" — to a shopper those are the
+  //                           same thing: there is no size to pick.
+  //
+  // MUST mirror packages/renderer/src/utils/ecommerce-products.ts.
+  var hasPurchasableVariant =
+    (requiresVariantSelection !== 'true' || !variantsResolved || hasInStockCombination)
+      ? 'true'
+      : 'false'
   // Stringified companions: a data-* attr bound to an ARRAY renders
   // '[object Object]', so the picker's on-mount/click workflows read the
   // combinations + axes from these JSON strings via getAttribute.
@@ -386,6 +420,7 @@ function buildEcommerceProduct(record, options) {
     variantsJson: variantsJson,
     defaultVariantId: defaultVariantId,
     defaultVariantPrice: defaultVariantPrice,
+    hasPurchasableVariant: hasPurchasableVariant,
   }
 }
 
@@ -416,11 +451,14 @@ function pickFirstAvailableVariant(variants, axisKeys) {
 }
 // Map of composite "axisKey|valueKey" -> true for every value that appears in
 // NO in-stock combination (rendered as the Unavailable state).
-function computeDeadVariantKeys(variants, axes) {
-  // No combinations attached (flat product, zero-variant product, or editor
-  // preview) -> nothing is dead; every value stays selectable. Dead-marking is
-  // only meaningful relative to combinations that actually exist.
-  if (!Array.isArray(variants) || variants.length === 0) return {}
+//
+// variantsResolved is the whole subtlety: dead-marking is only meaningful
+// against combinations we actually LOOKED UP. When the lookup could not run,
+// nothing is dead — a missing table or a failed query must not grey out every
+// picker in the store. When it DID run, an empty list is a fact, not a gap:
+// every value is unbuyable and renders as Unavailable.
+function computeDeadVariantKeys(variants, axes, variantsResolved) {
+  if (!variantsResolved || !Array.isArray(variants)) return {}
   var alive = {}
   for (var i = 0; i < variants.length; i++) {
     var v = variants[i]
@@ -651,6 +689,10 @@ async function getRelatedProductsMap(getClientFn, records) {
   return map
 }
 
+// Combinations for every product on the page, keyed by product id. Returns NULL
+// when the lookup could not run, which the transform reads as "unknown" and
+// stays permissive with; an empty map means the query ran and this catalogue
+// simply has no combinations.
 async function getVariantsMap(getClientFn, productIds) {
   var map = {}
   if (!Array.isArray(productIds) || productIds.length === 0) return map
@@ -678,7 +720,10 @@ async function getVariantsMap(getClientFn, productIds) {
       }
     }
   } catch (e) {
-    // teleport_product_variants may not exist for a non-variant store.
+    // teleport_product_variants may not exist for a non-variant store, or the
+    // query may have failed. Either way the combinations are UNKNOWN — null
+    // keeps every picker selectable instead of declaring the catalogue unbuyable.
+    map = null
   } finally {
     if (client) {
       try { await client.end() } catch (e) { /* ignore */ }

--- a/packages/teleport-plugin-next-data-source/src/transformations/index.ts
+++ b/packages/teleport-plugin-next-data-source/src/transformations/index.ts
@@ -107,18 +107,38 @@ export const getTransformWrapperCode = (tableName: string): string => {
 
   // Products additionally get their purchasable variant combinations attached in
   // ONE batched query (keyed by product id). Blog posts have no such enrichment.
+  //
+  // ⛔ The map starts as NULL and stays null when the query cannot run. The
+  // transform reads null as "combinations unknown" and keeps every picker
+  // selectable; a `{}` would mean "the lookup ran and this catalogue has none",
+  // which strikes out every value and hides every buy button. A transient DB
+  // failure must not be able to say that.
+  //
+  // Runs AFTER the related-items lookup so the related rows — which the details
+  // page draws as real product cards, each with its own picker — get their
+  // combinations from the SAME query instead of transforming as variant-less.
   const variantEnrichment =
     type === 'ecommerce-product'
       ? `
-  var variantsByProductId = {}
+  var variantsByProductId = null
   try {
     var __variantPids = []
     for (var __i = 0; __i < records.length; __i++) {
       if (records[__i] && records[__i].id != null) __variantPids.push(records[__i].id)
     }
+    if (relatedProductsById) {
+      for (var __rk in relatedProductsById) {
+        if (!Object.prototype.hasOwnProperty.call(relatedProductsById, __rk)) continue
+        // The ROW's own id, not the map key: the key was stringified when the map
+        // was built, and a query parameter array of mixed types is one the driver
+        // cannot type against the product_id column.
+        var __rrow = relatedProductsById[__rk]
+        if (__rrow && __rrow.id != null) __variantPids.push(__rrow.id)
+      }
+    }
     variantsByProductId = await getVariantsMap(getClientFn, __variantPids)
   } catch (e) {
-    // Variant enrichment is best-effort; flat products keep variants: [].
+    // Leaves the map null — "unknown", never "none".
   }`
       : ''
 
@@ -155,7 +175,7 @@ async function transformRecords(records, getClientFn, reqQuery) {
     assetMap = await getAssetMap(getClientFn)
   } catch (e) {
     // Asset resolution is best-effort; continue without it
-  }${variantEnrichment}${relatedEnrichment}
+  }${relatedEnrichment}${variantEnrichment}
   var currentLanguage = (reqQuery && reqQuery.lang) || null
   var mainLanguage = (reqQuery && reqQuery.mainLang) || null
   var options = { assetMap: assetMap, currentLanguage: currentLanguage, mainLanguage: mainLanguage${variantOption}, ${relatedMapVar}: ${relatedMapVar} }

--- a/packages/teleport-plugin-next-workflows/__tests__/cart-clear-db-mirror.test.ts
+++ b/packages/teleport-plugin-next-workflows/__tests__/cart-clear-db-mirror.test.ts
@@ -1,0 +1,45 @@
+import { cartClear } from '../src/nodes/cart/cart-clear'
+
+// Regression: after a cash-on-delivery order the buyer's cart came back.
+//
+// `cart-clear` only emptied `localStorage.workflow_cart`. The database copy
+// (`teleport_cart` / `teleport_cart_items`) stayed active, and
+// `EcommerceProvider` re-hydrates from `/api/cart/load` on any mount where the
+// local cart is empty — so the very next full page load (the post-order
+// redirect, or a plain refresh) restored the cart the shopper had just ordered
+// and wrote it straight back into localStorage.
+
+describe('cart-clear mirrors the empty cart into the database cart', () => {
+  const handlerCode = cartClear.generateHandler()
+
+  it('still clears localStorage first — the DB mirror is best-effort on top', () => {
+    expect(handlerCode).toContain("localStorage.setItem('workflow_cart'")
+    expect(handlerCode).toContain("dispatchEvent(new CustomEvent('teleport:cart-changed'))")
+  })
+
+  it('pushes an empty cart through /api/cart/sync with the guest session id', () => {
+    expect(handlerCode).toContain("'/api/cart/sync'")
+    expect(handlerCode).toContain("localStorage.getItem('workflow_cart_session_id')")
+    expect(handlerCode).toMatch(/items:\s*\[\s*\]/)
+  })
+
+  it('never awaits the sync and never lets it fail the node', () => {
+    // The route only exists for Postgres datasources, so a 404 here is a
+    // normal outcome — it must not surface to the shopper or abort the
+    // workflow (which would strand the order mid-chain).
+    const syncSection = handlerCode.slice(handlerCode.indexOf("'/api/cart/sync'"))
+    expect(syncSection).not.toMatch(/await\s+fetch/)
+    expect(syncSection).toContain('.catch(')
+  })
+
+  it('does NOT mark the cart as ordered — this handler also backs "Clear cart"', () => {
+    // `mark-ordered` is the checkout-only signal and stays owned by
+    // data-create-item. Flipping the status here would mislabel a cart the
+    // shopper simply emptied by hand.
+    expect(handlerCode).not.toContain('mark-ordered')
+  })
+
+  it('stamps the clear so the provider can tell it apart from a first visit', () => {
+    expect(handlerCode).toContain("localStorage.setItem('workflow_cart_cleared_at'")
+  })
+})

--- a/packages/teleport-plugin-next-workflows/__tests__/cron-route-loop-templateparams.test.ts
+++ b/packages/teleport-plugin-next-workflows/__tests__/cron-route-loop-templateparams.test.ts
@@ -4,6 +4,7 @@
 // into its component body — the cron route previously used a naive inline loop
 // that did neither, so a per-cart reminder email would ship raw {{token}} merge
 // fields and its loop body would never run.
+import { generateSharedRuntimeUtilsCode } from '../src/executor-generator'
 import { generateCronAPIRoute } from '../src/api-route-generator'
 
 const TRIGGER_ID = 'cron-1'
@@ -123,12 +124,20 @@ describe('generateCronAPIRoute — loop + templateParams support', () => {
   })
 
   it('merges templateParams into email body + subject', () => {
-    // Both the top-level and loop-body execution paths apply the merge; the
-    // email node lives in the loop body here.
-    expect(route).toContain('utils.applyTemplateParams(bResolved.body, bResolved.templateParams)')
-    expect(route).toContain(
-      'utils.applyTemplateParams(bResolved.subject, bResolved.templateParams)'
-    )
+    // The merge lives in the SHARED runtime's `resolveConfig`, not pasted at
+    // each call site. That is the whole point: `resolveConfig` is the single
+    // function every execution path — main loop, loop body, parallel branch,
+    // error branch, across all four route generators and the client executor —
+    // funnels a node config through. Pasting it per site is what left the main
+    // loop of `generateServerSegmentAPIRoute` (where every ordinary page
+    // workflow's email node runs) without it, shipping literal `{{token}}`s.
+    const runtime = generateSharedRuntimeUtilsCode()
+    expect(runtime).toContain('applyTemplateParams(resolved.body, resolved.templateParams)')
+    expect(runtime).toContain('applyTemplateParams(resolved.subject, resolved.templateParams)')
+    // …and the route reaches it simply by calling resolveConfig.
+    expect(route).toContain('const resolveConfig = utils.resolveConfig')
+    // No stale per-site copy left behind to drift out of sync.
+    expect(route).not.toContain('utils.applyTemplateParams(')
   })
 
   it('bakes the scan + loop + email nodes into the server WORKFLOW_CONFIG', () => {

--- a/packages/teleport-plugin-next-workflows/__tests__/data-create-item-order-notification.test.ts
+++ b/packages/teleport-plugin-next-workflows/__tests__/data-create-item-order-notification.test.ts
@@ -106,3 +106,36 @@ describe('data_create_item — order-notification piggyback payload', () => {
 // cover the contract (which fields are read, where they default,
 // fire-and-forget shape, etc.). The full integration is exercised
 // by the existing end-to-end test in the dist project.
+
+describe('data-create-item stands down when the workflow owns the send', () => {
+  const suppressionHandlerCode = dataCreateItem.generateHandler()
+
+  it('gates the auto-fire on the builder-set suppressOrderNotification flag', () => {
+    // The place-order workflow sets this on its create-order node whenever it
+    // also carries a "Send Order-Notification Email" node. Without the gate
+    // the merchant receives the SAME order twice — once from here with a NULL
+    // order_number (rendered as the raw UUID) and a flat-filled body, once
+    // from the workflow with the real order number and the fully expanded
+    // template.
+    expect(suppressionHandlerCode).toContain('suppressOrderNotification')
+    expect(suppressionHandlerCode).toMatch(/suppressOrderNotification\s*!==\s*true/)
+  })
+
+  it('keeps firing when the flag is absent, so exported projects are unaffected', () => {
+    // `!== true` (not a truthiness check) is what makes "flag missing" mean
+    // "behave exactly as before".
+    expect(suppressionHandlerCode).not.toMatch(/config\.suppressOrderNotification\s*\)/)
+  })
+
+  it('sends both the {{itemsList}} and the array-mapper row keys per item', () => {
+    // One payload feeds the endpoint's own <ul> builder AND a builder email
+    // template's `tq:each` row block, so neither renderer needs to know which
+    // template style the merchant is on.
+    for (const key of ['product_name', 'unit_price', 'line_total', 'image_url']) {
+      expect(suppressionHandlerCode).toContain(key)
+    }
+    expect(suppressionHandlerCode).toMatch(
+      /it\.image \|\| it\.image_url \|\| it\.imageUrl \|\| it\.thumbnail/
+    )
+  })
+})

--- a/packages/teleport-plugin-next-workflows/__tests__/resolve-config-template-params.test.ts
+++ b/packages/teleport-plugin-next-workflows/__tests__/resolve-config-template-params.test.ts
@@ -1,0 +1,174 @@
+import { generateSharedRuntimeUtilsCode } from '../src/executor-generator'
+import { generateServerSegmentAPIRoute } from '../src/api-route-generator'
+
+/**
+ * Regression: every component-bodied transactional email shipped with its
+ * `{{token}}` merge fields unfilled.
+ *
+ * The fill was pasted at individual call sites instead of living in the one
+ * function every path shares. It reached only three of the sixteen sites — the
+ * client executor, and the main + loop-body loops of the cron/webhook route —
+ * so the MAIN loop of `generateServerSegmentAPIRoute`, where every ordinary
+ * page workflow's email node actually executes, never applied it. Delivered
+ * result: literal `{{customerName}}` / `{{orderNumber}}` in the body, the same
+ * in the SUBJECT line, an un-expanded `<!--tq:each products-->` row block, and
+ * `href="{{resetUrl}}"` on the password-reset button — an invalid relative URL
+ * that mail clients drop, so the button had no link at all.
+ *
+ * These tests EXECUTE the emitted runtime rather than grepping it: the defect
+ * was never a missing function, it was a function nobody called.
+ */
+
+type ResolveConfig = (
+  config: Record<string, unknown>,
+  context: Record<string, unknown>
+) => Record<string, unknown>
+
+function loadRuntime(): { resolveConfig: ResolveConfig } {
+  const code = generateSharedRuntimeUtilsCode()
+  const moduleShim = { exports: {} as Record<string, unknown> }
+  // eslint-disable-next-line no-new-func
+  new Function('module', 'exports', 'require', 'process', code)(
+    moduleShim,
+    moduleShim.exports,
+    () => ({}),
+    { env: {} }
+  )
+  const exported = (moduleShim.exports as { resolveConfig?: ResolveConfig }).resolveConfig
+  if (typeof exported !== 'function') {
+    throw new Error('server-runtime does not export resolveConfig')
+  }
+  return { resolveConfig: exported }
+}
+
+const wfCtx = (nodeId: string, path: string[]) => ({
+  type: 'workflowContext',
+  nodeId,
+  path: [nodeId, ...path],
+})
+
+describe('resolveConfig fills component-bodied email templates', () => {
+  const { resolveConfig } = loadRuntime()
+
+  const context = {
+    assemble: {
+      customerName: 'Jane Cooper',
+      orderNumber: 'ORD-42',
+      products: [
+        { product_name: 'Beans', quantity: '2', unit_price: '12.00', currency: 'USD' },
+        { product_name: 'Mug', quantity: '1', unit_price: '15.00', currency: 'USD' },
+      ],
+    },
+    buildRef: { result: 'WDR-7' },
+  }
+
+  const emailConfig = (over: Record<string, unknown> = {}) => ({
+    to: 'jane@example.com',
+    subject: 'New withdrawal request {{requestReference}} for order {{orderNumber}}',
+    body: '<p>Submitted by {{customerName}} for order {{orderNumber}}.</p>',
+    templateParams: [
+      { key: 'customerName', value: wfCtx('assemble', ['customerName']) },
+      { key: 'orderNumber', value: wfCtx('assemble', ['orderNumber']) },
+      { key: 'requestReference', value: wfCtx('buildRef', ['result']) },
+      { key: 'products', value: wfCtx('assemble', ['products']) },
+      { key: 'companyName', value: 'Acme Inc.' },
+    ],
+    ...over,
+  })
+
+  it('fills the BODY from workflow-context-bound params', () => {
+    const resolved = resolveConfig(emailConfig(), context)
+    expect(resolved.body).toBe('<p>Submitted by Jane Cooper for order ORD-42.</p>')
+  })
+
+  it('fills the SUBJECT too — the email title had the same defect', () => {
+    const resolved = resolveConfig(emailConfig(), context)
+    expect(resolved.subject).toBe('New withdrawal request WDR-7 for order ORD-42')
+  })
+
+  it('fills a literal (non-bound) param value', () => {
+    const resolved = resolveConfig(emailConfig({ body: '<p>Sent by {{companyName}}</p>' }), context)
+    expect(resolved.body).toBe('<p>Sent by Acme Inc.</p>')
+  })
+
+  it('expands the array-mapper row block before the flat fill', () => {
+    const resolved = resolveConfig(
+      emailConfig({
+        body: '<div><!--tq:each products--><li>{{quantity}}x {{product_name}} @ {{unit_price}} {{currency}}</li><!--/tq:each--></div>',
+      }),
+      context
+    )
+    expect(resolved.body).toBe(
+      '<div><li>2x Beans @ 12.00 USD</li><li>1x Mug @ 15.00 USD</li></div>'
+    )
+    expect(resolved.body).not.toContain('<!--tq:each')
+  })
+
+  it('produces a REAL href on a token-bound link', () => {
+    // The password-reset button serializes to href="{{resetUrl}}". Unfilled,
+    // that is a relative URL mail clients discard — the reported "the reset
+    // button has no link".
+    const resolved = resolveConfig(
+      {
+        subject: 'Password Reset Request',
+        body: '<a href="{{resetUrl}}">Reset password</a>',
+        templateParams: [{ key: 'resetUrl', value: wfCtx('buildLink', ['resetLink']) }],
+      },
+      { buildLink: { resetLink: 'https://shop.example.com/reset?token=abc' } }
+    )
+    expect(resolved.body).toBe(
+      '<a href="https://shop.example.com/reset?token=abc">Reset password</a>'
+    )
+  })
+
+  it('leaves configs without templateParams untouched', () => {
+    const resolved = resolveConfig({ query: 'SELECT 1', body: 'not {{anything}} special' }, context)
+    expect(resolved.body).toBe('not {{anything}} special')
+  })
+
+  it('does not choke when body/subject are absent or non-string', () => {
+    const resolved = resolveConfig(
+      { templateParams: [{ key: 'a', value: 'b' }], to: ['x@y.z'] },
+      context
+    )
+    expect(resolved.to).toEqual(['x@y.z'])
+  })
+})
+
+describe('the server-segment route reaches the fill', () => {
+  // The route that runs every ordinary page workflow's server nodes. It had no
+  // fill of its own; it must now get one purely by calling resolveConfig.
+  const route = generateServerSegmentAPIRoute(
+    {
+      id: 'server-1',
+      env: 'server',
+      nodeIds: ['n1'],
+      nodes: [
+        {
+          id: 'n1',
+          type: 'email-resend',
+          label: 'Send Withdrawal Confirmation Email',
+          stepNumber: 1,
+          config: {
+            to: 'a@b.c',
+            subject: 'Ref {{requestReference}}',
+            body: '<p>{{customerName}}</p>',
+            templateParams: [{ key: 'customerName', value: 'Jane' }],
+          },
+        },
+      ],
+      edges: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    'Submit Withdrawal'
+  )
+
+  it('routes the node config through the shared resolveConfig', () => {
+    expect(route).toContain('const resolveConfig = utils.resolveConfig')
+    expect(route).toContain('resolveConfig(node.config, context)')
+  })
+
+  it('carries no private copy of the fill that could drift', () => {
+    expect(route).not.toContain('applyTemplateParams')
+  })
+})

--- a/packages/teleport-plugin-next-workflows/src/api-route-generator.ts
+++ b/packages/teleport-plugin-next-workflows/src/api-route-generator.ts
@@ -211,10 +211,6 @@ module.exports = async function handler(req, res) {
             var bNode = bodyNodes[bi];
             var bResolved = resolveConfig(bNode.config, context);
             bResolved.__nodeId = bNode.id;
-            if (bResolved && Array.isArray(bResolved.templateParams)) {
-              if (typeof bResolved.body === 'string') { bResolved.body = utils.applyTemplateParams(bResolved.body, bResolved.templateParams); }
-              if (typeof bResolved.subject === 'string') { bResolved.subject = utils.applyTemplateParams(bResolved.subject, bResolved.templateParams); }
-            }
             if (bNode.type === 'general-if-statement') {
               context[bNode.id] = { result: utils.evaluateCondition(bResolved, context) };
               continue;
@@ -1155,10 +1151,6 @@ const generateNodeExecutionLoop = (
       var __configError = utils.finalizeResolvedConfig(node.type, resolved);
       if (__configError) { throw new Error(__configError); }
       resolved.__nodeId = node.id;
-      if (resolved && Array.isArray(resolved.templateParams)) {
-        if (typeof resolved.body === 'string') { resolved.body = utils.applyTemplateParams(resolved.body, resolved.templateParams); }
-        if (typeof resolved.subject === 'string') { resolved.subject = utils.applyTemplateParams(resolved.subject, resolved.templateParams); }
-      }
 
       if (node.type === 'general-if-statement') {
         var condResult = utils.evaluateCondition(resolved, context);
@@ -1229,10 +1221,6 @@ const generateNodeExecutionLoop = (
             var bNode = bodyNodes[bi];
             var bResolved = resolveConfig(bNode.config, context);
             bResolved.__nodeId = bNode.id;
-            if (bResolved && Array.isArray(bResolved.templateParams)) {
-              if (typeof bResolved.body === 'string') { bResolved.body = utils.applyTemplateParams(bResolved.body, bResolved.templateParams); }
-              if (typeof bResolved.subject === 'string') { bResolved.subject = utils.applyTemplateParams(bResolved.subject, bResolved.templateParams); }
-            }
             if (bNode.type === 'general-if-statement') {
               context[bNode.id] = { result: utils.evaluateCondition(bResolved, context) };
               continue;

--- a/packages/teleport-plugin-next-workflows/src/executor-generator.ts
+++ b/packages/teleport-plugin-next-workflows/src/executor-generator.ts
@@ -501,6 +501,35 @@ function resolveConfig(config, context) {
       resolved[key] = resolveScalarValue(val, context);
     }
   }
+  // Component-bodied email nodes carry their merge values as \`templateParams\`
+  // and their body/subject as \`{{token}}\` templates. Filling them HERE — the one
+  // function every execution path funnels a node config through — is what makes
+  // the fill unmissable.
+  //
+  // It used to be pasted at the individual call sites instead, and it was only
+  // ever pasted at three of the sixteen: the client executor, and the loop-body
+  // + main loops of the cron/webhook route. The MAIN loop of
+  // \`generateServerSegmentAPIRoute\` — which is where every ordinary page
+  // workflow's email node actually executes — never had it, so withdrawal
+  // confirmations, withdrawal owner notifications, review notifications,
+  // order notifications and the password-reset email all shipped with their
+  // tokens verbatim: literal "{{customerName}}" in the body, "{{orderNumber}}"
+  // in the subject, and \`href="{{resetUrl}}"\` on the reset button (an invalid
+  // relative URL, which mail clients drop — so the button had no link at all).
+  // The abandoned-cart reminder was the only one that worked, because its send
+  // node sits inside a loop body AND on a cron route: the two paths that had
+  // the paste.
+  //
+  // Runs after resolution on purpose: \`templateParams[].value\` is itself a
+  // workflow-context ref that the loop above has just resolved.
+  if (Array.isArray(resolved.templateParams)) {
+    if (typeof resolved.body === 'string') {
+      resolved.body = applyTemplateParams(resolved.body, resolved.templateParams);
+    }
+    if (typeof resolved.subject === 'string') {
+      resolved.subject = applyTemplateParams(resolved.subject, resolved.templateParams);
+    }
+  }
   return resolved;
 }
 
@@ -809,17 +838,9 @@ async function executeNodes(nodes, edges, context, nodeHandlers, workflowConfig,
         throw new Error(configError);
       }
 
-      // Component-bodied send-email node: fill {{token}} merge fields in the
-      // serialized template body/subject from the resolved templateParams
-      // (resolveConfig already resolved each param value against context).
-      if (resolvedConfig && Array.isArray(resolvedConfig.templateParams)) {
-        if (typeof resolvedConfig.body === 'string') {
-          resolvedConfig.body = applyTemplateParams(resolvedConfig.body, resolvedConfig.templateParams);
-        }
-        if (typeof resolvedConfig.subject === 'string') {
-          resolvedConfig.subject = applyTemplateParams(resolvedConfig.subject, resolvedConfig.templateParams);
-        }
-      }
+      // NOTE: the component-bodied email fill used to live here. It now runs
+      // inside resolveConfig itself, so every execution path gets it exactly
+      // once — see the comment there.
 
       if (node.type === 'general-if-statement') {
         const condResult = evaluateCondition(resolvedConfig, context);

--- a/packages/teleport-plugin-next-workflows/src/nodes/cart/cart-clear.ts
+++ b/packages/teleport-plugin-next-workflows/src/nodes/cart/cart-clear.ts
@@ -3,7 +3,47 @@ import { NodeHandlerGenerator, handlerToString } from '../types'
 async function cart_clear() {
   try {
     localStorage.setItem('workflow_cart', JSON.stringify([]))
+
+    // Mirror the empty cart into the DATABASE cart as well.
+    //
+    // `EcommerceProvider` re-hydrates from `/api/cart/load` whenever
+    // localStorage is empty on mount (see `cartDbMountEffect` in
+    // ecommerce-context-generator). Clearing only localStorage therefore
+    // leaves the server copy intact, and the very next full page load
+    // (checkout -> order-details, or any hard reload) resurrects the cart the
+    // buyer just ordered. The provider's own debounced persist would push the
+    // empty state eventually, but it fires 300ms later — after a post-order
+    // redirect has already navigated away.
+    //
+    // `/api/cart/sync` is the same endpoint the provider persists through: it
+    // resolves identity server-side (NextAuth token for signed-in users, the
+    // client `sessionId` for guests) and transactionally replaces the active
+    // cart's items — so an empty payload empties the stored cart for BOTH
+    // identities. Deliberately does NOT flip the cart's status to ordered:
+    // this handler also backs the storefront's plain "Clear cart" button, and
+    // that cart was never ordered. Checkout owns that signal (see the
+    // data-create-item handler).
+    //
+    // Fire-and-forget and fully guarded: the route only exists for Postgres
+    // datasources (see `isPostgresCartDataSource`), so a 404 here is a normal,
+    // expected outcome that must never surface to the shopper or abort the
+    // workflow.
     if (typeof window !== 'undefined') {
+      try {
+        // Marks this empty cart as DELIBERATE. `EcommerceProvider`'s DB
+        // reconcile effect reads the stamp (`wasCartJustCleared`) so it can
+        // tell "just checked out" apart from "first visit, restore my cart"
+        // and skip re-hydrating while the sync below is still in flight.
+        localStorage.setItem('workflow_cart_cleared_at', String(Date.now()))
+        const sessionId = localStorage.getItem('workflow_cart_session_id') || null
+        fetch('/api/cart/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items: [], sessionId }),
+        }).catch(function () {})
+      } catch (_dbErr) {
+        /* localStorage or fetch unavailable — local clear already succeeded */
+      }
       window.dispatchEvent(new CustomEvent('teleport:cart-changed'))
     }
     return { success: true }

--- a/packages/teleport-plugin-next-workflows/src/nodes/data/data-create-item.ts
+++ b/packages/teleport-plugin-next-workflows/src/nodes/data/data-create-item.ts
@@ -92,7 +92,19 @@ async function data_create_item(config: any, context: any) {
     // requiring the AI to remember to add an explicit email-send
     // workflow node. The endpoint is a no-op when notifications
     // are not configured, so it is safe to call unconditionally.
-    if (typeof tableName === 'string' && tableName === 'teleport_orders' && data && data.item) {
+    //
+    // ...unless the workflow that owns this INSERT already carries its own
+    // "Send Order-Notification Email" node. The builder sets
+    // `suppressOrderNotification: true` on this node in that case, because
+    // otherwise the merchant receives the SAME order twice: once from here
+    // and once from the workflow. The workflow node is the canonical sender —
+    // it runs AFTER `order_number` has been backfilled (this INSERT still
+    // sees NULL and falls back to the raw UUID) and it renders the merchant's
+    // builder template through the full filler, list blocks included. Absent
+    // flag ⇒ previous behaviour, so already-exported projects are unaffected.
+    const notifiesOnInsert = config.suppressOrderNotification !== true
+    const isOrderInsert = typeof tableName === 'string' && tableName === 'teleport_orders'
+    if (isOrderInsert && data && data.item && notifiesOnInsert) {
       const item: any = data.item
 
       // Best-effort: mark the buyer's active database cart as ordered. This is
@@ -136,19 +148,38 @@ async function data_create_item(config: any, context: any) {
           }
         }
       }
-      // Normalise items into the shape the email endpoint can render
-      // (name, quantity, unit_price, total_price). Defensive about
-      // every field — different cart sources spell them differently.
+      // Normalise items into the shape the email endpoint can render.
+      // Defensive about every field — different cart sources spell them
+      // differently.
+      //
+      // Each row carries BOTH spellings on purpose:
+      //  - camelCase (`name`/`unitPrice`/`totalPrice`) for the endpoint's own
+      //    `{{itemsList}}` <ul> builder, and
+      //  - the snake_case array-mapper row keys (`product_name`, `quantity`,
+      //    `unit_price`, `line_total`, `currency`, `image_url`) that a builder
+      //    email template's `<!--tq:each items-->` row block binds to.
+      // One payload therefore feeds both renderers without either having to
+      // know which template style the merchant is on.
+      const orderCurrency = item.currency || ''
       const normalisedItems = cartItems.map(function (it: any) {
         const unitPrice = Number(it.unitPrice != null ? it.unitPrice : it.price) || 0
         const quantity = parseInt(it.quantity, 10)
         const qty = isFinite(quantity) && quantity > 0 ? quantity : 1
+        const lineTotal = Math.round(unitPrice * qty * 100) / 100
+        const displayName = it.name || it.productName || it.product_name || 'Item'
+        const imageUrl = it.image || it.image_url || it.imageUrl || it.thumbnail || ''
         return {
-          name: it.name || it.productName || it.product_name || 'Item',
+          name: displayName,
           sku: it.sku || it.SKU || '',
           quantity: qty,
           unitPrice: Math.round(unitPrice * 100) / 100,
-          totalPrice: Math.round(unitPrice * qty * 100) / 100,
+          totalPrice: lineTotal,
+          image: imageUrl,
+          product_name: displayName,
+          unit_price: unitPrice.toFixed(2),
+          line_total: lineTotal.toFixed(2),
+          currency: orderCurrency,
+          image_url: imageUrl,
         }
       })
 

--- a/packages/teleport-project-generator-next/__tests__/cart-persistence-provider.test.ts
+++ b/packages/teleport-project-generator-next/__tests__/cart-persistence-provider.test.ts
@@ -61,3 +61,35 @@ describe('EcommerceProvider — database cart layer', () => {
     expect(withFlagOff).not.toContain('persistCartToDb')
   })
 })
+
+describe('EcommerceProvider — deliberate-clear guard', () => {
+  const clearGuardSettings = { cashOnDelivery: true } as any
+  const withDb = generateEcommerceContextFileContent(clearGuardSettings, undefined, 'ds-1', true)
+
+  it('skips the DB re-hydration when the cart was just cleared on purpose', () => {
+    // Without this, the post-order redirect mounts the provider with an empty
+    // localStorage cart, the /api/cart/load round trip beats the in-flight
+    // empty sync, and the buyer's confirmation page shows a full cart again.
+    expect(withDb).toContain('function wasCartJustCleared()')
+    expect(withDb).toContain('if (wasCartJustCleared()) return')
+    expect(withDb).toContain("const CART_CLEARED_AT_KEY = 'workflow_cart_cleared_at'")
+  })
+
+  it('expires the stamp so a later visit can still restore a cross-device cart', () => {
+    expect(withDb).toContain('CART_CLEARED_GRACE_MS')
+    expect(withDb).toContain('localStorage.removeItem(CART_CLEARED_AT_KEY)')
+  })
+
+  it('checks the stamp only AFTER a non-empty local cart has won', () => {
+    const localWinsAt = withDb.indexOf('persistCartToDb(local)')
+    const guardAt = withDb.indexOf('if (wasCartJustCleared()) return')
+    expect(localWinsAt).toBeGreaterThan(-1)
+    expect(guardAt).toBeGreaterThan(localWinsAt)
+  })
+
+  it('emits none of the guard when the DB cart layer is off', () => {
+    const noDb = generateEcommerceContextFileContent(clearGuardSettings, undefined, 'ds-1', false)
+    expect(noDb).not.toContain('wasCartJustCleared')
+    expect(noDb).not.toContain('workflow_cart_cleared_at')
+  })
+})

--- a/packages/teleport-project-generator-next/__tests__/email-sender-and-low-stock-alert.test.ts
+++ b/packages/teleport-project-generator-next/__tests__/email-sender-and-low-stock-alert.test.ts
@@ -373,3 +373,86 @@ function extractFn(haystack: string, decl: string): string {
   }
   throw new Error('unbalanced braces in ' + decl)
 }
+
+describe('generateEmailSenderModule — list-block expansion (executed, not grepped)', () => {
+  // The expander's regexes are written inside a TS template literal, so every
+  // backslash is doubled in the source. A string-contains assertion cannot tell
+  // a correctly-escaped `\\s` from a broken one — the only honest check is to
+  // run the emitted function.
+  const loadModule = () => {
+    const code = generateEmailSenderModule(baseSettings())
+    const moduleShim = { exports: {} as Record<string, (...fnArgs: any[]) => any> }
+    // The provider dispatch requires('resend' | '@sendgrid/mail' | 'pg'), which
+    // we don't want to pull in — stub require for anything but the shape the
+    // functions under test touch.
+    // eslint-disable-next-line no-new-func
+    new Function('module', 'require', 'process', code)(moduleShim, () => ({}), { env: {} })
+    return moduleShim.exports
+  }
+
+  it('repeats the row body once per item and fills the per-row tokens', () => {
+    const { expandListBlocks } = loadModule()
+    const out = expandListBlocks(
+      '<div><!--tq:each items--><li>{{quantity}}x {{product_name}}</li><!--/tq:each--></div>',
+      {
+        items: [
+          { quantity: 2, product_name: 'Beans' },
+          { quantity: 1, product_name: 'Mug' },
+        ],
+      }
+    )
+    expect(out).toBe('<div><li>2x Beans</li><li>1x Mug</li></div>')
+  })
+
+  it('tolerates whitespace-padded tokens and dotted/dashed field names', () => {
+    const { expandListBlocks } = loadModule()
+    const out = expandListBlocks('<!--tq:each items-->[{{ image_url }}]<!--/tq:each-->', {
+      items: [{ image_url: 'https://cdn.x/a.png' }],
+    })
+    expect(out).toBe('[https://cdn.x/a.png]')
+  })
+
+  it('HTML-escapes row values so a product name cannot break out of the markup', () => {
+    const { expandListBlocks } = loadModule()
+    const out = expandListBlocks('<!--tq:each items--><li>{{name}}</li><!--/tq:each-->', {
+      items: [{ name: '<script>alert(1)</script> & "quoted"' }],
+    })
+    expect(out).toBe('<li>&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;quoted&quot;</li>')
+  })
+
+  it('leaves a token the row does not carry for the page-level fill to resolve', () => {
+    const { expandListBlocks, renderTemplate } = loadModule()
+    const expanded = expandListBlocks(
+      '<!--tq:each items-->{{name}} by {{companyName}}<!--/tq:each-->',
+      {
+        items: [{ name: 'Beans' }],
+      }
+    )
+    expect(expanded).toBe('Beans by {{companyName}}')
+    expect(renderTemplate(expanded, { companyName: 'Acme' })).toBe('Beans by Acme')
+  })
+
+  it('drops the block entirely when the list is missing or not an array', () => {
+    const { expandListBlocks } = loadModule()
+    const tpl = 'a<!--tq:each items-->{{name}}<!--/tq:each-->b'
+    expect(expandListBlocks(tpl, {})).toBe('ab')
+    expect(expandListBlocks(tpl, { items: null })).toBe('ab')
+    expect(expandListBlocks(tpl, { items: [] })).toBe('ab')
+  })
+
+  it('is a pass-through for a template with no block, and for non-strings', () => {
+    const { expandListBlocks } = loadModule()
+    expect(expandListBlocks('<p>{{orderNumber}}</p>', { items: [{}] })).toBe(
+      '<p>{{orderNumber}}</p>'
+    )
+    expect(expandListBlocks(null, { items: [{}] })).toBe(null)
+  })
+
+  it('hasOwnItemList recognises BOTH ways a template renders its own list', () => {
+    const { hasOwnItemList } = loadModule()
+    expect(hasOwnItemList('<!--tq:each items-->x<!--/tq:each-->')).toBe(true)
+    expect(hasOwnItemList('<p>{{itemsList}}</p>')).toBe(true)
+    expect(hasOwnItemList('<p>Items: {{itemsCount}}</p>')).toBe(false)
+    expect(hasOwnItemList('')).toBe(false)
+  })
+})

--- a/packages/teleport-project-generator-next/__tests__/order-notification-template-rendering.test.ts
+++ b/packages/teleport-project-generator-next/__tests__/order-notification-template-rendering.test.ts
@@ -125,9 +125,18 @@ describe('generateOrderNotificationApiRoute — itemsList rendering + auto-injec
   })
 
   it('builds an <ul> when the items array is non-empty', () => {
-    expect(route).toContain('<ul style="margin:8px 0;padding-left:20px;">')
+    // `list-style:none` because each row leads with a product thumbnail — a
+    // bullet next to a 44px image reads as a rendering glitch.
+    expect(route).toContain('<ul style="margin:8px 0;padding-left:20px;list-style:none;">')
     // Each line item shows quantity × unit price = total
     expect(route).toMatch(/qty\s*\+\s*' × '\s*\+\s*unit/)
+  })
+
+  it('leads each auto-built line item with the product image when one is known', () => {
+    expect(route).toContain('it.image || it.image_url || it.imageUrl || it.thumbnail')
+    expect(route).toContain('object-fit:cover')
+    // No URL ⇒ no <img> at all: an empty src renders as a broken-image icon.
+    expect(route).toMatch(/imgFrag\s*=\s*imgUrl\s*\n?\s*\?/)
   })
 
   it('formats every monetary field to 2 decimals via formatMoney', () => {
@@ -135,12 +144,69 @@ describe('generateOrderNotificationApiRoute — itemsList rendering + auto-injec
     expect(route).toContain('v.toFixed(2)')
   })
 
-  it('auto-injects an "Items ordered" block when the body lacks {{itemsList}} but has items', () => {
+  it('auto-injects an "Items ordered" block when the body renders no list of its own', () => {
     expect(route).toContain('Items ordered:')
-    expect(route).toContain("indexOf('{{itemsList}}') < 0")
+    // The guard covers BOTH ways a template can render its own list: the
+    // legacy {{itemsList}} blob and a builder array-mapper's tq:each block.
+    expect(route).toContain('sender.hasOwnItemList(')
     // The injection prefers to land just after the line that mentions
     // "Items:" so the merchant's existing layout is preserved.
     expect(route).toContain("html.indexOf('Items:')")
+  })
+
+  it('expands a builder template list block BEFORE the flat token fill', () => {
+    expect(route).toContain('sender.expandListBlocks(')
+    const expandAt = route.indexOf('sender.expandListBlocks(')
+    const renderBodyAt = route.indexOf('sender.renderTemplate(expandedBody')
+    expect(expandAt).toBeGreaterThan(-1)
+    expect(renderBodyAt).toBeGreaterThan(expandAt)
+  })
+
+  it('falls back to the order’s persisted lines when the caller sends no items', () => {
+    // The payment webhooks know an orderId but have no cart to forward.
+    expect(route).toContain('await loadOrderItems(orderId)')
+  })
+
+  it('emits a real order-lines loader only for Postgres datasources', () => {
+    const pg = generateOrderNotificationApiRoute(baseSettings(), 'teleport', {
+      connectionString: 'postgres://x',
+    })
+    expect(pg).toContain('FROM teleport_order_items oi')
+    expect(pg).toContain("require('pg')")
+
+    // A non-Postgres (or unknown) datasource keeps the endpoint SQL-free; the
+    // loader degrades to "no items" rather than emitting `$N` placeholders a
+    // MySQL/Turso driver could never bind.
+    const nonPg = generateOrderNotificationApiRoute(baseSettings(), 'mysql', { host: 'x' })
+    expect(nonPg).not.toContain('teleport_order_items')
+    expect(nonPg).toContain('async function loadOrderItems()')
+
+    // Omitting the datasource entirely (the pre-existing 1-arg call shape)
+    // must stay valid and behave like the non-Postgres case.
+    expect(route).not.toContain('teleport_order_items')
+    expect(route).toContain('async function loadOrderItems()')
+  })
+
+  it('emits syntactically valid JavaScript in every datasource shape', () => {
+    // The route is assembled from nested template literals; a stray backtick
+    // or `${` in a comment silently truncates the emitted file. Parsing it
+    // here is the only way to catch that before a project build does.
+    const parse = (source: string) => {
+      // `export default` is only legal inside a module — swap it for a plain
+      // declaration so `new Function` can parse the body.
+      const body = source.replace('export default async function handler', 'async function handler')
+      // eslint-disable-next-line no-new-func
+      return () => new Function(body)
+    }
+    expect(parse(route)).not.toThrow()
+    expect(
+      parse(
+        generateOrderNotificationApiRoute(baseSettings(), 'teleport', {
+          connectionString: 'postgres://x',
+        })
+      )
+    ).not.toThrow()
+    expect(parse(generateOrderNotificationApiRoute(baseSettings({ provider: null })))).not.toThrow()
   })
 
   it('renders shipping address with <br> separators (multi-line in email clients)', () => {

--- a/packages/teleport-project-generator-next/src/ecommerce/cart-api-routes-generator.ts
+++ b/packages/teleport-project-generator-next/src/ecommerce/cart-api-routes-generator.ts
@@ -1,16 +1,12 @@
 import { generateCommonJsSessionTokenResolverCode } from '@teleporthq/teleport-plugin-next-workflows'
-import { generateDbImport } from './ecommerce-api-routes-generator'
+import { generateDbImport, isPostgresCartDataSource } from './ecommerce-api-routes-generator'
 
-// Datasource types whose `generateDbImport` emits a node-postgres `Pool`. The
-// cart route is Postgres-specific (transactions via `db.connect()`, `$N`
-// placeholders, `FOR UPDATE`, `RETURNING`), so it only generates for these —
-// exactly the same set the orders/checkout SQL already assumes. For anything
-// else (mysql/supabase/turso/none) the route is skipped and the cart stays
-// pure-localStorage, unchanged from before.
-const POSTGRES_DATA_SOURCE_TYPES = ['teleport', 'postgresql', 'cockroachdb', 'amazon-redshift']
-
-export const isPostgresCartDataSource = (dataSourceType: string | null): boolean =>
-  !!dataSourceType && POSTGRES_DATA_SOURCE_TYPES.indexOf(dataSourceType) !== -1
+// Re-exported from `ecommerce-api-routes-generator`, which owns the
+// datasource-shape knowledge (`generateDbImport` lives there and the
+// order-notification route needs the same predicate). Kept exported from this
+// module too so the existing importers — and the cart-persistence tests —
+// don't have to move.
+export { isPostgresCartDataSource }
 
 /**
  * Generates `pages/api/cart/[op].js` — the database-backed cart endpoint.

--- a/packages/teleport-project-generator-next/src/ecommerce/ecommerce-api-routes-generator.ts
+++ b/packages/teleport-project-generator-next/src/ecommerce/ecommerce-api-routes-generator.ts
@@ -624,7 +624,11 @@ export const generateDeliveryPriceApiRoute = (settings: UIDLEcommerceSettings): 
 `
 }
 
-export const generateOrderNotificationApiRoute = (settings: UIDLEcommerceSettings): string => {
+export const generateOrderNotificationApiRoute = (
+  settings: UIDLEcommerceSettings,
+  dataSourceType: string | null = null,
+  dataSourceConfig: Record<string, unknown> | null = null
+): string => {
   const config = settings.orderNotificationConfig
   if (!config || !config.provider) {
     return `export default async function handler(req, res) {
@@ -640,12 +644,75 @@ export const generateOrderNotificationApiRoute = (settings: UIDLEcommerceSetting
   const bodyTemplate = config.body || 'A new order ({{orderNumber}}) was placed.'
   const notificationEmails = JSON.stringify(config.notificationEmails || [])
 
+  // The order-line fallback below is Postgres-only: it uses `$N` placeholders
+  // and joins the teleport_* order tables, exactly like the checkout / cart
+  // routes. For any other datasource the loader is omitted and the endpoint
+  // behaves as before (it renders whatever `items` the caller passed).
+  const dbImport = isPostgresCartDataSource(dataSourceType)
+    ? generateDbImport(dataSourceType, dataSourceConfig)
+    : null
+
+  // Loads the order's persisted lines when the CALLER couldn't supply them.
+  // The payment webhooks (Stripe `checkout.session.completed`, PayPal
+  // `PAYMENT.CAPTURE.COMPLETED`) only know the provider's session/capture
+  // payload — they have an orderId but no cart — so without this every
+  // online-payment notification reached the merchant with an empty item list.
+  // `teleport_order_items` is the authoritative snapshot written by checkout,
+  // and the image is resolved variant-override-first, matching the
+  // order-details page. Never throws: a failure degrades to "no items", which
+  // is exactly the pre-existing behaviour.
+  const orderItemsLoader = dbImport
+    ? `
+const ORDER_ITEMS_QUERY =
+  "SELECT oi.product_name, oi.variant_label, oi.quantity, oi.unit_price, oi.total_price, oi.currency, " +
+  "COALESCE(NULLIF(v.image_url, ''), NULLIF(p.image_url, ''), '') AS image_url " +
+  'FROM teleport_order_items oi ' +
+  'LEFT JOIN teleport_products p ON p.id = oi.product_id ' +
+  'LEFT JOIN teleport_product_variants v ON v.id::text = oi.variant_id ' +
+  'WHERE oi.order_id = $1 ORDER BY oi.created_at ASC'
+
+async function loadOrderItems(orderId) {
+  if (!orderId) return []
+  try {
+    const result = await db.query(ORDER_ITEMS_QUERY, [orderId])
+    const rows = (result && result.rows) || []
+    return rows.map(function (row) {
+      const qty = Number(row.quantity) || 1
+      const unit = Number(row.unit_price) || 0
+      const total = row.total_price != null ? Number(row.total_price) : unit * qty
+      const label = row.variant_label ? row.product_name + ' (' + row.variant_label + ')' : row.product_name
+      return {
+        name: label || 'Item',
+        sku: '',
+        quantity: qty,
+        unitPrice: unit,
+        totalPrice: total,
+        image: row.image_url || '',
+        product_name: label || 'Item',
+        unit_price: unit.toFixed(2),
+        line_total: total.toFixed(2),
+        currency: row.currency || '',
+        image_url: row.image_url || '',
+      }
+    })
+  } catch (err) {
+    console.error('[order-notification] could not load order items: ' + (err && err.message ? err.message : String(err)))
+    return []
+  }
+}
+`
+    : `
+async function loadOrderItems() {
+  return []
+}
+`
+
   // Token resolution + subject/body rendering happens here at request
   // time; the actual dispatch is delegated to the shared
   // utils/ecommerce/email-sender module, which encapsulates the
   // provider switch + logging + error normalisation.
   return `var sender = require('../../../utils/ecommerce/email-sender')
-
+${dbImport ? `${dbImport}\n` : ''}${orderItemsLoader}
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -678,7 +745,7 @@ export default async function handler(req, res) {
     // orderId is provided we fall back to that so the customer-
     // facing "Order ID" line still renders.
     const resolvedOrderNumber = orderNumber || orderId || ''
-    const itemsArr = Array.isArray(items) ? items : []
+    const itemsArr = Array.isArray(items) && items.length > 0 ? items : await loadOrderItems(orderId)
     const itemsCount = itemsArr.reduce(function(sum, it) {
       var q = Number(it && it.quantity) || 1
       return sum + q
@@ -708,7 +775,7 @@ export default async function handler(req, res) {
     }
     var itemsListHtml = ''
     if (itemsArr.length > 0) {
-      var parts = ['<ul style="margin:8px 0;padding-left:20px;">']
+      var parts = ['<ul style="margin:8px 0;padding-left:20px;list-style:none;">']
       for (var ii = 0; ii < itemsArr.length; ii++) {
         var it = itemsArr[ii] || {}
         var name = htmlEscape(it.name || it.productName || it.product_name || 'Item')
@@ -717,7 +784,15 @@ export default async function handler(req, res) {
         var qty = Number(it.quantity) || 1
         var unit = formatMoney(it.unitPrice != null ? it.unitPrice : it.price)
         var total = formatMoney(it.totalPrice != null ? it.totalPrice : (Number(it.unitPrice != null ? it.unitPrice : it.price) || 0) * qty)
-        parts.push('<li><strong>' + name + '</strong>' + skuFrag +
+        // Thumbnail of the product's main image, matching the order-details
+        // page (and the builder template's item rows). Only emitted when the
+        // caller actually supplied a URL — an <img src=""> renders as a broken
+        // image icon in most desktop clients.
+        var imgUrl = it.image || it.image_url || it.imageUrl || it.thumbnail || ''
+        var imgFrag = imgUrl
+          ? '<img src="' + htmlEscape(imgUrl) + '" alt="" width="44" height="44" style="width:44px;height:44px;object-fit:cover;border-radius:6px;vertical-align:middle;margin-right:10px;" />'
+          : ''
+        parts.push('<li style="margin:0 0 8px;">' + imgFrag + '<strong>' + name + '</strong>' + skuFrag +
           ' — ' + qty + ' × ' + unit +
           ' = <strong>' + total + '</strong></li>')
       }
@@ -751,18 +826,28 @@ export default async function handler(req, res) {
     }
 
     const subject = sender.renderTemplate(${JSON.stringify(subjectTemplate)}, tokenPayload)
-    let html = sender.renderTemplate(${JSON.stringify(bodyTemplate)}, tokenPayload)
-
-    // Auto-inject the items list when the merchant's template doesn't
-    // reference {{itemsList}}. Without this, merchants whose template
-    // only has {{itemsCount}} see just a number ("Items: 3") with no
-    // line-item detail — useless for fulfillment. Insertion point:
-    // right after the line that mentions itemsCount if we can find it,
-    // otherwise before the closing </p> sequence at the end. Skipped
-    // when there are no items.
-    if (itemsListHtml && ${JSON.stringify(
+    // Expand the builder template's <!--tq:each items--> row block FIRST —
+    // renderTemplate blanks every token it doesn't know, so an un-expanded row
+    // block would render once with all per-item values empty. A raw-HTML
+    // template has no such block and this is a pass-through.
+    const expandedBody = sender.expandListBlocks(${JSON.stringify(
       bodyTemplate
-    )}.indexOf('{{itemsList}}') < 0 && html.length > 0) {
+    )}, { items: itemsArr })
+    let html = sender.renderTemplate(expandedBody, tokenPayload)
+
+    // Auto-inject the items list when the merchant's template renders no item
+    // list of its own. Without this, merchants whose template only has
+    // {{itemsCount}} see just a number ("Items: 3") with no line-item detail —
+    // useless for fulfillment. Insertion point: right after the line that
+    // mentions itemsCount if we can find it, otherwise appended at the end.
+    // Skipped when there are no items, and skipped when the template already
+    // renders them itself (via {{itemsList}} or a tq:each row block) —
+    // injecting there produced a SECOND, unstyled copy of the list, landing
+    // wherever the first "</p>" after "Items:" happened to be (in the builder
+    // template, inside the shipping-address block).
+    if (itemsListHtml && !sender.hasOwnItemList(${JSON.stringify(
+      bodyTemplate
+    )}) && html.length > 0) {
       const itemsHeader = '<p><strong>Items ordered:</strong></p>' + itemsListHtml
       const itemsCountAnchor = html.indexOf('Items:')
       if (itemsCountAnchor !== -1) {
@@ -939,7 +1024,16 @@ export default async function handler(req, res) {
     }
 
     const subject = sender.renderTemplate(${JSON.stringify(subjectTemplate)}, tokenPayload)
-    const html = sender.renderTemplate(${JSON.stringify(bodyTemplate)}, tokenPayload)
+    // Same ordering contract as the order-notification route: expand a builder
+    // template's <!--tq:each products--> row block before the flat token
+    // fill, or every per-product value in it renders empty. The scan rows
+    // ({ id, name, stock, sku }) already match the row keys the builder's
+    // low-stock array-mapper binds to. Pass-through for a raw-HTML body, which
+    // renders the list through the {{productsList}} blob instead.
+    const expandedBody = sender.expandListBlocks(${JSON.stringify(
+      bodyTemplate
+    )}, { products: productsArr })
+    const html = sender.renderTemplate(expandedBody, tokenPayload)
 
     const result = await sender.sendNotificationEmail(notificationEmails, subject, html)
     return res.status(200).json(result)
@@ -950,6 +1044,17 @@ export default async function handler(req, res) {
 }
 `
 }
+
+// Datasource types whose `generateDbImport` emits a node-postgres `Pool`. Every
+// SQL-emitting e-commerce route (checkout, cart, the order-line loader in the
+// order-notification route) is Postgres-specific — `$N` placeholders,
+// transactions via `db.connect()`, `FOR UPDATE`, `RETURNING` — so they only
+// generate for these. For anything else (mysql/supabase/turso/none) the caller
+// skips the SQL-backed behaviour and degrades to the pure-client path.
+const POSTGRES_DATA_SOURCE_TYPES = ['teleport', 'postgresql', 'cockroachdb', 'amazon-redshift']
+
+export const isPostgresCartDataSource = (dataSourceType: string | null): boolean =>
+  !!dataSourceType && POSTGRES_DATA_SOURCE_TYPES.indexOf(dataSourceType) !== -1
 
 export function generateDbImport(
   dataSourceType: string | null,

--- a/packages/teleport-project-generator-next/src/ecommerce/ecommerce-context-generator.ts
+++ b/packages/teleport-project-generator-next/src/ecommerce/ecommerce-context-generator.ts
@@ -188,6 +188,34 @@ export const generateEcommerceContextFileContent = (
   const cartDbHelpers = cartDbEnabled
     ? `const CART_SESSION_KEY = 'workflow_cart_session_id'
 
+// Timestamp written by the workflow cart-clear handler when the cart is
+// emptied on purpose (order placed, or the shopper hit "Clear cart"). Read by
+// the DB reconcile effect below so a deliberate clear is never mistaken for a
+// first-visit empty cart worth restoring. Short-lived: it only has to outlive
+// the in-flight cart-sync round trip, and it must NOT suppress a legitimate
+// cross-device restore on the shopper's next visit.
+const CART_CLEARED_AT_KEY = 'workflow_cart_cleared_at'
+const CART_CLEARED_GRACE_MS = 60000
+
+function wasCartJustCleared() {
+  if (typeof window === 'undefined') return false
+  try {
+    const raw = localStorage.getItem(CART_CLEARED_AT_KEY)
+    if (!raw) return false
+    const age = Date.now() - Number(raw)
+    // A clock change (or a corrupted value) must never wedge the cart into a
+    // permanently un-restorable state, so anything outside the grace window —
+    // in either direction — is treated as stale and dropped.
+    const fresh = isFinite(age) && age >= 0 && age < CART_CLEARED_GRACE_MS
+    if (!fresh) {
+      localStorage.removeItem(CART_CLEARED_AT_KEY)
+    }
+    return fresh
+  } catch {
+    return false
+  }
+}
+
 // Stable per-browser guest id, used to scope a cart for users who aren't
 // logged in. Logged-in carts are keyed server-side by the auth token instead.
 function getOrCreateSessionId() {
@@ -228,7 +256,8 @@ function persistCartToDb(items) {
     : ''
 
   // In-provider reconcile effect: on mount, local cart wins (and is backed up
-  // to the DB); if local is empty, hydrate from the DB.
+  // to the DB); if local is empty, hydrate from the DB — unless the cart was
+  // just deliberately emptied (see CART_CLEARED_AT_KEY below).
   const cartDbMountEffect = cartDbEnabled
     ? `
   const cartDbInitRef = useRef(false)
@@ -241,6 +270,15 @@ function persistCartToDb(items) {
       persistCartToDb(local)
       return
     }
+    // "Empty local cart" is ambiguous: it means either "first visit on this
+    // device, restore my cart" or "I just checked out / cleared the cart".
+    // The workflow \`cart-clear\` handler stamps the second case and also pushes
+    // the empty cart to /api/cart/sync — but that push is fire-and-forget, so a
+    // post-order redirect can mount this provider before it lands. Without the
+    // stamp we would then re-hydrate the cart the shopper just ordered, write
+    // it back to localStorage, and the buyer lands on the confirmation page
+    // with a full cart. The window only has to outlive the in-flight sync.
+    if (wasCartJustCleared()) return
     try {
       fetch('/api/cart/load', {
         method: 'POST',

--- a/packages/teleport-project-generator-next/src/ecommerce/email-sender-generator.ts
+++ b/packages/teleport-project-generator-next/src/ecommerce/email-sender-generator.ts
@@ -35,6 +35,56 @@ const RENDER_TEMPLATE_FN = `function renderTemplate(template, payload) {
   })
 }`
 
+// Expand the repeating-row blocks a BUILDER email template serializes an
+// array-mapper into: `<!--tq:each KEY-->…{{field}}…<!--/tq:each-->`. The inner
+// body is repeated once per row of `lists[KEY]`, with the row's `{{field}}`
+// tokens replaced by the (HTML-escaped) item value. Tokens the row doesn't
+// carry are left verbatim so the page-level `renderTemplate` below can still
+// resolve them (e.g. `{{companyName}}` inside a row).
+//
+// MUST run BEFORE `renderTemplate`: that one blanks every unknown token, so a
+// row template reaching it un-expanded renders exactly once with every
+// per-item value empty — which is precisely the "Items ordered section is
+// blank" defect this exists to prevent.
+//
+// PAIRED EDIT: identical logic lives in the workflow runtime
+// (`executor-generator.ts` `expandListBlocks`), in teleport-gui
+// (`order-side-effects-helper.ts` `EXPAND_LIST_BLOCKS_JS`) and in
+// teleport-services-worker (`adapters/email/_bridge.ts`). Keep in sync.
+const EXPAND_LIST_BLOCKS_FN = `function expandListBlocks(template, lists) {
+  if (typeof template !== 'string' || template.indexOf('<!--tq:each') === -1) return template
+  function escRow(v) {
+    return String(v == null ? '' : v)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+  }
+  return template.replace(/<!--tq:each\\s+([\\w.-]+)\\s*-->([\\s\\S]*?)<!--\\/tq:each-->/g, function(_m, key, body) {
+    var rows = lists && lists[key]
+    if (!Array.isArray(rows)) return ''
+    var out = ''
+    for (var r = 0; r < rows.length; r++) {
+      var row = rows[r] || {}
+      out += body.replace(/\\{\\{\\s*([\\w.-]+)\\s*\\}\\}/g, function(mm, field) {
+        return (Object.prototype.hasOwnProperty.call(row, field) && row[field] != null)
+          ? escRow(row[field])
+          : mm
+      })
+    }
+    return out
+  })
+}`
+
+// True when a merchant template renders its own item list — either as a
+// builder array-mapper block or via the legacy `{{itemsList}}` blob. The
+// endpoints use this to skip appending a second, auto-generated list.
+const HAS_OWN_ITEM_LIST_FN = `function hasOwnItemList(template) {
+  if (!template) return false
+  var t = String(template)
+  return t.indexOf('<!--tq:each') !== -1 || t.indexOf('{{itemsList}}') !== -1
+}`
+
 // Strip every HTML tag for the plain-text fallback. Mail clients that
 // can't render HTML (and most spam-score heuristics) need a parallel
 // text body — this is the cheapest way to derive one from the HTML
@@ -263,6 +313,10 @@ ${providerDispatch}
 
 ${RENDER_TEMPLATE_FN}
 
+${EXPAND_LIST_BLOCKS_FN}
+
+${HAS_OWN_ITEM_LIST_FN}
+
 ${HTML_TO_TEXT_FN}
 
 ${senderFn}
@@ -270,6 +324,8 @@ ${senderFn}
 module.exports = {
   sendNotificationEmail: sendNotificationEmail,
   renderTemplate: renderTemplate,
+  expandListBlocks: expandListBlocks,
+  hasOwnItemList: hasOwnItemList,
 }
 `
 }

--- a/packages/teleport-project-generator-next/src/ecommerce/project-plugin.ts
+++ b/packages/teleport-project-generator-next/src/ecommerce/project-plugin.ts
@@ -249,7 +249,10 @@ export class NextEcommerceProjectPlugin implements ProjectPlugin {
           {
             name: 'order-notification',
             fileType: FileType.JS,
-            content: generateOrderNotificationApiRoute(settings),
+            // The datasource is passed so the route can load the order's
+            // persisted lines when a caller (the Stripe / PayPal webhooks)
+            // knows the orderId but has no cart to send.
+            content: generateOrderNotificationApiRoute(settings, dataSourceType, dataSourceConfig),
           },
         ],
       })


### PR DESCRIPTION
## What this fixes

Four independent storefront defects found while auditing a generated e-commerce project. They ship together because three of them meet in the order-notification path.

---

### 1. Emails shipped with literal `{{token}}` text

**Symptom:** withdrawal confirmations, withdrawal owner notifications, review notifications, order notifications and the password-reset email all arrived with their merge fields unfilled — a literal `{{customerName}}` in the body, `{{orderNumber}}` in the subject, and `href="{{resetUrl}}"` on the reset button (an invalid relative URL, which mail clients drop, so the button had no link at all).

**Cause:** the `templateParams` fill was pasted at individual call sites rather than living in one place, and it had only ever been pasted at 3 of the 16. The main loop of `generateServerSegmentAPIRoute` — where every ordinary page workflow's email node actually executes — never had it. The abandoned-cart reminder was the only email that worked, because its send node sits inside a loop body *and* on a cron route: the two paths that happened to have the paste.

**Fix:** moved the fill into `resolveConfig` itself (`executor-generator.ts`), the one function every execution path funnels a node config through, and deleted the three copies from `api-route-generator.ts`. Runs after resolution on purpose — `templateParams[].value` is itself a workflow-context ref.

### 2. Builder email templates rendered an empty "Items ordered" section

The builder serialises an array-mapper into a `<!--tq:each items-->…{{field}}…<!--/tq:each-->` row block. `renderTemplate` blanks every token it doesn't know, so an un-expanded block rendered exactly once with every per-item value empty.

- Added `expandListBlocks` + `hasOwnItemList` to the shared `utils/ecommerce/email-sender` module, and run the expansion **before** the flat token fill in both the order-notification and low-stock routes.
- Stopped the auto-injected `{{itemsList}}` fallback from firing when the template already renders its own list. It previously produced a **second, unstyled copy** of the list, landing wherever the first `</p>` after `"Items:"` happened to be — in the builder template, inside the shipping-address block.
- Line items now lead with the product thumbnail (only when a URL is actually known — an `<img src="">` renders as a broken-image icon in most desktop clients).
- `data-create-item` now emits **both** key spellings per row (camelCase for the endpoint's own `<ul>` builder, snake_case for the builder template's row block), so one payload feeds both renderers.

**Empty item lists on online payments:** the Stripe (`checkout.session.completed`) and PayPal (`PAYMENT.CAPTURE.COMPLETED`) webhooks only know the provider's payload — they have an `orderId` but no cart — so every online-payment notification reached the merchant with no line items. The order-notification route now takes the datasource and falls back to loading the order's persisted lines from `teleport_order_items` (image resolved variant-override-first, matching the order-details page). Postgres-only; other datasources get a stub loader and behave exactly as before. Never throws — a failure degrades to "no items", the pre-existing behaviour.

**Duplicate merchant emails:** when the place-order workflow carries its own "Send Order-Notification Email" node, the builder now sets `suppressOrderNotification: true` on the create-order node, so the merchant stops receiving the same order twice. The workflow node is the canonical sender — it runs *after* `order_number` is backfilled (the INSERT still sees `NULL` and falls back to the raw UUID) and renders the merchant's template through the full filler. Gated on `!== true`, so already-exported projects are unaffected.

### 3. The cart came back after checkout

**Symptom:** the buyer places an order, gets redirected to the confirmation page, and their cart is full again.

**Cause:** `cart-clear` only cleared `localStorage`. `EcommerceProvider` re-hydrates from `/api/cart/load` whenever localStorage is empty on mount, so the next full page load resurrected the cart that was just ordered. The provider's own debounced persist would have pushed the empty state eventually, but it fires 300ms later — after the post-order redirect has already navigated away.

**Fix:** `cart-clear` now also mirrors the empty cart through `/api/cart/sync` (the same endpoint the provider persists through — it resolves identity server-side, so this empties the stored cart for both the NextAuth and guest-session identities), and stamps `workflow_cart_cleared_at`. The provider's reconcile effect reads that stamp and skips re-hydration inside a 60s grace window, which is all it takes to outlive the in-flight sync. The stamp expires — and is dropped if the clock moved or the value is corrupt — so a legitimate cross-device restore on the next visit still works.

Deliberately does **not** flip the cart's status to `ordered`: this handler also backs the plain "Clear cart" button, and that cart was never ordered. Checkout owns that signal. The sync is fire-and-forget and fully guarded — the route only exists for Postgres datasources, so a 404 is a normal outcome that must never surface to the shopper.

### 4. A failed variant lookup made the whole catalogue unbuyable

`variantsByProductId` started as `{}`, and the `catch` around the batched query left it that way. `{}` means "the lookup ran and this catalogue has no combinations" — which strikes out every value in every picker and hides every buy button. A missing `teleport_product_variants` table or one transient DB failure could therefore take the entire store offline.

- The map now starts as `null` and stays null when the query can't run. `null` = **unknown** → stay permissive; `{}` = **none** → an empty list is a fact, and every value correctly renders as Unavailable.
- Related products are passed the map **uncoalesced**, so a related card inherits the same known/unknown answer as its parent instead of being told "the lookup ran and found nothing".
- The variant enrichment now runs **after** the related-items lookup and includes the related rows' ids in the same batched query — the details page draws related items as real product cards with their own pickers, and they were transforming as variant-less. (Uses each row's own `id`, not the stringified map key, so the driver can type the parameter array against `product_id`.)
- New `hasPurchasableVariant` output (a string, matching the `outOfStock` / `requiresVariantSelection` convention) gates the buy button: `'true'` for flat products and for the unknown case; otherwise whether an in-stock combination covering every axis exists. Mirrors `packages/renderer/src/utils/ecommerce-products.ts`.

---

## Refactors carried along

- `isPostgresCartDataSource` moved to `ecommerce-api-routes-generator.ts`, which owns the datasource-shape knowledge (`generateDbImport` lives there and the order-notification route now needs the same predicate). Still re-exported from `cart-api-routes-generator.ts` so no importer had to move.

## Tests

3 new suites, 3 extended, ~35 new cases. All 1416 tests across the three touched packages pass; lint and `manypkg check` are clean.

- `ecommerce-product-variant-availability.test.ts` — the full unknown / none / all-sold-out / partially-in-stock matrix, plus the wrapper executed end to end against a stubbed client to prove a failed query stays permissive and a query that *ran* and returned nothing does not.
- `resolve-config-template-params.test.ts` — the fill itself, and that the server-segment route reaches it and carries no private copy that could drift.
- `cart-clear-db-mirror.test.ts` — the sync payload, the fire-and-forget shape, that localStorage is still cleared first, and that the cart is *not* marked ordered.
- The email-sender list-block tests **execute** the emitted function rather than grepping it: its regexes are written inside a TS template literal where every backslash is doubled, and a string-contains assertion cannot tell a correct `\\s` from a broken one.

## Paired edits in other repos

`expandListBlocks` is duplicated by design across the workflow runtime, **teleport-gui** (`order-side-effects-helper.ts` → `EXPAND_LIST_BLOCKS_JS`) and **teleport-services-worker** (`adapters/email/_bridge.ts`). Those copies need to stay in sync. The `suppressOrderNotification` flag also needs the corresponding builder-side change in teleport-gui to actually take effect — without it this MR is a no-op for that defect, not a regression.
