### PR TITLE
import path collision fixes

### DIFF
--- a/packages/teleport-plugin-next-data-source/src/cache/ast.ts
+++ b/packages/teleport-plugin-next-data-source/src/cache/ast.ts
@@ -1,5 +1,6 @@
 import * as types from '@babel/types'
 import { UIDLDependency } from '@teleporthq/teleport-types'
+import { GenericUtils } from '@teleporthq/teleport-shared'
 import { ResolvedDataSourceCache } from './types'
 
 /** Identifiers the emitted page imports from `utils/tq-cache/client`. */
@@ -29,8 +30,7 @@ export const registerCacheClientImports = (
   dependencies: Record<string, UIDLDependency>,
   folderPath: string[] | undefined
 ): void => {
-  const depth = (folderPath ? folderPath.length : 0) + 1
-  const path = `${'../'.repeat(depth)}utils/tq-cache/client`
+  const path = `${GenericUtils.generatePageToRootPrefix({ folderPath })}utils/tq-cache/client`
 
   CACHE_CLIENT_IMPORTS.forEach((identifier) => {
     if (!dependencies[identifier]) {

--- a/packages/teleport-plugin-next-data-source/src/pagination-plugin.ts
+++ b/packages/teleport-plugin-next-data-source/src/pagination-plugin.ts
@@ -6,7 +6,7 @@ import {
 } from '@teleporthq/teleport-types'
 import * as types from '@babel/types'
 import { parseExpression } from '@babel/parser'
-import { ASTStatementOrder, StringUtils } from '@teleporthq/teleport-shared'
+import { ASTStatementOrder, GenericUtils, StringUtils } from '@teleporthq/teleport-shared'
 import { ASTUtils, URLQueryWriter, URLSearchParamSync } from '@teleporthq/teleport-plugin-common'
 import { generateSafeFileName } from './utils'
 import { generateDataSourceFetcherWithCore } from './data-source-fetchers'
@@ -3597,8 +3597,7 @@ function updateGetStaticProps(
 
         // Add import dependency for the fetcher
         if (!dependencies[fetcherImportName]) {
-          const depth = (folderPath ? folderPath.length : 0) + 1
-          const relativePrefix = '../'.repeat(depth)
+          const relativePrefix = GenericUtils.generatePageToRootPrefix({ folderPath })
           dependencies[fetcherImportName] = {
             type: 'local',
             path: `${relativePrefix}utils/data-sources/${fileName}`,
@@ -3815,8 +3814,7 @@ function updateGetStaticProps(
 
         // Add import dependency for the fetcher
         if (!dependencies[fetcherImportName]) {
-          const depth = (folderPath ? folderPath.length : 0) + 1
-          const relativePrefix = '../'.repeat(depth)
+          const relativePrefix = GenericUtils.generatePageToRootPrefix({ folderPath })
           dependencies[fetcherImportName] = {
             type: 'local',
             path: `${relativePrefix}utils/data-sources/${fileName}`,

--- a/packages/teleport-plugin-next-data-source/src/utils.ts
+++ b/packages/teleport-plugin-next-data-source/src/utils.ts
@@ -10,7 +10,7 @@ import {
 } from '@teleporthq/teleport-types'
 import * as types from '@babel/types'
 import { ASTUtils } from '@teleporthq/teleport-plugin-common'
-import { StringUtils } from '@teleporthq/teleport-shared'
+import { GenericUtils, StringUtils } from '@teleporthq/teleport-shared'
 import { generateDataSourceFetcherWithCore } from './data-source-fetchers'
 import type { EcommerceProductTransformOptions } from './transformations'
 import { DATA_SOURCE_ISR_REVALIDATE_SECONDS } from './isr'
@@ -1253,13 +1253,11 @@ export const extractDataSourceIntoGetStaticProps = (
 
     // Add dependency for the fetcher
     const fetcherImportName = StringUtils.dashCaseToCamelCase(fileName)
-    // Calculate the correct relative path based on page folder depth.
-    // folderPath contains subfolders within pages/ (e.g. ['admin'] for pages/admin/X.js).
-    // We add 1 for the pages/ directory itself.
-    // Pages at pages/X.js (folderPath=[]) need '../' (1 level up)
-    // Pages at pages/admin/X.js (folderPath=['admin']) need '../../' (2 levels up)
-    const depth = (folderPath ? folderPath.length : 0) + 1
-    const relativePrefix = '../'.repeat(depth)
+    // Relative path from the page back to the project root. `folderPath` holds
+    // the subfolders WITHIN pages/ (e.g. ['admin'] for pages/admin/X.js), so
+    // the pages/ folder itself has to be counted too — which is exactly what
+    // the shared helper does (see `generatePageDependenciesPrefix`).
+    const relativePrefix = GenericUtils.generatePageToRootPrefix({ folderPath })
     dependencies[fetcherImportName] = {
       type: 'local',
       path: `${relativePrefix}utils/data-sources/${fileName}`,

--- a/packages/teleport-plugin-next-inline-fetch/__tests__/page-folder-name-collision.test.ts
+++ b/packages/teleport-plugin-next-inline-fetch/__tests__/page-folder-name-collision.test.ts
@@ -1,0 +1,92 @@
+import * as types from '@babel/types'
+import { ComponentStructure } from '@teleporthq/teleport-types'
+import { createNextPagesInlineFetchPlugin } from '../src/index'
+
+/**
+ * Same coordinate-system defect as the static-props/static-paths guards: a
+ * cms-list whose resource is static enough to be hoisted into getStaticProps
+ * imports the resource file straight into the page, so a page folder named
+ * after the project's `resources/` folder produced an import that resolved
+ * inside `pages/`.
+ */
+
+const RESOURCE_ID = 'fetch-content-items'
+const RESOURCE_NAME = 'fetch_content_items'
+const NODE_KEY = 'content-items-list'
+
+const makeStructure = (params: {
+  folderPath: string[]
+  resourcesPath?: string[]
+  pagesPath?: string[]
+}): ComponentStructure => {
+  const { folderPath, resourcesPath = ['resources'], pagesPath } = params
+
+  const jsxNode = types.jsxElement(
+    types.jsxOpeningElement(types.jsxIdentifier('DataProvider'), [], false),
+    types.jsxClosingElement(types.jsxIdentifier('DataProvider')),
+    [],
+    false
+  )
+
+  return {
+    uidl: {
+      name: 'CustomResources',
+      node: {
+        type: 'cms-list',
+        content: {
+          key: NODE_KEY,
+          renderPropIdentifier: 'contentItems',
+          valuePath: [],
+          resource: { id: RESOURCE_ID, params: {} },
+          nodes: { success: { type: 'element', content: { elementType: 'container' } } },
+        },
+      },
+      outputOptions: { folderPath, fileName: '[id]' },
+    },
+    chunks: [
+      {
+        name: 'jsx-component',
+        meta: { nodesLookup: { [NODE_KEY]: jsxNode } },
+      },
+    ],
+    dependencies: {},
+    options: {
+      ...(pagesPath && { pagesPath }),
+      extractedResources: {},
+      resources: {
+        items: { [RESOURCE_ID]: { id: RESOURCE_ID, name: RESOURCE_NAME, params: {} } },
+        path: resourcesPath,
+      },
+    },
+  } as unknown as ComponentStructure
+}
+
+describe('teleport-plugin-next-inline-fetch: hoisted resource import path', () => {
+  const plugin = createNextPagesInlineFetchPlugin()
+
+  it('reaches the project resources folder from a page whose folder is named "resources"', async () => {
+    const structure = await plugin(makeStructure({ folderPath: ['resources'] }))
+
+    expect(structure.dependencies.fetchContentItemsResource.path).toBe(
+      `../../resources/${RESOURCE_NAME}`
+    )
+  })
+
+  it('keeps working for a page in a non-colliding subfolder', async () => {
+    const structure = await plugin(makeStructure({ folderPath: ['blog'] }))
+
+    expect(structure.dependencies.fetchContentItemsResource.path).toBe(
+      `../../resources/${RESOURCE_NAME}`
+    )
+  })
+
+  it('honours a pages root that is not the project root child', async () => {
+    const structure = await plugin(
+      makeStructure({ folderPath: ['resources'], pagesPath: ['src', 'pages'] })
+    )
+
+    expect(structure.dependencies.fetchContentItemsResource.path).toBe(
+      `../../../resources/${RESOURCE_NAME}`
+    )
+  })
+})

--- a/packages/teleport-plugin-next-inline-fetch/src/index.ts
+++ b/packages/teleport-plugin-next-inline-fetch/src/index.ts
@@ -9,7 +9,6 @@ import { StringUtils, UIDLUtils, GenericUtils } from '@teleporthq/teleport-share
 import * as types from '@babel/types'
 import { ASTUtils } from '@teleporthq/teleport-plugin-common'
 import { extractResourceIntoNextAPIFolder } from './utils'
-import { join } from 'path'
 
 /*
   When defining a cms-item or cms-list in the UIDL, the user can specify a resource associated with the node.
@@ -93,10 +92,11 @@ export const createNextPagesInlineFetchPlugin: ComponentPluginFactory<{}> = () =
           )
           dependencies[resourceName] = {
             type: 'local',
-            path: GenericUtils.localRelativePath(
-              join(...uidl.outputOptions.folderPath, uidl.outputOptions.fileName),
-              join(...resources.path, StringUtils.camelCaseToDashCase(usedResource.name))
-            ),
+            path: `${GenericUtils.generatePageDependenciesPrefix({
+              toPath: resources.path,
+              folderPath: uidl.outputOptions.folderPath,
+              pagesPath: options.pagesPath,
+            })}${StringUtils.camelCaseToDashCase(usedResource.name)}`,
           }
         }
 

--- a/packages/teleport-plugin-next-static-paths/__tests__/page-folder-name-collision.test.ts
+++ b/packages/teleport-plugin-next-static-paths/__tests__/page-folder-name-collision.test.ts
@@ -1,0 +1,75 @@
+import { ComponentStructure } from '@teleporthq/teleport-types'
+import { createStaticPathsPlugin } from '../src/index'
+
+/**
+ * Regression guard for the `pages/resources/[id].js` build break — the
+ * getStaticPaths half of it:
+ *
+ *   Module not found: Can't resolve '../fetch_content_items_paths'
+ *
+ * See the sibling test in teleport-plugin-next-static-props for the full story.
+ */
+
+const RESOURCE_ID = 'fetch-content-item-paths'
+const RESOURCE_NAME = 'fetch_content_items_paths'
+
+const makeStructure = (params: {
+  folderPath: string[]
+  resourcesPath?: string[]
+  pagesPath?: string[]
+}): ComponentStructure => {
+  const { folderPath, resourcesPath = ['resources'], pagesPath } = params
+  return {
+    uidl: {
+      name: 'CustomResources',
+      node: { type: 'element', content: { elementType: 'container' } },
+      outputOptions: {
+        folderPath,
+        fileName: '[id]',
+        initialPathsData: {
+          exposeAs: { name: 'id', valuePath: [], itemValuePath: ['id'] },
+          resource: { id: RESOURCE_ID, params: {} },
+        },
+      },
+    },
+    chunks: [{ name: 'jsx-component' }],
+    dependencies: {},
+    options: {
+      ...(pagesPath && { pagesPath }),
+      resources: {
+        items: { [RESOURCE_ID]: { id: RESOURCE_ID, name: RESOURCE_NAME } },
+        path: resourcesPath,
+      },
+    },
+  } as unknown as ComponentStructure
+}
+
+describe('teleport-plugin-next-static-paths: resource import path', () => {
+  const plugin = createStaticPathsPlugin()
+
+  it('reaches the project resources folder from a page whose folder is named "resources"', async () => {
+    const structure = await plugin(makeStructure({ folderPath: ['resources'] }))
+
+    expect(structure.dependencies.fetchContentItemsPathsResource.path).toBe(
+      `../../resources/${RESOURCE_NAME}`
+    )
+  })
+
+  it('keeps working for a page in a non-colliding subfolder', async () => {
+    const structure = await plugin(makeStructure({ folderPath: ['blog'] }))
+
+    expect(structure.dependencies.fetchContentItemsPathsResource.path).toBe(
+      `../../resources/${RESOURCE_NAME}`
+    )
+  })
+
+  it('honours a pages root that is not the project root child', async () => {
+    const structure = await plugin(
+      makeStructure({ folderPath: ['resources'], pagesPath: ['src', 'pages'] })
+    )
+
+    expect(structure.dependencies.fetchContentItemsPathsResource.path).toBe(
+      `../../../resources/${RESOURCE_NAME}`
+    )
+  })
+})

--- a/packages/teleport-plugin-next-static-paths/src/index.ts
+++ b/packages/teleport-plugin-next-static-paths/src/index.ts
@@ -7,7 +7,6 @@ import {
   TeleportError,
   UIDLLocalResource,
 } from '@teleporthq/teleport-types'
-import { join } from 'path'
 import { StringUtils, GenericUtils } from '@teleporthq/teleport-shared'
 import { RouteUtils } from '@teleporthq/teleport-plugin-common'
 import { generateInitialPathsAST } from './utils'
@@ -137,10 +136,11 @@ export const createStaticPathsPlugin: ComponentPluginFactory<StaticPropsPluginCo
 
       dependencies[resourceImportName] = {
         type: 'local',
-        path: GenericUtils.localRelativePath(
-          join(...uidl.outputOptions.folderPath, uidl.outputOptions.fileName),
-          join(...resources.path, StringUtils.camelCaseToDashCase(usedResource.name))
-        ),
+        path: `${GenericUtils.generatePageDependenciesPrefix({
+          toPath: resources.path,
+          folderPath: uidl.outputOptions.folderPath,
+          pagesPath: options.pagesPath,
+        })}${StringUtils.camelCaseToDashCase(usedResource.name)}`,
       }
     }
 

--- a/packages/teleport-plugin-next-static-props/__tests__/page-folder-name-collision.test.ts
+++ b/packages/teleport-plugin-next-static-props/__tests__/page-folder-name-collision.test.ts
@@ -1,0 +1,96 @@
+import { ComponentStructure } from '@teleporthq/teleport-types'
+import { createStaticPropsPlugin } from '../src/index'
+
+/**
+ * Regression guard for the `pages/resources/[id].js` build break:
+ *
+ *   Module not found: Can't resolve '../fetch_content_items_detail'
+ *
+ * `outputOptions.folderPath` is relative to the PAGES ROOT while
+ * `resources.path` is relative to the PROJECT ROOT, so resolving one against
+ * the other cancelled the `resources` segment they only appeared to share and
+ * the import pointed inside `pages/`. Every page whose folder is named after a
+ * project-root folder hits it — and only those, which is why it went unnoticed.
+ */
+
+const RESOURCE_ID = 'fetch-content-item'
+const RESOURCE_NAME = 'fetch_content_items_detail'
+
+const makeStructure = (params: {
+  folderPath: string[]
+  resourcesPath?: string[]
+  pagesPath?: string[]
+}): ComponentStructure => {
+  const { folderPath, resourcesPath = ['resources'], pagesPath } = params
+  return {
+    uidl: {
+      name: 'CustomResources',
+      node: { type: 'element', content: { elementType: 'container' } },
+      outputOptions: {
+        folderPath,
+        fileName: '[id]',
+        initialPropsData: {
+          exposeAs: { name: 'contentItem', valuePath: [] },
+          resource: { id: RESOURCE_ID, params: {} },
+        },
+      },
+    },
+    chunks: [],
+    dependencies: {},
+    options: {
+      ...(pagesPath && { pagesPath }),
+      resources: {
+        items: { [RESOURCE_ID]: { id: RESOURCE_ID, name: RESOURCE_NAME } },
+        path: resourcesPath,
+      },
+    },
+  } as unknown as ComponentStructure
+}
+
+describe('teleport-plugin-next-static-props: resource import path', () => {
+  const plugin = createStaticPropsPlugin()
+
+  it('reaches the project resources folder from a page whose folder is named "resources"', async () => {
+    const structure = await plugin(makeStructure({ folderPath: ['resources'] }))
+
+    expect(structure.dependencies.fetchContentItemsDetailResource.path).toBe(
+      `../../resources/${RESOURCE_NAME}`
+    )
+  })
+
+  it('keeps working for a page in a non-colliding subfolder', async () => {
+    const structure = await plugin(makeStructure({ folderPath: ['blog'] }))
+
+    expect(structure.dependencies.fetchContentItemsDetailResource.path).toBe(
+      `../../resources/${RESOURCE_NAME}`
+    )
+  })
+
+  it('keeps working for a page at the pages root', async () => {
+    const structure = await plugin(makeStructure({ folderPath: [] }))
+
+    expect(structure.dependencies.fetchContentItemsDetailResource.path).toBe(
+      `../resources/${RESOURCE_NAME}`
+    )
+  })
+
+  it('does not collapse a multi-segment resources folder either', async () => {
+    const structure = await plugin(
+      makeStructure({ folderPath: ['utils'], resourcesPath: ['utils', 'data-sources'] })
+    )
+
+    expect(structure.dependencies.fetchContentItemsDetailResource.path).toBe(
+      `../../utils/data-sources/${RESOURCE_NAME}`
+    )
+  })
+
+  it('honours a pages root that is not the project root child', async () => {
+    const structure = await plugin(
+      makeStructure({ folderPath: ['resources'], pagesPath: ['src', 'pages'] })
+    )
+
+    expect(structure.dependencies.fetchContentItemsDetailResource.path).toBe(
+      `../../../resources/${RESOURCE_NAME}`
+    )
+  })
+})

--- a/packages/teleport-plugin-next-static-props/src/index.ts
+++ b/packages/teleport-plugin-next-static-props/src/index.ts
@@ -8,7 +8,6 @@ import {
 import { StringUtils, GenericUtils } from '@teleporthq/teleport-shared'
 import { RouteUtils } from '@teleporthq/teleport-plugin-common'
 import { generateInitialPropsAST } from './utils'
-import { join } from 'path'
 
 interface StaticPropsPluginConfig {
   componentChunkName?: string
@@ -64,10 +63,11 @@ export const createStaticPropsPlugin: ComponentPluginFactory<StaticPropsPluginCo
 
       dependencies[resourceImportName] = {
         type: 'local',
-        path: GenericUtils.localRelativePath(
-          join(...uidl.outputOptions.folderPath, uidl.outputOptions.fileName),
-          join(...resources.path, StringUtils.camelCaseToDashCase(usedResource.name))
-        ),
+        path: `${GenericUtils.generatePageDependenciesPrefix({
+          toPath: resources.path,
+          folderPath: uidl.outputOptions.folderPath,
+          pagesPath: options.pagesPath,
+        })}${StringUtils.camelCaseToDashCase(usedResource.name)}`,
       }
     }
 

--- a/packages/teleport-plugin-next-workflows/src/workflow-component-plugin.ts
+++ b/packages/teleport-plugin-next-workflows/src/workflow-component-plugin.ts
@@ -12,7 +12,7 @@ import {
   UIDLCustomWorkflowNode,
 } from '@teleporthq/teleport-types'
 import * as types from '@babel/types'
-import { JSIdentifiers, StringUtils } from '@teleporthq/teleport-shared'
+import { GenericUtils, JSIdentifiers, StringUtils } from '@teleporthq/teleport-shared'
 import {
   splitIntoSegments,
   resolveNodeExecutionEnv,
@@ -633,8 +633,10 @@ export const createNextWorkflowPlugin: ComponentPluginFactory<WorkflowPluginConf
         }
       }
 
-      const folderDepth = (uidl.outputOptions?.folderPath || []).length
-      const pathPrefix = '../'.repeat(1 + folderDepth)
+      const pathPrefix = GenericUtils.generatePageToRootPrefix({
+        folderPath: uidl.outputOptions?.folderPath,
+        pagesPath: options.pagesPath,
+      })
 
       dependencies.workflowRuntime = {
         type: 'local',

--- a/packages/teleport-project-generator-next/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-next/__tests__/end2end/index.ts
@@ -48,10 +48,11 @@ describe('React Next Project Generator', () => {
   it('runs without crashing and adding external dependencies', async () => {
     const outputFolder = await generator.generateProject(uidlSampleWithDependencies, template)
 
-    const pages = outputFolder.subFolders[1]
+    const pages = outputFolder.subFolders.find((folder) => folder.name === 'pages')
+    const indexPage = pages?.files.find((file) => file.name === 'index')
 
-    expect(pages.files[0].content).toContain(`import Script from 'dangerous-html/react'`)
-    expect(pages.files[0].content).toContain(`Page 1<Modal></Modal>`)
+    expect(indexPage?.content).toContain(`import Script from 'dangerous-html/react'`)
+    expect(indexPage?.content).toContain(`Page 1<Modal></Modal>`)
   })
 
   it('runs without crashing', async () => {
@@ -62,12 +63,13 @@ describe('React Next Project Generator', () => {
     expect(outputFolder.name).toBe(template.name)
     expect(outputFolder.files[0].name).toBe('package')
 
-    const components = outputFolder.subFolders[0]
-    const pages = outputFolder.subFolders[1]
+    const components = outputFolder.subFolders.find((folder) => folder.name === 'components')
+    const pages = outputFolder.subFolders.find((folder) => folder.name === 'pages')
+    const fileNames = (folder?: GeneratedFolder) => (folder?.files || []).map((file) => file.name)
 
-    expect(components.files[0].name).toBe('one-component')
-    expect(pages.files[0].name).toBe('index')
-    expect(pages.files[1].name).toBe('about')
+    expect(fileNames(components)).toContain('one-component')
+    expect(fileNames(pages)).toContain('index')
+    expect(fileNames(pages)).toContain('about')
   })
 
   it('runs without crashing and adds import of style sheet in _app.js', async () => {

--- a/packages/teleport-project-generator-next/src/partial.ts
+++ b/packages/teleport-project-generator-next/src/partial.ts
@@ -82,6 +82,7 @@ export interface NextPartialGeneratorOptions {
   projectStyleSet?: GeneratorOptions['projectStyleSet']
   projectComponents?: Record<string, ComponentUIDL>
   projectRouteDefinition?: GeneratorOptions['projectRouteDefinition']
+  pagesPath?: GeneratorOptions['pagesPath']
   internationalization?: GeneratorOptions['internationalization']
   dataSources?: GeneratorOptions['dataSources']
   forms?: GeneratorOptions['forms']
@@ -584,6 +585,7 @@ export const useGlobalContext = () => {
       ...(this.sharedOptions.projectRouteDefinition && {
         projectRouteDefinition: this.sharedOptions.projectRouteDefinition,
       }),
+      ...(this.sharedOptions.pagesPath && { pagesPath: this.sharedOptions.pagesPath }),
       ...(this.sharedOptions.internationalization && {
         internationalization: this.sharedOptions.internationalization,
       }),

--- a/packages/teleport-project-generator-next/src/split-utils.ts
+++ b/packages/teleport-project-generator-next/src/split-utils.ts
@@ -124,6 +124,10 @@ export const splitProjectUIDL = (
   // --- Build shared options ---
   const sharedOptions: NextPartialGeneratorOptions = {
     projectRouteDefinition: routeDefinition,
+    // Page folder paths in `outputOptions.folderPath` are relative to this
+    // folder — page plugins need it to reach project-root folders. Mirrors the
+    // full project generator (see `GenericUtils.generatePageDependenciesPrefix`).
+    pagesPath,
     projectComponents: components,
     ...(designLanguage && { designLanguage }),
     ...(Object.keys(styleSetDefinitions).length > 0 && {

--- a/packages/teleport-project-generator-next/src/state-data-source-plugin.ts
+++ b/packages/teleport-project-generator-next/src/state-data-source-plugin.ts
@@ -9,7 +9,7 @@ import {
   UIDLStateDataSourceBinding,
   UIDLFilterConfigEntry,
 } from '@teleporthq/teleport-types'
-import { StringUtils } from '@teleporthq/teleport-shared'
+import { GenericUtils, StringUtils } from '@teleporthq/teleport-shared'
 import * as types from '@babel/types'
 import {
   generateDataSourceFetcherWithCore,
@@ -1074,11 +1074,12 @@ export const createStateDataSourcePlugin: ComponentPluginFactory<{}> = () => {
       tryBlock = created.tryBlock
     }
 
-    // Compute folder depth for import paths
-    // componentFolderPath contains subfolders within pages/ (e.g. ['admin'] for pages/admin/X.js)
-    const componentFolderPath = (uidl.outputOptions as any)?.folderPath || []
-    const depth = (componentFolderPath.length || 0) + 1
-    const relativePrefix = '../'.repeat(depth)
+    // Relative path from the page back to the project root. `folderPath` holds
+    // the subfolders WITHIN pages/ (e.g. ['admin'] for pages/admin/X.js).
+    const relativePrefix = GenericUtils.generatePageToRootPrefix({
+      folderPath: uidl.outputOptions?.folderPath,
+      pagesPath: options.pagesPath,
+    })
 
     const extractedResources = options.extractedResources
 

--- a/packages/teleport-project-generator-nuxt/__tests__/end2end/index.ts
+++ b/packages/teleport-project-generator-nuxt/__tests__/end2end/index.ts
@@ -17,7 +17,7 @@ describe('Vue Nuxt Project Generator', () => {
     const outputFolder = await generator.generateProject(uidlSample, template)
     const assetsPath = generator.getAssetsPath()
 
-    const packageJSON = outputFolder.files[1]
+    const packageJSON = outputFolder.files.find((file) => file.name === 'package')
 
     expect(assetsPath).toBeDefined()
     expect(outputFolder.name).toBe(template.name)
@@ -28,7 +28,7 @@ describe('Vue Nuxt Project Generator', () => {
     const outputFolder = await generator.generateProject(uidlSampleWithDependencies, template)
     const assetsPath = generator.getAssetsPath()
 
-    const packageJSON = outputFolder.files[2]
+    const packageJSON = outputFolder.files.find((file) => file.name === 'package')
     const pages = outputFolder.subFolders[1]
     const components = outputFolder.subFolders[0]
 
@@ -49,8 +49,8 @@ describe('Vue Nuxt Project Generator', () => {
       `import DangerousHTML from 'dangerous-html/dist/vue/lib.js'`
     )
 
-    expect(packageJSON.content).toContain(`"antd": "4.5.4"`)
-    expect(packageJSON.content).toContain(`"dangerous-html": "0.1.13"`)
+    expect(packageJSON?.content).toContain(`"antd": "4.5.4"`)
+    expect(packageJSON?.content).toContain(`"dangerous-html": "0.1.13"`)
 
     /* For Nuxt based projects, just imports are injected in index file of the routes */
     expect(pages.files[0].content).toContain(`import 'antd/dist/antd.css'`)

--- a/packages/teleport-project-generator/src/index.ts
+++ b/packages/teleport-project-generator/src/index.ts
@@ -26,6 +26,7 @@ import {
   generateExternalCSSImports,
   fileFileAndReplaceContent,
   bootstrapGenerator,
+  reportUnresolvedLocalImports,
 } from './utils'
 import {
   createManifestJSONFile,
@@ -277,6 +278,11 @@ export class ProjectGenerator implements ProjectGeneratorType {
         ) as UIDLLocalFontAsset[],
       },
       projectRouteDefinition: uidl.root.stateDefinitions.route,
+      // Page plugins receive page folder paths relative to THIS folder, while
+      // every other path they get (resources, utils, components) is relative to
+      // the project root — they need both to build an import specifier between
+      // the two. See `GenericUtils.generatePageDependenciesPrefix`.
+      pagesPath: this.strategy.pages.path,
       designLanguage: uidl.root?.designLanguage,
       mapping,
       extractedResources: {},
@@ -365,9 +371,30 @@ export class ProjectGenerator implements ProjectGeneratorType {
         }
       )
 
+      // The framework's app file imports this stylesheet unconditionally when
+      // the strategy declares `isGlobalStylesDependent` (Next's `_app.js`,
+      // Nuxt's config), but the style sheet generator emits NO file when the
+      // UIDL carries neither style sets nor design tokens — leaving an import
+      // of a `style.css` that was never written, which fails the build with the
+      // same "Module not found" as any other dangling local import. Emit the
+      // empty sheet that import promises. Project plugins that take the import
+      // away (styled-components, css-modules, react-jss) set the flag to false
+      // in `runBefore`, before this runs, so they write nothing extra.
+      const styleSheetFiles = [...files]
+      if (
+        this.strategy.framework?.config?.isGlobalStylesDependent === true &&
+        !styleSheetFiles.some((file) => file.name === this.strategy.projectStyleSheet.fileName)
+      ) {
+        styleSheetFiles.push({
+          name: this.strategy.projectStyleSheet.fileName,
+          fileType: FileType.CSS,
+          content: '',
+        })
+      }
+
       inMemoryFilesMap.set('projectStyleSheet', {
         path: this.strategy.projectStyleSheet.path,
-        files,
+        files: styleSheetFiles,
       })
       collectedDependencies = { ...collectedDependencies, ...dependencies }
     }
@@ -768,6 +795,8 @@ export class ProjectGenerator implements ProjectGeneratorType {
 
     // Inject all the collected dependencies in the package.json file
     handlePackageJSON(rootFolder, uidl, collectedDependencies, collectedDevDependencies)
+
+    reportUnresolvedLocalImports(rootFolder)
 
     return rootFolder
   }

--- a/packages/teleport-project-generator/src/utils.ts
+++ b/packages/teleport-project-generator/src/utils.ts
@@ -1,4 +1,10 @@
-import { UIDLUtils, StringUtils, GenericUtils, RoutePaths } from '@teleporthq/teleport-shared'
+import {
+  UIDLUtils,
+  StringUtils,
+  GenericUtils,
+  RoutePaths,
+  LocalImports,
+} from '@teleporthq/teleport-shared'
 import {
   GeneratedFile,
   GeneratedFolder,
@@ -604,4 +610,40 @@ export const bootstrapGenerator = (
     ...(style && { variation: style }),
     strictHtmlWhitespaceSensitivity,
   })
+}
+
+/**
+ * Last line of defence against "Module not found" builds: walk the finished
+ * project and report every relative import that resolves to no generated file.
+ *
+ * A plugin that computes an import path from the wrong base (a page folder path
+ * measured from `pages/` against a folder measured from the project root, say)
+ * produces a project that looks complete and only breaks when the framework
+ * compiles it — on the user's machine, or on Vercel. This puts the failure back
+ * next to the code that caused it.
+ *
+ * Reports, never throws: the scan is text-based, so a string literal that merely
+ * LOOKS like an import could show up here, and no generation should ever be
+ * lost to that. `teleport-test`'s standalone run turns the same check into a
+ * non-zero exit code, which is where a regression gets caught for real.
+ */
+export const reportUnresolvedLocalImports = (rootFolder: GeneratedFolder): void => {
+  let unresolved: LocalImports.UnresolvedLocalImport[] = []
+
+  try {
+    unresolved = LocalImports.findUnresolvedLocalImportsInProject(rootFolder)
+  } catch {
+    // A diagnostic must never cost a caller its generated project — the files
+    // are already complete by the time this runs.
+    return
+  }
+
+  if (unresolved.length === 0) {
+    return
+  }
+
+  /* tslint:disable-next-line:no-console */
+  console.warn(
+    `[teleport-project-generator] ${LocalImports.formatUnresolvedLocalImports(unresolved)}`
+  )
 }

--- a/packages/teleport-shared/__tests__/utils/local-imports.ts
+++ b/packages/teleport-shared/__tests__/utils/local-imports.ts
@@ -1,0 +1,174 @@
+import { GeneratedFolder } from '@teleporthq/teleport-types'
+import { LocalImports } from '../../src'
+
+const {
+  collectProjectFiles,
+  findUnresolvedLocalImports,
+  findUnresolvedLocalImportsInProject,
+  formatUnresolvedLocalImports,
+} = LocalImports
+
+const file = (name: string, fileType: string, content = '') => ({ name, fileType, content })
+
+const folder = (
+  name: string,
+  files: Array<ReturnType<typeof file>> = [],
+  subFolders: GeneratedFolder[] = []
+): GeneratedFolder => ({ name, files, subFolders } as GeneratedFolder)
+
+describe('collectProjectFiles', () => {
+  it('addresses every file relative to the project root, not to the root folder name', () => {
+    const project = folder(
+      'my-project',
+      [file('package', 'json', '{}')],
+      [folder('pages', [file('index', 'js', '')], [folder('blog', [file('[slug]', 'js', '')])])]
+    )
+
+    expect(
+      collectProjectFiles(project)
+        .map((entry) => entry.path)
+        .sort()
+    ).toEqual(['package.json', 'pages/blog/[slug].js', 'pages/index.js'])
+  })
+
+  it('skips the content of base64 files', () => {
+    const project = folder('my-project', [
+      { ...file('logo', 'png', 'iVBORw0KGgo='), contentEncoding: 'base64' as const },
+    ])
+
+    expect(collectProjectFiles(project)[0].content).toBe('')
+  })
+})
+
+describe('findUnresolvedLocalImports', () => {
+  it('accepts an import that resolves to a generated file', () => {
+    const unresolved = findUnresolvedLocalImports([
+      {
+        path: 'pages/blog/[slug].js',
+        content: `import fetcher from '../../resources/fetch-posts'`,
+      },
+      { path: 'resources/fetch-posts.js', content: '' },
+    ])
+
+    expect(unresolved).toEqual([])
+  })
+
+  it('reports the page-folder/root-folder collision that broke `next build`', () => {
+    const unresolved = findUnresolvedLocalImports([
+      {
+        path: 'pages/resources/[id].js',
+        content: `import fetcher from '../fetch_content_items_detail'`,
+      },
+      { path: 'resources/fetch_content_items_detail.js', content: '' },
+    ])
+
+    expect(unresolved).toEqual([
+      { filePath: 'pages/resources/[id].js', specifier: '../fetch_content_items_detail' },
+    ])
+  })
+
+  it('resolves extensionless, explicit-extension, folder-index and multi-line imports', () => {
+    const unresolved = findUnresolvedLocalImports([
+      {
+        path: 'pages/index.js',
+        content: [
+          `import {`,
+          `  Repeater,`,
+          `} from '../components/navigation'`,
+          `import '../pages/style.css'`,
+          `import cache from '../utils/tq-cache'`,
+          `const runtime = require('../utils/workflows/runtime')`,
+          `const lazy = () => import('../components/footer')`,
+        ].join('\n'),
+      },
+      { path: 'components/navigation.js', content: '' },
+      { path: 'components/footer.jsx', content: '' },
+      { path: 'pages/style.css', content: '' },
+      { path: 'utils/tq-cache/index.js', content: '' },
+      { path: 'utils/workflows/runtime.js', content: '' },
+    ])
+
+    expect(unresolved).toEqual([])
+  })
+
+  it('reports an import that climbs above the project root', () => {
+    const unresolved = findUnresolvedLocalImports([
+      { path: 'pages/index.js', content: `import x from '../../outside/thing'` },
+    ])
+
+    expect(unresolved).toEqual([{ filePath: 'pages/index.js', specifier: '../../outside/thing' }])
+  })
+
+  it('ignores package imports, aliases and non-JS files', () => {
+    const unresolved = findUnresolvedLocalImports([
+      {
+        path: 'pages/index.js',
+        content: [
+          `import React from 'react'`,
+          `import { useGlobalState } from '@/global-state-context'`,
+        ].join('\n'),
+      },
+      { path: 'pages/style.css', content: `@import './missing.css';` },
+    ])
+
+    expect(unresolved).toEqual([])
+  })
+
+  it('ignores a bundler suffix on the specifier', () => {
+    const unresolved = findUnresolvedLocalImports([
+      { path: 'pages/index.js', content: `import icon from '../public/icon.svg?inline'` },
+      { path: 'public/icon.svg', content: '' },
+    ])
+
+    expect(unresolved).toEqual([])
+  })
+
+  it('reports every offending file, sorted, and reports each specifier once', () => {
+    const unresolved = findUnresolvedLocalImports([
+      { path: 'pages/b.js', content: `import x from './missing'\nimport y from './missing'` },
+      { path: 'pages/a.js', content: `import z from './also-missing'` },
+    ])
+
+    expect(unresolved).toEqual([
+      { filePath: 'pages/a.js', specifier: './also-missing' },
+      { filePath: 'pages/b.js', specifier: './missing' },
+    ])
+  })
+})
+
+describe('findUnresolvedLocalImportsInProject', () => {
+  it('walks a generated folder', () => {
+    const project = folder(
+      'my-project',
+      [],
+      [
+        folder(
+          'pages',
+          [],
+          [folder('resources', [file('[id]', 'js', `import r from '../fetch'`)])]
+        ),
+        folder('resources', [file('fetch', 'js', '')]),
+      ]
+    )
+
+    expect(findUnresolvedLocalImportsInProject(project)).toEqual([
+      { filePath: 'pages/resources/[id].js', specifier: '../fetch' },
+    ])
+  })
+})
+
+describe('formatUnresolvedLocalImports', () => {
+  it('is empty when there is nothing to report', () => {
+    expect(formatUnresolvedLocalImports([])).toBe('')
+  })
+
+  it('names every file and specifier', () => {
+    const report = formatUnresolvedLocalImports([
+      { filePath: 'pages/resources/[id].js', specifier: '../fetch_content_items_detail' },
+    ])
+
+    expect(report).toContain('pages/resources/[id].js')
+    expect(report).toContain('../fetch_content_items_detail')
+    expect(report).toContain('Module not found')
+  })
+})

--- a/packages/teleport-shared/__tests__/utils/page-dependencies-prefix.ts
+++ b/packages/teleport-shared/__tests__/utils/page-dependencies-prefix.ts
@@ -1,0 +1,89 @@
+import { GenericUtils } from '../../src'
+
+const { generatePageDependenciesPrefix, generatePageToRootPrefix, DEFAULT_PAGES_PATH } =
+  GenericUtils
+
+/**
+ * Regression guard for the `pages/resources/[id].js` → `../fetch_content_items_detail`
+ * build break: the page folder path is relative to the PAGES ROOT while the
+ * target folder path is relative to the PROJECT ROOT, and resolving one against
+ * the other cancelled the `resources` segment that only looked shared.
+ */
+describe('generatePageDependenciesPrefix', () => {
+  it('reaches a root folder from a page at the pages root', () => {
+    expect(generatePageDependenciesPrefix({ toPath: ['resources'], folderPath: [] })).toBe(
+      '../resources/'
+    )
+  })
+
+  it('reaches a root folder from a page in a subfolder', () => {
+    expect(generatePageDependenciesPrefix({ toPath: ['resources'], folderPath: ['blog'] })).toBe(
+      '../../resources/'
+    )
+  })
+
+  it('does NOT collapse a page folder that is named after the target root folder', () => {
+    expect(
+      generatePageDependenciesPrefix({ toPath: ['resources'], folderPath: ['resources'] })
+    ).toBe('../../resources/')
+  })
+
+  it('does not collapse deeper collisions either', () => {
+    expect(
+      generatePageDependenciesPrefix({
+        toPath: ['utils', 'data-sources'],
+        folderPath: ['utils', 'data-sources'],
+      })
+    ).toBe('../../../utils/data-sources/')
+  })
+
+  it('counts a multi-segment pages root', () => {
+    expect(
+      generatePageDependenciesPrefix({
+        toPath: ['resources'],
+        folderPath: ['resources'],
+        pagesPath: ['src', 'pages'],
+      })
+    ).toBe('../../../resources/')
+  })
+
+  it('cancels a genuinely shared ancestor', () => {
+    expect(
+      generatePageDependenciesPrefix({
+        toPath: ['src', 'resources'],
+        folderPath: ['blog'],
+        pagesPath: ['src', 'pages'],
+      })
+    ).toBe('../../resources/')
+  })
+
+  it('defaults to the Next pages root and to a page at that root', () => {
+    expect(generatePageDependenciesPrefix({ toPath: ['components'] })).toBe('../components/')
+    expect(DEFAULT_PAGES_PATH).toEqual(['pages'])
+  })
+
+  it('treats a missing folder path the same as an empty one', () => {
+    expect(
+      generatePageDependenciesPrefix({
+        toPath: ['resources'],
+        folderPath: undefined,
+        pagesPath: undefined,
+      })
+    ).toBe('../resources/')
+  })
+})
+
+describe('generatePageToRootPrefix', () => {
+  it('matches the hand-rolled depth math it replaced', () => {
+    expect(generatePageToRootPrefix({ folderPath: [] })).toBe('../')
+    expect(generatePageToRootPrefix({ folderPath: ['admin'] })).toBe('../../')
+    expect(generatePageToRootPrefix({ folderPath: ['admin', 'reports'] })).toBe('../../../')
+    expect(generatePageToRootPrefix({})).toBe('../')
+  })
+
+  it('counts a multi-segment pages root', () => {
+    expect(generatePageToRootPrefix({ folderPath: ['admin'], pagesPath: ['src', 'pages'] })).toBe(
+      '../../../'
+    )
+  })
+})

--- a/packages/teleport-shared/src/index.ts
+++ b/packages/teleport-shared/src/index.ts
@@ -2,6 +2,7 @@ import * as Constants from './constants'
 import * as StringUtils from './utils/string-utils'
 import * as UIDLUtils from './utils/uidl-utils'
 import * as GenericUtils from './utils/generic'
+import * as LocalImports from './utils/local-imports'
 import * as JSIdentifiers from './utils/js-identifiers'
 import * as ASTScope from './utils/ast-scope'
 import * as ASTStatementOrder from './utils/ast-statement-order'
@@ -20,6 +21,7 @@ export {
   StringUtils,
   UIDLUtils,
   GenericUtils,
+  LocalImports,
   JSIdentifiers,
   ASTScope,
   ASTStatementOrder,

--- a/packages/teleport-shared/src/utils/generic.ts
+++ b/packages/teleport-shared/src/utils/generic.ts
@@ -69,6 +69,63 @@ export const generateLocalDependenciesPrefix = (fromPath: string[], toPath: stri
   return dependencyPrefix
 }
 
+/**
+ * The folder every framework-agnostic page path in this repo is relative to by
+ * default. Next.js is the only target that emits pages through the plugins
+ * below, and its pages root is `pages/` (see the `pages.path` of the strategy
+ * in teleport-project-generator-next). Used only as a fallback for callers that
+ * do not receive `GeneratorOptions.pagesPath`.
+ */
+export const DEFAULT_PAGES_PATH = ['pages']
+
+/**
+ * Import prefix from a PAGE file to a folder that lives at the PROJECT ROOT
+ * (`resources/`, `utils/`, `components/` ...). Returns a prefix ending in '/',
+ * so callers append the file name: `${prefix}${fileName}`.
+ *
+ * ⛔ A page's `outputOptions.folderPath` is relative to the PAGES ROOT
+ * (`['resources']` for `pages/resources/[id].js`), while every folder path in
+ * the project strategy is relative to the PROJECT ROOT. Handing those two
+ * coordinate systems to a single `path.relative()` call cancels segments that
+ * only LOOK common: `relative('/resources/[id]', '/resources/fetch_items')`
+ * returned `'../fetch_items'`, which resolves to `pages/fetch_items` — a
+ * "Module not found: Can't resolve '../fetch_items'" at `next build` time for
+ * every page whose folder happens to be named after a root folder (a
+ * `/resources/[id]` route against the `resources/` folder, a `/utils/[id]` one
+ * against `utils/`, ...). Every other page built fine, which is exactly why it
+ * survived so long.
+ *
+ * Rebasing the page folder onto the pages root puts both sides in the same
+ * coordinate system, so only genuinely shared ancestors are cancelled. The math
+ * runs through `generateLocalDependenciesPrefix` — plain array bookkeeping, no
+ * `path.relative()` — so it is also immune to the truncated `relative()` that
+ * Next's compiled `path-browserify` ships (see `localRelativePath` above).
+ */
+export const generatePageDependenciesPrefix = (params: {
+  toPath: string[]
+  folderPath?: string[]
+  pagesPath?: string[]
+}): string => {
+  const { toPath, folderPath, pagesPath } = params
+  // `folderPath` comes straight out of the UIDL, where it can be absent (or a
+  // JSON null) for a page at the pages root — never let that throw on a spread.
+  return generateLocalDependenciesPrefix(
+    [...(pagesPath || DEFAULT_PAGES_PATH), ...(folderPath || [])],
+    toPath
+  )
+}
+
+/**
+ * Prefix from a PAGE file back to the PROJECT ROOT ('../', '../../', ...), for
+ * callers that build the rest of the path themselves
+ * (`${prefix}utils/workflows/runtime`). Same coordinate-system correction as
+ * `generatePageDependenciesPrefix`, which it delegates to.
+ */
+export const generatePageToRootPrefix = (params: {
+  folderPath?: string[]
+  pagesPath?: string[]
+}): string => generatePageDependenciesPrefix({ ...params, toPath: [] })
+
 const removeCommonStartingPointsFromPaths = (paths: string[][]): string[][] => {
   const pathsClone: string[][] = JSON.parse(JSON.stringify(paths))
 

--- a/packages/teleport-shared/src/utils/local-imports.ts
+++ b/packages/teleport-shared/src/utils/local-imports.ts
@@ -1,0 +1,226 @@
+import { GeneratedFile, GeneratedFolder } from '@teleporthq/teleport-types'
+
+/**
+ * Safety net for the whole family of "Module not found" build breaks: a plugin
+ * emits a relative import whose specifier points at a file the generator never
+ * writes. The generated project still LOOKS fine — the defect only surfaces
+ * when `next build` (or Vercel) compiles the page, which is far away from the
+ * code that computed the path.
+ *
+ * The one that motivated this module: a page in `pages/resources/` importing
+ * from the project's root `resources/` folder collapsed to `../fetch_items`
+ * because the page-relative and root-relative folder paths were mixed in a
+ * single `path.relative()` call (fixed at the source — see
+ * `generatePageDependenciesPrefix` in ./generic). Nothing in the pipeline
+ * noticed, so the check below runs over the finished file tree and reports
+ * every relative specifier that resolves to no generated file.
+ *
+ * Report-only by design: a false positive (a string literal that merely looks
+ * like an import) must never be able to fail a generation or, worse, rewrite
+ * someone's code.
+ */
+
+/** One generated file, addressed by its PROJECT-ROOT-relative path. */
+export interface ProjectFileEntry {
+  /** e.g. `pages/resources/[id].js` — always '/'-separated, no leading slash. */
+  path: string
+  content: string
+}
+
+export interface UnresolvedLocalImport {
+  /** Project-root-relative path of the file holding the import. */
+  filePath: string
+  /** The specifier exactly as it appears in the source. */
+  specifier: string
+}
+
+/** File types whose contents are parsed for import specifiers. */
+const SCANNED_EXTENSIONS = ['js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx']
+
+/**
+ * Extensions a bundler appends to an extensionless specifier. The empty string
+ * comes first so a specifier that already carries its extension (`./style.css`)
+ * matches as-is.
+ */
+const RESOLVED_EXTENSIONS = [
+  '',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.ts',
+  '.tsx',
+  '.json',
+  '.css',
+  '.scss',
+  '.sass',
+  '.less',
+  '.vue',
+  '.svelte',
+  '.md',
+  '.svg',
+]
+
+/** Extensions tried for a specifier that points at a folder (`./utils` → `./utils/index.js`). */
+const INDEX_EXTENSIONS = ['.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx', '.vue', '.json']
+
+/**
+ * Every shape a relative module specifier takes in generated code. Kept as
+ * separate, deliberately narrow patterns rather than one clever regex: an
+ * over-eager match here would only ever produce noise in a warning.
+ */
+const IMPORT_PATTERNS: RegExp[] = [
+  // import x from './y' / export { x } from './y' (incl. multi-line import lists)
+  /\bfrom\s*['"](\.[^'"\n]*)['"]/g,
+  // import('./y')
+  /\bimport\s*\(\s*['"](\.[^'"\n]*)['"]\s*\)/g,
+  // require('./y')
+  /\brequire\s*\(\s*['"](\.[^'"\n]*)['"]\s*\)/g,
+  // import './y' (side-effect only)
+  /\bimport\s+['"](\.[^'"\n]*)['"]/g,
+]
+
+const getFileName = (file: GeneratedFile): string =>
+  file.fileType ? `${file.name}.${file.fileType}` : file.name
+
+const getExtension = (filePath: string): string => {
+  const fileName = filePath.slice(filePath.lastIndexOf('/') + 1)
+  const dotIndex = fileName.lastIndexOf('.')
+  return dotIndex > 0 ? fileName.slice(dotIndex + 1).toLowerCase() : ''
+}
+
+/**
+ * Resolve `specifier` against the folder holding `filePath`, purely on the
+ * segment arrays. Node's `path` is deliberately not used: this code also runs
+ * inside teleport-gui's packer Web Worker, where 'path' is swapped for Next's
+ * compiled `path-browserify` (see `localRelativePath` in ./generic).
+ *
+ * Returns null when the specifier climbs above the project root — nothing above
+ * it is ever generated, so such an import is unresolvable by definition.
+ */
+const resolveSpecifier = (filePath: string, specifier: string): string | null => {
+  const segments = filePath.split('/').slice(0, -1)
+
+  for (const part of specifier.split('/')) {
+    if (part === '' || part === '.') {
+      continue
+    }
+    if (part === '..') {
+      if (segments.length === 0) {
+        return null
+      }
+      segments.pop()
+      continue
+    }
+    segments.push(part)
+  }
+
+  return segments.join('/')
+}
+
+/** Drop a bundler suffix (`./icon.svg?inline`, `./font.woff#iefix`) before resolving. */
+const stripSpecifierSuffix = (specifier: string): string => {
+  const cutIndex = Math.min(
+    ...['?', '#'].map((marker) => {
+      const index = specifier.indexOf(marker)
+      return index === -1 ? specifier.length : index
+    })
+  )
+  return specifier.slice(0, cutIndex)
+}
+
+const extractSpecifiers = (content: string): string[] => {
+  const specifiers = new Set<string>()
+
+  IMPORT_PATTERNS.forEach((pattern) => {
+    // Patterns are module-level (and therefore stateful through `lastIndex`) —
+    // reset before each file so a previous scan can't skip the first match.
+    pattern.lastIndex = 0
+    let match = pattern.exec(content)
+    while (match !== null) {
+      specifiers.add(match[1])
+      match = pattern.exec(content)
+    }
+  })
+
+  return Array.from(specifiers)
+}
+
+/**
+ * Flatten a generated project into project-root-relative file entries. The root
+ * folder's own name is the project directory itself, so it is not part of any
+ * path.
+ */
+export const collectProjectFiles = (folder: GeneratedFolder): ProjectFileEntry[] => {
+  const entries: ProjectFileEntry[] = []
+
+  const walk = (currentFolder: GeneratedFolder, prefix: string) => {
+    currentFolder.files.forEach((file) => {
+      entries.push({
+        path: `${prefix}${getFileName(file)}`,
+        content: file.contentEncoding === 'base64' ? '' : file.content || '',
+      })
+    })
+
+    currentFolder.subFolders.forEach((subFolder) => {
+      walk(subFolder, `${prefix}${subFolder.name}/`)
+    })
+  }
+
+  walk(folder, '')
+
+  return entries
+}
+
+/**
+ * Every relative import in `files` that resolves to no file in `files`.
+ * Deterministically ordered (file, then specifier) so callers can snapshot it.
+ */
+export const findUnresolvedLocalImports = (files: ProjectFileEntry[]): UnresolvedLocalImport[] => {
+  const existingPaths = new Set(files.map((file) => file.path))
+  const unresolved: UnresolvedLocalImport[] = []
+
+  const resolvesToAFile = (target: string): boolean =>
+    RESOLVED_EXTENSIONS.some((extension) => existingPaths.has(`${target}${extension}`)) ||
+    INDEX_EXTENSIONS.some((extension) => existingPaths.has(`${target}/index${extension}`))
+
+  files.forEach((file) => {
+    if (SCANNED_EXTENSIONS.indexOf(getExtension(file.path)) === -1) {
+      return
+    }
+
+    extractSpecifiers(file.content).forEach((specifier) => {
+      const target = resolveSpecifier(file.path, stripSpecifierSuffix(specifier))
+
+      if (target === null || !resolvesToAFile(target)) {
+        unresolved.push({ filePath: file.path, specifier })
+      }
+    })
+  })
+
+  return unresolved.sort((first, second) =>
+    first.filePath === second.filePath
+      ? first.specifier.localeCompare(second.specifier)
+      : first.filePath.localeCompare(second.filePath)
+  )
+}
+
+/** `findUnresolvedLocalImports` over a generated project folder. */
+export const findUnresolvedLocalImportsInProject = (
+  folder: GeneratedFolder
+): UnresolvedLocalImport[] => findUnresolvedLocalImports(collectProjectFiles(folder))
+
+/** Human-readable report. Returns an empty string when there is nothing to report. */
+export const formatUnresolvedLocalImports = (unresolved: UnresolvedLocalImport[]): string => {
+  if (unresolved.length === 0) {
+    return ''
+  }
+
+  const lines = unresolved.map((item) => `  ${item.filePath}  →  '${item.specifier}'`)
+
+  return (
+    `${unresolved.length} generated import${unresolved.length === 1 ? '' : 's'} ` +
+    `resolve${unresolved.length === 1 ? 's' : ''} to no generated file — ` +
+    `the build will fail with "Module not found":\n${lines.join('\n')}`
+  )
+}

--- a/packages/teleport-test/package.json
+++ b/packages/teleport-test/package.json
@@ -42,6 +42,7 @@
     "@teleporthq/teleport-project-plugin-tailwind": "^0.43.60",
     "@teleporthq/teleport-publisher-codesandbox": "^0.43.60",
     "@teleporthq/teleport-publisher-disk": "^0.43.60",
+    "@teleporthq/teleport-shared": "^0.43.60",
     "@teleporthq/teleport-types": "^0.43.60"
   },
   "devDependencies": {

--- a/packages/teleport-test/src/standalone.ts
+++ b/packages/teleport-test/src/standalone.ts
@@ -7,6 +7,7 @@ import {
   rmSync,
   existsSync,
   readdirSync,
+  statSync,
 } from 'fs'
 import { join } from 'path'
 import chalk from 'chalk'
@@ -19,6 +20,7 @@ import {
   ProjectPlugin,
 } from '@teleporthq/teleport-types'
 import { performance } from 'perf_hooks'
+import { LocalImports } from '@teleporthq/teleport-shared'
 import { ProjectPluginCSSModules } from '@teleporthq/teleport-project-plugin-css-modules'
 import { ProjectPluginReactJSS } from '@teleporthq/teleport-project-plugin-react-jss'
 import { ProjectPluginStyledComponents } from '@teleporthq/teleport-project-plugin-styled-components'
@@ -231,6 +233,80 @@ const cleanGeneratedFiles = (projectDir: string): boolean => {
   return hadNextCache
 }
 
+// Directories inside the generated project that were never produced by the
+// generator — scanning them would only report other people's code.
+const IMPORT_SCAN_SKIPPED_DIRS = new Set([
+  'node_modules',
+  '.next',
+  '.git',
+  // Editor/agent scaffolding the clean deliberately preserves (PRESERVE_ON_CLEAN)
+  '.vscode',
+  '.claude',
+])
+
+// Extensions whose CONTENT is parsed for import specifiers. Everything else is
+// still collected (an import has to be able to resolve to a .css/.json/asset
+// file), just not read from disk.
+const IMPORT_SCAN_READ_EXTENSIONS = ['.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx']
+
+const collectFilesForImportScan = (
+  dir: string,
+  prefix = ''
+): Array<{ path: string; content: string }> => {
+  const entries: Array<{ path: string; content: string }> = []
+
+  for (const entry of readdirSync(dir)) {
+    const absolute = join(dir, entry)
+
+    if (statSync(absolute).isDirectory()) {
+      if (IMPORT_SCAN_SKIPPED_DIRS.has(entry)) {
+        continue
+      }
+      entries.push(...collectFilesForImportScan(absolute, `${prefix}${entry}/`))
+      continue
+    }
+
+    const shouldRead = IMPORT_SCAN_READ_EXTENSIONS.some((extension) => entry.endsWith(extension))
+    entries.push({
+      path: `${prefix}${entry}`,
+      content: shouldRead ? readFileSync(absolute, 'utf8') : '',
+    })
+  }
+
+  return entries
+}
+
+// Fail the run when a generated file imports something that was never written.
+// `next build` reports this as "Module not found: Can't resolve '<specifier>'"
+// minutes later (or only once it reaches Vercel) with no hint about which
+// plugin computed the path — this reports it right where it was generated. The
+// project generator logs the same finding during generation; the exit code is
+// what makes it impossible to scroll past.
+const verifyLocalImports = (projectDir: string): void => {
+  if (!existsSync(projectDir)) {
+    return
+  }
+
+  let unresolved: LocalImports.UnresolvedLocalImport[] = []
+
+  try {
+    unresolved = LocalImports.findUnresolvedLocalImports(collectFilesForImportScan(projectDir))
+  } catch (error) {
+    // Never turn a good generation into a failed run because the CHECK broke.
+    console.info(chalk.yellow(`\n[standalone] could not verify local imports: ${error}\n`))
+    return
+  }
+
+  if (unresolved.length === 0) {
+    return
+  }
+
+  console.info(
+    chalk.red(`\n[standalone] ${LocalImports.formatUnresolvedLocalImports(unresolved)}\n`)
+  )
+  process.exitCode = 1
+}
+
 const run = async () => {
   // Reported twice in one session: the warning below is printed BEFORE ~1500
   // lines of generation output, so it scrolls away and the next thing anyone
@@ -338,6 +414,11 @@ const run = async () => {
       //   uidl: flotiqUIDL,
       // }),
     ])
+
+    if (generatedProjectDir) {
+      verifyLocalImports(generatedProjectDir)
+    }
+
     // ⛔ The clean deletes `.next`, so nothing this script does can recreate it.
     // If it is back by the time generation finishes, a dev server was WATCHING
     // the regeneration — and it rebuilt the cache during the window where

--- a/packages/teleport-types/src/generators.ts
+++ b/packages/teleport-types/src/generators.ts
@@ -201,6 +201,20 @@ export interface GeneratorOptions {
     tokens?: UIDLDesignTokens
   }
   resources?: { items: UIDLResources['items']; cache: UIDLResources['cache']; path: string[] }
+  /**
+   * PROJECT-ROOT-relative folder the framework serves pages from
+   * (`['pages']` for Next) — i.e. the project strategy's `pages.path`.
+   *
+   * A page UIDL's `outputOptions.folderPath` is relative to THAT folder, while
+   * every other path in these options (`resources.path`, the data-source and
+   * workflow util folders, ...) is relative to the PROJECT ROOT. A page plugin
+   * that needs an import path between the two has to rebase the page folder on
+   * this one first — see `GenericUtils.generatePageDependenciesPrefix`, which
+   * exists because mixing the two coordinate systems silently produced
+   * `../fetch_items` (resolving inside `pages/`) for a page in
+   * `pages/resources/` importing the root `resources/` folder.
+   */
+  pagesPath?: string[]
   dataSources?: Record<string, UIDLDataSource>
   forms?: UIDLForms
   globalAssets?: UIDLGlobalAsset[]


### PR DESCRIPTION
## Fix "Module not found" for pages whose folder collides with a project-root folder

### Problem

A page UIDL's `outputOptions.folderPath` is relative to the **pages root** (`['resources']` →
`pages/resources/[id].js`), while every folder path in the project strategy (`resources/`,
`utils/`, `components/`) is relative to the **project root**. Several Next page plugins fed both
into a single `path.relative()` call, which cancelled segments that only *looked* common:

relative('/resources/[id]', '/resources/fetch_items') → '../fetch_items'



That resolves to `pages/fetch_items`, so `next build` failed with
`Module not found: Can't resolve '../fetch_items'` — but only for pages whose folder happens to be
named after a root folder (a `/resources/[id]` route against `resources/`, `/utils/[id]` against
`utils/`, …). Every other page built fine, which is why the bug survived so long and only showed up
on the user's machine or on Vercel.

The same class of bug also lived in the hand-rolled `'../'.repeat(folderPath.length + 1)` depth math
scattered across the data-source, pagination, cache and workflow plugins.

### Fix

**Shared helpers** (`teleport-shared/src/utils/generic.ts`)
- `generatePageDependenciesPrefix({ toPath, folderPath, pagesPath })` — rebases the page folder onto
  the pages root so both sides share one coordinate system, then does plain array bookkeeping via
  `generateLocalDependenciesPrefix`. No `path.relative()`, so it is also immune to the truncated
  `relative()` shipped by Next's compiled `path-browserify` in the GUI packer worker.
- `generatePageToRootPrefix({ folderPath, pagesPath })` — the `'../'`-only variant, replacing every
  hand-rolled depth computation.

**New generator option** `GeneratorOptions.pagesPath` (`teleport-types`)
- The project-root-relative folder the framework serves pages from (the strategy's `pages.path`).
  Passed down by the full Next project generator, the partial generator and `splitProjectUIDL`, so
  plugins no longer have to assume `pages/`.

**Call sites migrated**
- `teleport-plugin-next-static-props`, `teleport-plugin-next-static-paths`,
  `teleport-plugin-next-inline-fetch` (the actual `path.relative()` collision)
- `teleport-plugin-next-data-source` (utils, pagination, cache client),
  `teleport-plugin-next-workflows`, `teleport-project-generator-next/state-data-source-plugin`
  (the `'../'.repeat(...)` duplicates)

### Safety net: unresolved local import detection

New `teleport-shared/src/utils/local-imports.ts` walks a finished project and reports every relative
import specifier that resolves to no generated file (extensionless, explicit-extension, folder-index,
`import()`, `require()` and side-effect imports; bundler `?`/`#` suffixes stripped; base64 files and
package/alias imports ignored).

- `ProjectGenerator` logs the finding at generation time (`reportUnresolvedLocalImports`) —
  **report-only**, wrapped in try/catch, so a false positive can never cost a caller its project.
- `teleport-test`'s standalone run performs the same scan over the written project directory and sets
  a non-zero exit code, so a regression of this class fails a run instead of scrolling past.

### Bonus fix: missing global stylesheet

When a strategy declares `isGlobalStylesDependent` (Next's `_app.js`, Nuxt's config), the app file
imports `style.css` unconditionally — but the stylesheet generator emits no file when the UIDL has
neither style sets nor design tokens, producing the same dangling-import build failure. The project
generator now emits the empty sheet that import promises. Project plugins that remove the import
(styled-components, css-modules, react-jss) flip the flag to `false` in `runBefore`, before this runs,
so they are unaffected.

### Tests

- `teleport-shared`: `page-dependencies-prefix` (collision cases, multi-segment pages root, genuinely
  shared ancestors, missing/absent folder path, defaults) and `local-imports` (resolution rules,
  ordering, formatting, project walking)
- `page-folder-name-collision.test.ts` for `next-static-props`, `next-static-paths` and
  `next-inline-fetch` — asserts the emitted import path for a colliding page folder, a non-colliding
  subfolder, a page at the pages root, a multi-segment resources folder and a non-default pages root
- Next/Nuxt end-to-end tests now look up folders and files by name instead of by positional index,
  which is what made them brittle against the extra generated stylesheet