### PR TITLE
embeds in blog posts + seo on blogs + speech recognition workflow node

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,6 +45,10 @@ module.exports = {
   // entire handlers directory is excluded from instrumentation.
   "coveragePathIgnorePatterns": [
     "/node_modules/",
-    "/packages/teleport-plugin-next-workflows/src/nodes/"
+    "/packages/teleport-plugin-next-workflows/src/nodes/",
+    // The rich-text embed helpers are emitted into generated projects via
+    // fn.toString(); istanbul's `cov_xxx()` calls would travel with them into a
+    // scope that cannot resolve the counter.
+    "/packages/teleport-shared/src/utils/rich-text-embeds.ts"
   ]
 }

--- a/packages/teleport-plugin-common/__tests__/node-handlers/node-to-jsx/utils.ts
+++ b/packages/teleport-plugin-common/__tests__/node-handlers/node-to-jsx/utils.ts
@@ -624,3 +624,94 @@ describe('createDynamicValueExpression — ctx reference (never emits an undecla
     )
   })
 })
+
+// An `expr` reference carries raw JavaScript, not the name of a binding. The
+// domain-to-UIDL mapper emits the literal `false` whenever a condition's
+// state/prop reference cannot be resolved (an orphaned or renamed definition),
+// documenting it as "renders nothing" — but the sanitiser that keeps a state
+// named `class` compiling used to rewrite it to `false_`, and the generated
+// page died server-side with `ReferenceError: false_ is not defined` before
+// rendering a single element.
+describe('createBinaryExpression — literal expr references', () => {
+  const render = (
+    key: string,
+    condition: { operation: string; operand?: string | number | boolean }
+  ): string =>
+    generate(
+      createBinaryExpression(condition, { key, type: 'boolean', isExpression: true }) as types.Node
+    ).code
+
+  // `'='` is what the domain-to-UIDL mapper actually writes for an equality
+  // condition, so this is the exact shape that crashed the generated page.
+  it('emits the unresolved-reference fallback as the literal false', () => {
+    expect(render('false', { operation: '=', operand: false })).toBe('false === false')
+    expect(render('false', { operation: '=', operand: true })).toBe('false === true')
+  })
+
+  it('keeps the boolean short forms for a strict-equality condition', () => {
+    expect(render('true', { operation: '===', operand: true })).toBe('true')
+    expect(render('false', { operation: '===', operand: false })).toBe('!false')
+  })
+
+  it('emits literal null, undefined and numbers', () => {
+    expect(render('null', { operation: '!==', operand: 'x' })).toBe(`null !== "x"`)
+    expect(render('undefined', { operation: '!==', operand: 'x' })).toBe(`undefined !== "x"`)
+    expect(render('0', { operation: '>', operand: 1 })).toBe('0 > 1')
+    expect(render('-2.5', { operation: '<', operand: 1 })).toBe('-2.5 < 1')
+  })
+
+  it('never sanitises a literal into an undefined binding', () => {
+    expect(render('false', { operation: '=', operand: false })).not.toContain('false_')
+  })
+
+  it('leaves a real expression body untouched', () => {
+    expect(render('chatMessage?.sender', { operation: '===', operand: 'ai' })).toBe(
+      `chatMessage?.sender === "ai"`
+    )
+  })
+
+  it('still sanitises a reserved BINDING name, which is not an expression', () => {
+    expect(
+      generate(
+        createBinaryExpression(
+          { operation: '===', operand: true },
+          {
+            key: 'class',
+            type: 'boolean',
+          }
+        ) as types.Node
+      ).code
+    ).toBe('class_')
+  })
+})
+
+describe('createConditionIdentifier — expr references are flagged as source', () => {
+  const params: JSXGenerationParams = {
+    propDefinitions: {},
+    stateDefinitions: {},
+    globalStateDefinitions: {},
+    dependencies: {},
+    nodesLookup: {},
+    windowImports: {},
+    localeReferences: [],
+    localeAttributeReferences: [],
+    globalReferences: [],
+    globalStateReferences: [],
+    hoistedConstants: [],
+  }
+  const options: JSXGenerationOptions = {
+    dynamicReferencePrefixMap: { prop: 'props', state: '', local: '' },
+  }
+
+  it('marks an expr VALUE reference', () => {
+    const result = createConditionIdentifier({ type: 'expr', content: 'false' }, params, options)
+
+    expect(result).toEqual({ key: 'false', type: 'boolean', isExpression: true })
+  })
+
+  it('does not mark a state reference', () => {
+    const result = createConditionIdentifier(dynamicNode('state', 'isActive'), params, options)
+
+    expect(result.isExpression).toBeUndefined()
+  })
+})

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/types.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/types.ts
@@ -136,4 +136,12 @@ export interface ConditionalIdentifier {
   type: string
   prefix?: string
   referenceType?: string
+  /**
+   * True when `key` is raw JavaScript SOURCE (a UIDL `expr` reference) rather
+   * than the name of a binding. The two are emitted differently: a binding name
+   * has to survive the reserved-word sanitiser (`class` -> `class_`), while
+   * source must not be rewritten by it — the literal `false` is a value, and
+   * `false_` is an undefined variable that throws while the page renders.
+   */
+  isExpression?: boolean
 }

--- a/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/utils.ts
+++ b/packages/teleport-plugin-common/src/node-handlers/node-to-jsx/utils.ts
@@ -806,6 +806,7 @@ export const createConditionIdentifier = (
     return {
       key: dynamicReference.content,
       type: 'boolean',
+      isExpression: true,
     }
   }
 
@@ -920,6 +921,7 @@ export const createConditionIdentifier = (
       return {
         key: id,
         type: 'boolean',
+        isExpression: true,
       }
 
     default:
@@ -1085,6 +1087,63 @@ const createLengthExpression = (
     : t.memberExpression(target, t.identifier('length'))
 }
 
+/**
+ * A UIDL `expr` reference whose whole body is a JavaScript LITERAL.
+ *
+ * `expr` content is source, not a name, so it must never reach the reserved
+ * word sanitiser: the domain-to-UIDL mapper emits the literal `false` as its
+ * "this condition could not be resolved" fallback (an orphaned state/prop
+ * reference), and `t.identifier(createSafeJSIdentifierPath('false'))` prints
+ * `false_` — an undefined binding that throws
+ * `ReferenceError: false_ is not defined` while the page is rendering, taking
+ * the whole page down instead of quietly rendering nothing.
+ *
+ * Only complete literals are matched. Anything else (`chatMessage?.sender`,
+ * `props.product?.slug`) keeps the historical verbatim-identifier printing,
+ * including the sanitiser pass that a state genuinely named `class` relies on.
+ */
+const NUMERIC_LITERAL_RE = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/
+
+const createJSLiteralExpression = (source: string, t = types): types.Expression | null => {
+  switch (source) {
+    case 'true':
+      return t.booleanLiteral(true)
+    case 'false':
+      return t.booleanLiteral(false)
+    case 'null':
+      return t.nullLiteral()
+    case 'undefined':
+      return t.identifier('undefined')
+    default:
+      return NUMERIC_LITERAL_RE.test(source) ? t.numericLiteral(Number(source)) : null
+  }
+}
+
+/** The left-hand side of one condition, as an AST node. */
+const createConditionalIdentifierExpression = (
+  conditionalIdentifier: ConditionalIdentifier,
+  t = types
+): types.Expression => {
+  // Same rule as `createDynamicValueExpression`: an un-prefixed key is the
+  // binding itself and must be identifier-safe; a prefixed one is a member
+  // access that has to keep the UIDL's original spelling.
+  if (conditionalIdentifier.prefix) {
+    return t.memberExpression(
+      t.identifier(conditionalIdentifier.prefix),
+      t.identifier(conditionalIdentifier.key)
+    )
+  }
+
+  if (conditionalIdentifier.isExpression) {
+    const literal = createJSLiteralExpression(conditionalIdentifier.key, t)
+    if (literal) {
+      return literal
+    }
+  }
+
+  return t.identifier(JSIdentifiers.createSafeJSIdentifierPath(conditionalIdentifier.key))
+}
+
 export const createBinaryExpression = (
   condition: {
     operation: string
@@ -1096,15 +1155,7 @@ export const createBinaryExpression = (
   t = types
 ) => {
   const { operand, operation, containsField } = condition
-  // Same rule as `createDynamicValueExpression`: an un-prefixed key is the
-  // binding itself and must be identifier-safe; a prefixed one is a member
-  // access that has to keep the UIDL's original spelling.
-  const identifier = conditionalIdentifier.prefix
-    ? t.memberExpression(
-        t.identifier(conditionalIdentifier.prefix),
-        t.identifier(conditionalIdentifier.key)
-      )
-    : t.identifier(JSIdentifiers.createSafeJSIdentifierPath(conditionalIdentifier.key))
+  const identifier = createConditionalIdentifierExpression(conditionalIdentifier, t)
 
   // Array/Object operators
   if (operation === 'isEmpty') {

--- a/packages/teleport-plugin-jsx-head-config/__tests__/seo-overrides.test.ts
+++ b/packages/teleport-plugin-jsx-head-config/__tests__/seo-overrides.test.ts
@@ -1,0 +1,204 @@
+import * as types from '@babel/types'
+import generator from '@babel/generator'
+import { createJSXHeadConfigPlugin } from '../src'
+import { component, elementNode } from '@teleporthq/teleport-uidl-builders'
+import {
+  ComponentStructure,
+  ChunkType,
+  FileType,
+  ChunkDefinition,
+  ComponentUIDL,
+  UIDLComponentSEO,
+} from '@teleporthq/teleport-types'
+
+// Per-entity SEO overrides on details pages:
+//  - a dynamic metaTag whose reference carries a `fallback` renders
+//    `content={props?.x?.y ?? '<fallback>'}` (without it an unset row leaves a
+//    content-less robots meta behind);
+//  - a canonical asset's `dynamicOverride` wraps the WHOLE page-level href in
+//    `props?.x?.canonicalUrl || <fallback>` — in every branch (static, dynamic
+//    route, multi-locale), and mirrored on og:url.
+
+const makeJsxChunk = (): ChunkDefinition => ({
+  type: ChunkType.AST,
+  fileType: FileType.JS,
+  name: 'jsx-component',
+  content: {},
+  linkAfter: [],
+  meta: {
+    nodesLookup: {
+      container: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: { type: 'JSXIdentifier', name: 'div' },
+          attributes: [],
+          selfClosing: false,
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: { type: 'JSXIdentifier', name: 'div' },
+        },
+        children: [],
+      },
+    },
+  },
+})
+
+const runPlugin = async (
+  seo: ComponentUIDL['seo'],
+  options: ComponentStructure['options'] = {}
+): Promise<string> => {
+  const plugin = createJSXHeadConfigPlugin()
+  const uidlSample = component('SimpleComponent', elementNode('container'))
+  uidlSample.node.content.key = 'container'
+  uidlSample.seo = seo
+
+  const structure: ComponentStructure = {
+    uidl: uidlSample,
+    options,
+    chunks: [makeJsxChunk()],
+    dependencies: {},
+  }
+
+  await plugin(structure)
+
+  const astNode = structure.chunks[0].meta.nodesLookup.container as types.JSXElement
+  const helmetNode = astNode.children[0] as types.JSXElement
+  return generator(helmetNode as unknown as types.Node).code
+}
+
+describe('plugin-jsx-head-config: per-entity SEO overrides', () => {
+  it('renders a dynamic meta content with its fallback via ??', async () => {
+    const code = await runPlugin({
+      metaTags: [
+        {
+          name: 'robots',
+          content: {
+            type: 'dynamic',
+            content: {
+              referenceType: 'prop',
+              id: 'root',
+              refPath: ['blogPost', 'robotsContent'],
+              fallback: 'index, follow',
+            },
+          },
+        },
+      ],
+    } as unknown as UIDLComponentSEO)
+
+    expect(code).toContain('props?.blogPost?.robotsContent ?? "index, follow"')
+  })
+
+  it('renders a dynamic meta content without fallback as the bare chain (unchanged behavior)', async () => {
+    const code = await runPlugin({
+      metaTags: [
+        {
+          name: 'robots',
+          content: {
+            type: 'dynamic',
+            content: {
+              referenceType: 'prop',
+              id: 'root',
+              refPath: ['blogPost', 'robotsContent'],
+            },
+          },
+        },
+      ],
+    } as unknown as UIDLComponentSEO)
+
+    expect(code).toContain('props?.blogPost?.robotsContent')
+    expect(code).not.toContain('??')
+  })
+
+  it('wraps a dynamic-route canonical (and og:url) with the entity override', async () => {
+    const code = await runPlugin({
+      assets: [
+        {
+          type: 'canonical',
+          path: 'https://example.com/blog/[slug]',
+          dynamicOverride: {
+            type: 'dynamic',
+            content: {
+              referenceType: 'prop',
+              id: 'root',
+              refPath: ['blogPost', 'canonicalUrl'],
+            },
+          },
+        },
+      ],
+    } as unknown as UIDLComponentSEO)
+
+    expect(code).toContain(
+      // tslint:disable-next-line:no-invalid-template-strings
+      'href={props?.blogPost?.canonicalUrl || `https://example.com/blog/${router.query.slug}`}'
+    )
+    expect(code).toContain(
+      // tslint:disable-next-line:no-invalid-template-strings
+      'content={props?.blogPost?.canonicalUrl || `https://example.com/blog/${router.query.slug}`}'
+    )
+  })
+
+  it('wraps a fully static canonical with the entity override', async () => {
+    const code = await runPlugin({
+      assets: [
+        {
+          type: 'canonical',
+          path: 'https://example.com/about',
+          dynamicOverride: {
+            type: 'dynamic',
+            content: {
+              referenceType: 'prop',
+              id: 'root',
+              refPath: ['blogPost', 'canonicalUrl'],
+            },
+          },
+        },
+      ],
+    } as unknown as UIDLComponentSEO)
+
+    expect(code).toContain('href={props?.blogPost?.canonicalUrl || "https://example.com/about"}')
+  })
+
+  it('keeps a static canonical byte-identical when no override is present (regression guard)', async () => {
+    const code = await runPlugin({
+      assets: [{ type: 'canonical', path: 'https://example.com/about' }],
+    } as unknown as UIDLComponentSEO)
+
+    expect(code).toContain('href="https://example.com/about"')
+    expect(code).toContain('content="https://example.com/about"')
+    expect(code).not.toContain('||')
+  })
+
+  it('wraps the multi-locale canonical template whole — the override is never spliced into it', async () => {
+    const code = await runPlugin(
+      {
+        assets: [
+          {
+            type: 'canonical',
+            path: 'https://example.com/blog/[slug]',
+            dynamicOverride: {
+              type: 'dynamic',
+              content: {
+                referenceType: 'prop',
+                id: 'root',
+                refPath: ['blogPost', 'canonicalUrl'],
+              },
+            },
+          },
+        ],
+      } as unknown as UIDLComponentSEO,
+      {
+        internationalization: {
+          languages: { en: 'English', fr: 'French' },
+          main: { locale: 'en', name: 'English' },
+        },
+      } as unknown as ComponentStructure['options']
+    )
+
+    expect(code).toContain('props?.blogPost?.canonicalUrl || `https://example.com${')
+    // hreflang alternates stay page-derived — no override leaks into them.
+    const hreflangSection = code.slice(code.indexOf('hrefLang'))
+    expect(hreflangSection).not.toContain('canonicalUrl')
+  })
+})

--- a/packages/teleport-plugin-jsx-head-config/src/index.ts
+++ b/packages/teleport-plugin-jsx-head-config/src/index.ts
@@ -93,6 +93,7 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
 
       uidl.seo.assets.forEach((asset) => {
         if (asset.type === 'canonical') {
+          const canonicalOverride = () => buildCanonicalOverrideExpression(asset.dynamicOverride)
           const { origin, pathname } = parseCanonicalUrl(asset.path)
           const isRootPath = pathname === '/'
           const { staticParts: pathParts, paramNames } = parseDynamicSegments(pathname)
@@ -158,7 +159,11 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
               ]
             }
 
-            const canonicalHrefExpr = types.templateLiteral(quasis, expressions)
+            const localeCanonicalOverride = canonicalOverride()
+            const localeTemplateExpr = types.templateLiteral(quasis, expressions)
+            const canonicalHrefExpr = localeCanonicalOverride
+              ? types.logicalExpression('||', localeCanonicalOverride, localeTemplateExpr)
+              : localeTemplateExpr
             canonicalLink.openingElement.attributes.push(
               types.jsxAttribute(
                 types.jsxIdentifier('href'),
@@ -200,10 +205,15 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
               ),
               ...paramNames.map((name) => buildRouterQueryParam(name)),
             ]
+            const ogUrlOverride = canonicalOverride()
+            const ogUrlTemplateExpr = types.templateLiteral(ogUrlQuasis, ogUrlExpressions)
+            const ogUrlContentExpr = ogUrlOverride
+              ? types.logicalExpression('||', ogUrlOverride, ogUrlTemplateExpr)
+              : ogUrlTemplateExpr
             ogUrlMeta.openingElement.attributes.push(
               types.jsxAttribute(
                 types.jsxIdentifier('content'),
-                types.jsxExpressionContainer(types.templateLiteral(ogUrlQuasis, ogUrlExpressions))
+                types.jsxExpressionContainer(ogUrlContentExpr)
               )
             )
             headASTTags.push(ogUrlMeta)
@@ -229,25 +239,26 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
             // No i18n but has dynamic params — needs router.query interpolation
             const canonicalLink = ASTBuilders.createSelfClosingJSXTag('link')
             ASTUtils.addAttributeToJSXTag(canonicalLink, 'rel', 'canonical')
-            addDynamicHrefAttribute(canonicalLink, asset.path)
+            addDynamicHrefAttribute(canonicalLink, asset.path, canonicalOverride())
             headASTTags.push(canonicalLink)
 
             // og:url meta tag — mirrors the canonical href
             const ogUrlMeta = ASTBuilders.createSelfClosingJSXTag('meta')
             ASTUtils.addAttributeToJSXTag(ogUrlMeta, 'property', 'og:url')
-            addDynamicContentAttribute(ogUrlMeta, asset.path)
+            addDynamicContentAttribute(ogUrlMeta, asset.path, canonicalOverride())
             headASTTags.push(ogUrlMeta)
           } else {
-            // No i18n or single locale — static canonical
+            // No i18n or single locale — static canonical (an entity override,
+            // when present, turns the attribute into `{override || 'path'}`)
             const canonicalLink = ASTBuilders.createSelfClosingJSXTag('link')
             ASTUtils.addAttributeToJSXTag(canonicalLink, 'rel', 'canonical')
-            ASTUtils.addAttributeToJSXTag(canonicalLink, 'href', asset.path)
+            addDynamicHrefAttribute(canonicalLink, asset.path, canonicalOverride())
             headASTTags.push(canonicalLink)
 
             // og:url meta tag — mirrors the canonical href
             const ogUrlMeta = ASTBuilders.createSelfClosingJSXTag('meta')
             ASTUtils.addAttributeToJSXTag(ogUrlMeta, 'property', 'og:url')
-            ASTUtils.addAttributeToJSXTag(ogUrlMeta, 'content', asset.path)
+            addDynamicContentAttribute(ogUrlMeta, asset.path, canonicalOverride())
             headASTTags.push(ogUrlMeta)
           }
         }
@@ -386,6 +397,45 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
     )
   }
 
+  /** `['blogPost', 'canonicalUrl']` -> `props?.blogPost?.canonicalUrl` */
+  const buildPropsChainExpression = (refPath: string[]): types.Expression => {
+    return refPath.reduce<types.Expression>(
+      (acc, pathItem) =>
+        types.optionalMemberExpression(acc, types.identifier(pathItem), false, true),
+      types.identifier('props')
+    )
+  }
+
+  const buildLiteralExpression = (value: string | number | boolean): types.Expression => {
+    if (typeof value === 'number') {
+      return types.numericLiteral(value)
+    }
+    if (typeof value === 'boolean') {
+      return types.booleanLiteral(value)
+    }
+    return types.stringLiteral(value)
+  }
+
+  /**
+   * A canonical asset's `dynamicOverride` is a per-entity prop reference (a
+   * details-page row's own canonical URL). Returns the `props?.…` chain to
+   * `||`-wrap around the page-level href expression, or null when the asset
+   * has no usable override. Built fresh on every call — the canonical href and
+   * the og:url mirror each need their own AST nodes.
+   */
+  const buildCanonicalOverrideExpression = (
+    dynamicOverride?: UIDLDynamicReference
+  ): types.Expression | null => {
+    if (
+      dynamicOverride?.type !== 'dynamic' ||
+      dynamicOverride.content.referenceType !== 'prop' ||
+      !dynamicOverride.content.refPath?.length
+    ) {
+      return null
+    }
+    return buildPropsChainExpression(dynamicOverride.content.refPath)
+  }
+
   /**
    * Adds an href attribute to a JSX tag. If the href contains ${paramName} patterns,
    * generates a template literal with router.query.paramName expressions.
@@ -394,31 +444,46 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
   const addDynamicAttributeToTag = (
     tag: types.JSXElement,
     attrName: string,
-    value: string
+    value: string,
+    overrideExpr?: types.Expression | null
   ): void => {
     const { staticParts, paramNames } = parseDynamicSegments(value)
-    if (paramNames.length === 0) {
+    if (paramNames.length === 0 && !overrideExpr) {
       ASTUtils.addAttributeToJSXTag(tag, attrName, value)
       return
     }
-    const quasis = staticParts.map((part, i) =>
-      types.templateElement({ raw: part, cooked: part }, i === staticParts.length - 1)
-    )
-    const expressions = paramNames.map((name) => buildRouterQueryParam(name))
+    const baseExpr: types.Expression =
+      paramNames.length === 0
+        ? types.stringLiteral(value)
+        : types.templateLiteral(
+            staticParts.map((part, i) =>
+              types.templateElement({ raw: part, cooked: part }, i === staticParts.length - 1)
+            ),
+            paramNames.map((name) => buildRouterQueryParam(name))
+          )
+    // The override wraps the WHOLE fallback expression: an entity-supplied URL
+    // must never be spliced into the page-level template (locale prefixes,
+    // route params) — it either fully replaces the href or is absent.
+    const attrExpr = overrideExpr ? types.logicalExpression('||', overrideExpr, baseExpr) : baseExpr
     tag.openingElement.attributes.push(
-      types.jsxAttribute(
-        types.jsxIdentifier(attrName),
-        types.jsxExpressionContainer(types.templateLiteral(quasis, expressions))
-      )
+      types.jsxAttribute(types.jsxIdentifier(attrName), types.jsxExpressionContainer(attrExpr))
     )
   }
 
-  const addDynamicHrefAttribute = (tag: types.JSXElement, href: string): void => {
-    addDynamicAttributeToTag(tag, 'href', href)
+  const addDynamicHrefAttribute = (
+    tag: types.JSXElement,
+    href: string,
+    overrideExpr?: types.Expression | null
+  ): void => {
+    addDynamicAttributeToTag(tag, 'href', href, overrideExpr)
   }
 
-  const addDynamicContentAttribute = (tag: types.JSXElement, content: string): void => {
-    addDynamicAttributeToTag(tag, 'content', content)
+  const addDynamicContentAttribute = (
+    tag: types.JSXElement,
+    content: string,
+    overrideExpr?: types.Expression | null
+  ): void => {
+    addDynamicAttributeToTag(tag, 'content', content, overrideExpr)
   }
 
   const addAttributeToMetaTag = (
@@ -442,15 +507,20 @@ export const createJSXHeadConfigPlugin: ComponentPluginFactory<JSXHeadPluginConf
     }
 
     if (value.content.referenceType === 'prop') {
-      let content = `props`
-      value.content.refPath?.forEach((pathItem) => {
-        content = content.concat(`?.${pathItem}`)
-      })
+      const propChain = buildPropsChainExpression(value.content.refPath || [])
+      // `fallback` keeps the attribute meaningful for rows that don't carry the
+      // field (e.g. a robots meta inheriting the page-level default) — without
+      // it an undefined prop renders a content-less tag.
+      const fallback = 'fallback' in value.content ? value.content.fallback : undefined
+      const contentExpression =
+        fallback === undefined || fallback === null
+          ? propChain
+          : types.logicalExpression('??', propChain, buildLiteralExpression(fallback))
 
       metaTag.openingElement.attributes.push(
         types.jsxAttribute(
           types.jsxIdentifier(key),
-          types.jsxExpressionContainer(types.identifier(content))
+          types.jsxExpressionContainer(contentExpression)
         )
       )
       return { translationUsed: false }

--- a/packages/teleport-plugin-next-data-source/src/transformations/blog-post.ts
+++ b/packages/teleport-plugin-next-data-source/src/transformations/blog-post.ts
@@ -77,6 +77,22 @@ function buildBlogPost(record, options) {
       ? coerceBoolean(record.allowComments, true)
       : true
 
+  // Per-post SEO overrides. The transform is the single normalization point —
+  // rows can also be written by the raw admin CRUD form, so whitespace and
+  // unknown redirect types are neutralized here. Absent columns (a table
+  // provisioned before the feature) read as undefined and normalize to null.
+  // robotsContent is null — never '' or false — for unset rows, so the
+  // page-level fallback (the \`??\` in the generated Head) can take over.
+  var noIndex = coerceBoolean(pickFirst(record.no_index, record.noIndex), false)
+  var canonicalUrl = normalizeSeoUrlField(pickFirst(record.canonical_url, record.canonicalUrl))
+  var redirectUrl = normalizeSeoUrlField(pickFirst(record.redirect_url, record.redirectUrl))
+  var rawRedirectType = pickFirst(record.redirect_type, record.redirectType)
+  var redirectType =
+    redirectUrl && (rawRedirectType === '301' || rawRedirectType === '302')
+      ? rawRedirectType
+      : null
+  var robotsContent = noIndex ? 'noindex' : null
+
   // The author's related-post picks. \`relatedPosts\` carries the TRANSFORMED
   // rows, not ids, so the details page's related-posts rail can map over it and
   // draw an article card per entry; \`relatedPostIds\` keeps the raw selection.
@@ -146,6 +162,11 @@ function buildBlogPost(record, options) {
     readingTimeMinutes: readingTimeMinutes,
     isFeatured: isFeatured,
     allowComments: allowComments,
+    noIndex: noIndex,
+    canonicalUrl: canonicalUrl,
+    redirectUrl: redirectUrl,
+    redirectType: redirectType,
+    robotsContent: robotsContent,
     publishedAt: publishedAt,
     createdAt: createdAt,
     updatedAt: updatedAt,
@@ -156,6 +177,14 @@ function buildBlogPost(record, options) {
 function transformBlogPosts(records, options) {
   if (!Array.isArray(records)) return []
   return records.map(function(record) { return buildBlogPost(record, options) })
+}
+
+// Trims a per-post SEO URL cell; blank/non-string values (including columns
+// that don't exist yet on tables provisioned before the feature) become null.
+function normalizeSeoUrlField(value) {
+  if (typeof value !== 'string') return null
+  var trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
 }
 
 // Batched fetch of the post rows a set of posts reference as "related", keyed by

--- a/packages/teleport-plugin-next-static-props/__tests__/entity-redirect.test.ts
+++ b/packages/teleport-plugin-next-static-props/__tests__/entity-redirect.test.ts
@@ -1,0 +1,142 @@
+import generator from '@babel/generator'
+import * as types from '@babel/types'
+import { ComponentStructure } from '@teleporthq/teleport-types'
+import { createStaticPropsPlugin } from '../src/index'
+
+// Entity-level redirects (`initialPropsData.redirect`): a details page whose
+// fetched row carries a destination answers with an HTTP redirect instead of
+// rendering. Two invariants matter beyond the emitted shape:
+//  - the redirect must live INSIDE an IfStatement — several later plugins
+//    (addDynamicSeoPropsToGetStaticProps, the parallel/inline-fetch plugins)
+//    locate the props return via `.find((s) => s.type === 'ReturnStatement')`
+//    on the try block, so a second top-level return would derail them;
+//  - `statusCode` (not `permanent`) is emitted, because Next.js maps
+//    `permanent: true/false` to 308/307 while the feature promises 301/302.
+
+const RESOURCE_ID = 'fetch-blog-post'
+
+const makeStructure = (params: {
+  redirect?: { destinationField: string; typeField?: string }
+  skipI18n?: boolean
+}): ComponentStructure => {
+  const { redirect, skipI18n } = params
+  return {
+    uidl: {
+      name: 'BlogPostDetails',
+      node: { type: 'element', content: { elementType: 'container' } },
+      outputOptions: {
+        pageId: 'page-blog-post-details',
+        folderPath: ['blog'],
+        fileName: '[slug]',
+        initialPropsData: {
+          exposeAs: { name: 'blogPost', valuePath: ['data', '0'] },
+          resource: { id: RESOURCE_ID, params: {} },
+          ...(redirect ? { redirect } : {}),
+        },
+      },
+    },
+    chunks: [],
+    dependencies: {},
+    options: {
+      skipI18n,
+      resources: {
+        items: {
+          [RESOURCE_ID]: { id: RESOURCE_ID, name: 'blog-post' },
+        },
+        path: ['utils', 'data-sources'],
+      },
+    },
+  } as unknown as ComponentStructure
+}
+
+const generateCode = async (structure: ComponentStructure): Promise<string> => {
+  const plugin = createStaticPropsPlugin()
+  const result = await plugin(structure)
+  const chunk = result.chunks.find((c) => c.name === 'getStaticProps')
+  expect(chunk).toBeDefined()
+  return generator(chunk?.content as types.Node).code
+}
+
+describe('teleport-plugin-next-static-props: entity redirect', () => {
+  it('emits a statusCode redirect between the notFound check and the props return', async () => {
+    const code = await generateCode(
+      makeStructure({ redirect: { destinationField: 'redirectUrl', typeField: 'redirectType' } })
+    )
+
+    expect(code).toContain('const entityRedirectUrl = response?.data?.[0]?.redirectUrl')
+    expect(code).toContain('if (entityRedirectUrl)')
+    expect(code).toContain('statusCode: response?.data?.[0]?.redirectType === "302" ? 302 : 301')
+    expect(code).not.toContain('permanent')
+
+    // The 404 for a missing row must win over the redirect check.
+    expect(code.indexOf('notFound')).toBeLessThan(code.indexOf('entityRedirectUrl'))
+    expect(code.indexOf('entityRedirectUrl')).toBeLessThan(code.indexOf('props:'))
+  })
+
+  it('keeps the props return as the ONLY top-level ReturnStatement in the try block', async () => {
+    const plugin = createStaticPropsPlugin()
+    const result = await plugin(
+      makeStructure({ redirect: { destinationField: 'redirectUrl', typeField: 'redirectType' } })
+    )
+    const chunk = result.chunks.find((c) => c.name === 'getStaticProps')
+    const exportDecl = chunk?.content as types.ExportNamedDeclaration
+    const fn = exportDecl.declaration as types.FunctionDeclaration
+    const tryStmt = fn.body.body.find(
+      (statement): statement is types.TryStatement => statement.type === 'TryStatement'
+    )
+    expect(tryStmt).toBeDefined()
+
+    const topLevelReturns = tryStmt!.block.body.filter(
+      (statement) => statement.type === 'ReturnStatement'
+    )
+    expect(topLevelReturns).toHaveLength(1)
+
+    // And the one `.find(ReturnStatement)` later plugins run must land on the
+    // props return, not the redirect.
+    const found = tryStmt!.block.body.find(
+      (statement) => statement.type === 'ReturnStatement'
+    ) as types.ReturnStatement
+    const foundCode = generator(found).code
+    expect(foundCode).toContain('props:')
+  })
+
+  it('prefixes internal destinations with the active non-default locale when i18n is on', async () => {
+    const code = await generateCode(
+      makeStructure({ redirect: { destinationField: 'redirectUrl', typeField: 'redirectType' } })
+    )
+
+    expect(code).toContain('context?.locale')
+    expect(code).toContain('context?.defaultLocale')
+    expect(code).toContain('entityRedirectUrl.startsWith("/")')
+    // tslint:disable-next-line:no-invalid-template-strings
+    expect(code).toContain('`/${context.locale}${entityRedirectUrl}`')
+  })
+
+  it('uses the destination as-is when i18n is skipped', async () => {
+    const code = await generateCode(
+      makeStructure({
+        redirect: { destinationField: 'redirectUrl', typeField: 'redirectType' },
+        skipI18n: true,
+      })
+    )
+
+    expect(code).toContain('destination: entityRedirectUrl')
+    expect(code).not.toContain('entityRedirectUrl.startsWith')
+  })
+
+  it('defaults to a permanent 301 when no typeField is configured', async () => {
+    const code = await generateCode(
+      makeStructure({ redirect: { destinationField: 'redirectUrl' } })
+    )
+
+    expect(code).toContain('statusCode: 301')
+    expect(code).not.toContain('redirectType')
+  })
+
+  it('emits no redirect code at all without a redirect config (regression guard)', async () => {
+    const code = await generateCode(makeStructure({}))
+
+    expect(code).not.toContain('entityRedirectUrl')
+    expect(code).not.toContain('redirect')
+  })
+})

--- a/packages/teleport-plugin-next-static-props/src/utils.ts
+++ b/packages/teleport-plugin-next-static-props/src/utils.ts
@@ -223,5 +223,126 @@ const computePropsAST = (
     )
   )
 
-  return [declarationAST, notFoundAST, returnAST]
+  return [
+    declarationAST,
+    notFoundAST,
+    ...computeEntityRedirectAST(initialPropsData, skipI18n),
+    returnAST,
+  ]
+}
+
+/**
+ * Entity-level redirect for details pages (`initialPropsData.redirect`): when
+ * the fetched row's destination field holds a value, the page answers with an
+ * HTTP redirect instead of rendering. Placed AFTER the notFound check (a
+ * missing row still 404s) and emitted as an IfStatement wrapping its return —
+ * several downstream plugins (`addDynamicSeoPropsToGetStaticProps`, the
+ * parallel/inline-fetch plugins) locate the props return via
+ * `.find((s) => s.type === 'ReturnStatement')` on the try block, so this must
+ * never introduce another top-level ReturnStatement.
+ */
+const computeEntityRedirectAST = (
+  initialPropsData: UIDLInitialPropsData,
+  skipI18n?: boolean
+): types.Statement[] => {
+  const redirect = initialPropsData.redirect
+  if (!redirect?.destinationField) {
+    return []
+  }
+
+  const rowPath = [
+    'response',
+    ...ASTUtils.parseValuePath(initialPropsData.exposeAs.valuePath || []),
+  ]
+  const destinationAST = ASTUtils.generateMemberExpressionASTFromPath([
+    ...rowPath,
+    redirect.destinationField,
+  ])
+
+  // const entityRedirectUrl = response?.data?.[0]?.<destinationField>
+  const destinationDeclarationAST = types.variableDeclaration('const', [
+    types.variableDeclarator(types.identifier('entityRedirectUrl'), destinationAST),
+  ])
+
+  // Site-internal destinations must keep the visitor's locale: next.config.js
+  // redirects are locale-aware, data-fetching redirects are not, so a `/`
+  // destination is prefixed with the active non-default locale by hand.
+  const localeAwareDestinationAST = skipI18n
+    ? types.identifier('entityRedirectUrl')
+    : types.conditionalExpression(
+        types.logicalExpression(
+          '&&',
+          types.logicalExpression(
+            '&&',
+            types.optionalMemberExpression(
+              types.identifier('context'),
+              types.identifier('locale'),
+              false,
+              true
+            ),
+            types.binaryExpression(
+              '!==',
+              types.memberExpression(types.identifier('context'), types.identifier('locale')),
+              types.optionalMemberExpression(
+                types.identifier('context'),
+                types.identifier('defaultLocale'),
+                false,
+                true
+              )
+            )
+          ),
+          types.callExpression(
+            types.memberExpression(
+              types.identifier('entityRedirectUrl'),
+              types.identifier('startsWith')
+            ),
+            [types.stringLiteral('/')]
+          )
+        ),
+        types.templateLiteral(
+          [
+            types.templateElement({ raw: '/', cooked: '/' }, false),
+            types.templateElement({ raw: '', cooked: '' }, false),
+            types.templateElement({ raw: '', cooked: '' }, true),
+          ],
+          [
+            types.memberExpression(types.identifier('context'), types.identifier('locale')),
+            types.identifier('entityRedirectUrl'),
+          ]
+        ),
+        types.identifier('entityRedirectUrl')
+      )
+
+  // statusCode: real 301/302 — `permanent: true/false` would answer 308/307.
+  const statusCodeAST = redirect.typeField
+    ? types.conditionalExpression(
+        types.binaryExpression(
+          '===',
+          ASTUtils.generateMemberExpressionASTFromPath([...rowPath, redirect.typeField]),
+          types.stringLiteral('302')
+        ),
+        types.numericLiteral(302),
+        types.numericLiteral(301)
+      )
+    : types.numericLiteral(301)
+
+  const redirectReturnAST = types.returnStatement(
+    types.objectExpression([
+      types.objectProperty(
+        types.identifier('redirect'),
+        types.objectExpression([
+          types.objectProperty(types.identifier('destination'), localeAwareDestinationAST),
+          types.objectProperty(types.identifier('statusCode'), statusCodeAST),
+        ])
+      ),
+    ])
+  )
+
+  return [
+    destinationDeclarationAST,
+    types.ifStatement(
+      types.identifier('entityRedirectUrl'),
+      types.blockStatement([redirectReturnAST])
+    ),
+  ]
 }

--- a/packages/teleport-plugin-next-workflows/__tests__/browser-speech-recognition.test.ts
+++ b/packages/teleport-plugin-next-workflows/__tests__/browser-speech-recognition.test.ts
@@ -1,0 +1,625 @@
+// The dictation node is the only node whose observable behaviour arrives AFTER
+// it returns, so its contract cannot be checked by reading the emitted string —
+// these tests execute the real handler against a fake Web Speech API and assert
+// what it dispatches.
+
+import { nodeRegistry } from '../src/nodes'
+
+type Handler = (config: any, context: Record<string, unknown>) => Promise<any>
+
+const loadHandler = (): Handler => {
+  const source = nodeRegistry['browser-speech-recognition'].generateHandler()
+  // Same shape the generated `node-handlers-client.js` uses.
+  // eslint-disable-next-line no-new-func
+  return new Function(`${source}\nreturn browser_speech_recognition;`)() as Handler
+}
+
+interface FakeRecognition {
+  lang: string
+  continuous: boolean
+  interimResults: boolean
+  maxAlternatives?: number
+  start: jest.Mock
+  stop: jest.Mock
+  onresult: ((event: any) => void) | null
+  onerror: ((event: any) => void) | null
+  onend: (() => void) | null
+}
+
+const instances: FakeRecognition[] = []
+
+/**
+ * Set to make the NEXT recogniser reject `start()`, the way a real one raises
+ * `InvalidStateError` while a previous session is still releasing the device.
+ * A flag rather than a mock on an existing instance: each start constructs a
+ * fresh recogniser, so the throwing one does not exist yet at arrange time.
+ */
+let nextStartThrows = false
+
+class FakeSpeechRecognition implements FakeRecognition {
+  lang = ''
+  continuous = false
+  interimResults = false
+  maxAlternatives?: number
+  onresult: ((event: any) => void) | null = null
+  onerror: ((event: any) => void) | null = null
+  onend: (() => void) | null = null
+  start = jest.fn(() => {
+    if (nextStartThrows) {
+      nextStartThrows = false
+      throw new Error('InvalidStateError')
+    }
+  })
+  stop = jest.fn(() => {
+    if (this.onend) {
+      this.onend()
+    }
+  })
+
+  constructor() {
+    instances.push(this)
+  }
+}
+
+const dispatched: Array<{ type: string; detail: any }> = []
+
+const result = (transcript: string, isFinal: boolean, resultIndex = 0) => ({
+  resultIndex,
+  results: [{ 0: { transcript }, isFinal }],
+})
+
+/** A result list holding several phrases at once, as a continuous session builds. */
+const resultList = (phrases: Array<[string, boolean]>, resultIndex = 0) => ({
+  resultIndex,
+  results: phrases.map(([transcript, isFinal]) => ({ 0: { transcript }, isFinal })),
+})
+
+const setupWindow = (options: { supported?: boolean; hidden?: boolean } = {}) => {
+  instances.length = 0
+  dispatched.length = 0
+  nextStartThrows = false
+  const win: any = {
+    document: { documentElement: { lang: 'en-GB' }, hidden: options.hidden === true },
+    dispatchEvent: (event: any) => {
+      dispatched.push({ type: event.type, detail: event.detail })
+      return true
+    },
+  }
+  if (options.supported !== false) {
+    win.webkitSpeechRecognition = FakeSpeechRecognition
+  }
+  ;(globalThis as any).window = win
+  ;(globalThis as any).CustomEvent = class {
+    type: string
+    detail: any
+    constructor(type: string, init?: { detail?: any }) {
+      this.type = type
+      this.detail = init ? init.detail : undefined
+    }
+  }
+  return win
+}
+
+const baseConfig = {
+  sessionId: 'chat',
+  resultEventName: 'dictation-result',
+  endEventName: 'dictation-ended',
+}
+
+const results = () => dispatched.filter((e) => e.type === 'workflow:custom:dictation-result')
+const ends = () => dispatched.filter((e) => e.type === 'workflow:custom:dictation-ended')
+
+describe('browser-speech-recognition', () => {
+  let handler: Handler
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    handler = loadHandler()
+    setupWindow()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    delete (globalThis as any).window
+    delete (globalThis as any).CustomEvent
+  })
+
+  it('starts a session and reports that it is listening', async () => {
+    const out = await handler({ ...baseConfig, action: 'start' }, {})
+    expect(out).toMatchObject({ listening: true, supported: true, action: 'started' })
+    expect(instances).toHaveLength(1)
+    expect(instances[0].start).toHaveBeenCalled()
+  })
+
+  it('falls back to the document language when none is configured', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    expect(instances[0].lang).toBe('en-GB')
+  })
+
+  it('prefers an explicit language over the document one', async () => {
+    await handler({ ...baseConfig, action: 'start', language: 'fr-FR' }, {})
+    expect(instances[0].lang).toBe('fr-FR')
+  })
+
+  it('toggles off a live session instead of starting a second recogniser', async () => {
+    await handler({ ...baseConfig, action: 'toggle' }, {})
+    const out = await handler({ ...baseConfig, action: 'toggle' }, {})
+    expect(out).toMatchObject({ listening: false, action: 'stopped' })
+    expect(instances).toHaveLength(1)
+    expect(instances[0].stop).toHaveBeenCalled()
+  })
+
+  it('appends the transcript to the text already in the field', async () => {
+    await handler({ ...baseConfig, action: 'start', initialText: 'Hello' }, {})
+    instances[0].onresult!(result('there', true))
+    expect(results()[0].detail.text).toBe('Hello there')
+    expect(results()[0].detail.transcript).toBe('there')
+  })
+
+  it('emits the transcript alone when the field was empty', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onresult!(result('just this', true))
+    expect(results()[0].detail.text).toBe('just this')
+  })
+
+  it('marks interim results as not final and finals as final', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onresult!(result('partial', false))
+    instances[0].onresult!(result('complete', true))
+    expect(results()[0].detail.isFinal).toBe(false)
+    expect(results()[1].detail.isFinal).toBe(true)
+  })
+
+  it('does not re-emit an unchanged interim result', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onresult!(result('same', false))
+    instances[0].onresult!(result('same', false))
+    instances[0].onresult!(result('same', false))
+    expect(results()).toHaveLength(1)
+  })
+
+  it('accumulates finals across a restart, which reports its own results from 0', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onresult!(result('first phrase', true))
+    // The browser ended the session on silence; auto-restart reuses the same
+    // recogniser, whose next result set starts at index 0 again.
+    instances[0].onend!()
+    instances[0].onresult!(result('second phrase', true))
+    expect(results().pop()!.detail.text).toBe('first phrase second phrase')
+  })
+
+  it('does not repeat a phrase the engine re-reports as already final', async () => {
+    // Chrome re-sends a settled result when a later phrase revises the list.
+    // Appending from `event.resultIndex` would say the first phrase twice.
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onresult!(resultList([['one', true]]))
+    instances[0].onresult!(
+      resultList([
+        ['one', true],
+        ['two', true],
+      ])
+    )
+    expect(results().pop()!.detail.text).toBe('one two')
+  })
+
+  it('replaces an interim phrase with its final form rather than keeping both', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onresult!(resultList([['hello wor', false]]))
+    instances[0].onresult!(resultList([['hello world', true]]))
+    expect(results().pop()!.detail.text).toBe('hello world')
+  })
+
+  it('shows finals and the live interim together', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onresult!(
+      resultList([
+        ['first', true],
+        ['sec', false],
+      ])
+    )
+    expect(results().pop()!.detail.text).toBe('first sec')
+  })
+
+  it('carries the running text on the end event too', async () => {
+    await handler({ ...baseConfig, action: 'start', initialText: 'Note:' }, {})
+    instances[0].onresult!(result('buy milk', true))
+    await handler({ ...baseConfig, action: 'stop' }, {})
+    expect(ends()[0].detail.text).toBe('Note: buy milk')
+    expect(ends()[0].detail.transcript).toBe('buy milk')
+  })
+
+  it('does not blame a mid-session "no-speech" for the eventual end', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onerror!({ error: 'no-speech' })
+    instances[0].onend!() // auto-restart clears the transient error
+    await handler({ ...baseConfig, action: 'stop' }, {})
+    expect(ends()[0].detail.error).toBe('')
+    expect(ends()[0].detail.reason).toBe('stopped')
+  })
+
+  it('reports an unsupported browser and still emits the end event', async () => {
+    setupWindow({ supported: false })
+    const out = await handler({ ...baseConfig, action: 'start' }, {})
+    expect(out).toMatchObject({ listening: false, supported: false, reason: 'unsupported' })
+    expect(ends()).toHaveLength(1)
+    expect(ends()[0].detail.reason).toBe('unsupported')
+  })
+
+  it('emits exactly one end event with reason "stopped" when the visitor stops it', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    await handler({ ...baseConfig, action: 'stop' }, {})
+    expect(ends()).toHaveLength(1)
+    expect(ends()[0].detail.reason).toBe('stopped')
+  })
+
+  it('surfaces a denied microphone as the end reason', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].onerror!({ error: 'not-allowed' })
+    instances[0].onend!()
+    expect(ends()).toHaveLength(1)
+    expect(ends()[0].detail.reason).toBe('not-allowed')
+  })
+
+  it('does not restart after a fatal error', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].start.mockClear()
+    instances[0].onerror!({ error: 'not-allowed' })
+    instances[0].onend!()
+    expect(instances[0].start).not.toHaveBeenCalled()
+  })
+
+  it('restarts after an ordinary silence timeout so long dictation is not cut short', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].start.mockClear()
+    instances[0].onend!()
+    expect(instances[0].start).toHaveBeenCalledTimes(1)
+    expect(ends()).toHaveLength(0)
+  })
+
+  it('treats "no-speech" as ordinary and keeps listening', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].start.mockClear()
+    instances[0].onerror!({ error: 'no-speech' })
+    instances[0].onend!()
+    expect(instances[0].start).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not restart while the tab is in the background', async () => {
+    const win = setupWindow()
+    await handler({ ...baseConfig, action: 'start' }, {})
+    instances[0].start.mockClear()
+    win.document.hidden = true
+    instances[0].onend!()
+    expect(instances[0].start).not.toHaveBeenCalled()
+    expect(ends()).toHaveLength(1)
+  })
+
+  it('does not restart when auto-restart is off', async () => {
+    await handler({ ...baseConfig, action: 'start', autoRestart: false }, {})
+    instances[0].start.mockClear()
+    instances[0].onend!()
+    expect(instances[0].start).not.toHaveBeenCalled()
+    expect(ends()[0].detail.reason).toBe('ended')
+  })
+
+  it('stops on its own after the maximum duration', async () => {
+    await handler({ ...baseConfig, action: 'start', maxDurationMs: 1000 }, {})
+    jest.advanceTimersByTime(1001)
+    expect(instances[0].stop).toHaveBeenCalled()
+    expect(ends()).toHaveLength(1)
+    expect(ends()[0].detail.reason).toBe('timeout')
+  })
+
+  it('leaves a live session alone when told to start again', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    const out = await handler({ ...baseConfig, action: 'start' }, {})
+    expect(out).toMatchObject({ listening: true, action: 'unchanged' })
+    expect(instances).toHaveLength(1)
+  })
+
+  it('is a no-op when told to stop a session that is not running', async () => {
+    const out = await handler({ ...baseConfig, action: 'stop' }, {})
+    expect(out).toMatchObject({ listening: false, action: 'unchanged' })
+    expect(ends()).toHaveLength(0)
+  })
+
+  it('finalizes rather than stranding the caller when start() throws', async () => {
+    await handler({ ...baseConfig, action: 'start' }, {})
+    await handler({ ...baseConfig, action: 'stop' }, {})
+    dispatched.length = 0
+    nextStartThrows = true
+    const out = await handler({ ...baseConfig, action: 'start' }, {})
+    expect(out).toMatchObject({ listening: false, reason: 'start-failed' })
+    expect(ends()).toHaveLength(1)
+    expect(ends()[0].detail.reason).toBe('start-failed')
+  })
+
+  it('gives up rather than restarting a recogniser that fails instantly', async () => {
+    // No microphone, or the speech service unreachable: every run ends at once.
+    // Restarting those as fast as the browser allows is a tight loop.
+    await handler({ ...baseConfig, action: 'start' }, {})
+    for (let i = 0; i < 20; i += 1) {
+      instances[0].onend!()
+    }
+    expect(instances[0].start.mock.calls.length).toBeLessThanOrEqual(6)
+    expect(ends()).toHaveLength(1)
+  })
+
+  it('keeps restarting when each run actually listened for a while', async () => {
+    const realNow = Date.now
+    let clock = 0
+    Date.now = () => clock
+    try {
+      await handler({ ...baseConfig, action: 'start' }, {})
+      instances[0].start.mockClear()
+      for (let i = 0; i < 8; i += 1) {
+        clock += 5000 // five seconds of listening before each end
+        instances[0].onend!()
+      }
+      expect(instances[0].start).toHaveBeenCalledTimes(8)
+      expect(ends()).toHaveLength(0)
+    } finally {
+      Date.now = realNow
+    }
+  })
+
+  it('does not let a replaced session turn the UI off under the new one', async () => {
+    // `onend` arrives a task after `.stop()`, so a click landing in that gap
+    // starts a fresh session under the same name. The old one must die quietly.
+    await handler({ ...baseConfig, action: 'start' }, {})
+    const first = instances[0]
+    first.stop.mockImplementation(() => {}) // onend deferred, as in a real browser
+    await handler({ ...baseConfig, action: 'stop' }, {})
+    dispatched.length = 0
+
+    const restarted = await handler({ ...baseConfig, action: 'start' }, {})
+    expect(restarted).toMatchObject({ listening: true })
+    first.onend!() // the OLD recogniser finally reports back
+
+    expect(ends()).toHaveLength(0)
+    expect(Object.keys((globalThis as any).window.__teleportSpeechSessions)).toEqual(['chat'])
+  })
+
+  it('keeps separate sessions independent', async () => {
+    await handler({ ...baseConfig, sessionId: 'a', action: 'start' }, {})
+    await handler({ ...baseConfig, sessionId: 'b', action: 'start' }, {})
+    const out = await handler({ ...baseConfig, sessionId: 'a', action: 'stop' }, {})
+    expect(out.sessionId).toBe('a')
+    expect(instances).toHaveLength(2)
+    expect(instances[0].stop).toHaveBeenCalled()
+    expect(instances[1].stop).not.toHaveBeenCalled()
+  })
+
+  it('emits nothing when no event names are configured', async () => {
+    await handler({ action: 'start' }, {})
+    instances[0].onresult!(result('quiet', true))
+    await handler({ action: 'stop' }, {})
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('is registered as a client-only node', () => {
+    expect(nodeRegistry['browser-speech-recognition'].executionEnv).toBe('client')
+  })
+
+  /**
+   * ⛔ `isFatalNodeResult` in the generated runtime treats `success === false`
+   * OR any non-empty `error` string as a FAILED node and abandons the rest of
+   * the workflow. For this node that would skip the state write that puts the
+   * button back to idle — leaving a control stuck showing "recording" precisely
+   * in the cases where nothing is being recorded.
+   *
+   * Not being able to listen is a normal outcome of asking, so no exit path may
+   * report one.
+   */
+  describe('never reports a workflow failure', () => {
+    const isFatalNodeResult = (out: any) =>
+      !!out &&
+      (out.success === false || (typeof out.error === 'string' && out.error) || out.error === true)
+
+    it('on an unsupported browser', async () => {
+      setupWindow({ supported: false })
+      expect(isFatalNodeResult(await handler({ ...baseConfig, action: 'start' }, {}))).toBe(false)
+    })
+
+    it('when start() throws', async () => {
+      await handler({ ...baseConfig, action: 'start' }, {})
+      await handler({ ...baseConfig, action: 'stop' }, {})
+      nextStartThrows = true
+      expect(isFatalNodeResult(await handler({ ...baseConfig, action: 'start' }, {}))).toBe(false)
+    })
+
+    it('on every ordinary path', async () => {
+      const outs = [
+        await handler({ ...baseConfig, action: 'stop' }, {}), // nothing running
+        await handler({ ...baseConfig, action: 'start' }, {}),
+        await handler({ ...baseConfig, action: 'start' }, {}), // already running
+        await handler({ ...baseConfig, action: 'stop' }, {}),
+      ]
+      outs.forEach((out) => expect(isFatalNodeResult(out)).toBe(false))
+    })
+
+    it('outside a browser', async () => {
+      delete (globalThis as any).window
+      expect(isFatalNodeResult(await handler({ ...baseConfig, action: 'start' }, {}))).toBe(false)
+    })
+  })
+
+  // A consumer that only acts on SETTLED speech — a spoken command, a submit —
+  // has nothing to act on unless the final result actually reaches it.
+  describe('the final result is never swallowed by the interim before it', () => {
+    it('emits the final even when its text is identical to the last interim', async () => {
+      await handler({ ...baseConfig, action: 'start' }, {})
+      instances[0].onresult!(result('send it', false))
+      instances[0].onresult!(result('send it', true))
+
+      expect(results().map((e) => [e.detail.text, e.detail.isFinal])).toEqual([
+        ['send it', false],
+        ['send it', true],
+      ])
+    })
+
+    it('still collapses an unchanged interim, which the API repeats several times a second', async () => {
+      await handler({ ...baseConfig, action: 'start' }, {})
+      instances[0].onresult!(result('hello', false))
+      instances[0].onresult!(result('hello', false))
+      instances[0].onresult!(result('hello', false))
+
+      expect(results()).toHaveLength(1)
+    })
+  })
+
+  describe('stopReason', () => {
+    it('reports the caller’s reason on the end event', async () => {
+      await handler({ ...baseConfig, action: 'start' }, {})
+      const out = await handler({ ...baseConfig, action: 'stop', stopReason: 'voice-submit' }, {})
+
+      expect(out).toMatchObject({ listening: false, action: 'stopped' })
+      expect(ends()).toHaveLength(1)
+      expect(ends()[0].detail.reason).toBe('voice-submit')
+    })
+
+    it('falls back to "stopped" when none is given', async () => {
+      await handler({ ...baseConfig, action: 'start' }, {})
+      await handler({ ...baseConfig, action: 'stop' }, {})
+
+      expect(ends()[0].detail.reason).toBe('stopped')
+    })
+
+    it('reports it even when stop() throws and the handler has to finalize itself', async () => {
+      await handler({ ...baseConfig, action: 'start' }, {})
+      instances[0].stop.mockImplementationOnce(() => {
+        throw new Error('InvalidStateError')
+      })
+      await handler({ ...baseConfig, action: 'stop', stopReason: 'voice-stop' }, {})
+
+      expect(ends()).toHaveLength(1)
+      expect(ends()[0].detail.reason).toBe('voice-stop')
+    })
+
+    it('leaves a reason the session ended on its own alone', async () => {
+      await handler(
+        { ...baseConfig, action: 'start', autoRestart: false, stopReason: 'ignored' },
+        {}
+      )
+      instances[0].onend!()
+
+      expect(ends()[0].detail.reason).toBe('ended')
+    })
+  })
+
+  // Hands-free commands. The visitor dictating has no free hand for a button,
+  // so the last thing they say can be the instruction — and the words they said
+  // to command must never end up in the field they were dictating into.
+  describe('spoken commands', () => {
+    // ⛔ Half of a cross-repo contract: the builder declares these same two
+    // strings as SPEECH_STOP_PHRASE_REASON / SPEECH_SUBMIT_PHRASE_REASON and
+    // gates its "now send the message" branch on them. Neither repo can import
+    // the other, so each pins the literal and a one-sided rename fails here.
+    it('reports the reason strings the builder gates its branches on', async () => {
+      await handler(
+        { ...baseConfig, action: 'start', autoRestart: false, stopPhrases: ['stop'] },
+        {}
+      )
+      instances[0].onresult!(result('that is all stop', true))
+      expect(ends()[0].detail.reason).toBe('stop-phrase')
+
+      setupWindow()
+      await handler(
+        { ...baseConfig, action: 'start', autoRestart: false, submitPhrases: ['send it'] },
+        {}
+      )
+      instances[0].onresult!(result('a question send it', true))
+      expect(ends()[0].detail.reason).toBe('submit-phrase')
+    })
+
+    const phraseConfig = {
+      ...baseConfig,
+      action: 'start',
+      autoRestart: false,
+      stopPhrases: ['stop listening', 'stop'],
+      submitPhrases: ['send the message', 'send it', 'send'],
+    }
+
+    it('stops the session when a stop phrase ends a settled result', async () => {
+      await handler(phraseConfig, {})
+      instances[0].onresult!(result('remind me to call the vet stop listening', true))
+
+      expect(instances[0].stop).toHaveBeenCalled()
+      expect(ends()).toHaveLength(1)
+      expect(ends()[0].detail.reason).toBe('stop-phrase')
+      expect(ends()[0].detail.matchedPhrase).toBe('stop listening')
+    })
+
+    it('reports the submit reason for a send phrase, so a workflow can act', async () => {
+      await handler(phraseConfig, {})
+      instances[0].onresult!(result('what are your opening hours send it', true))
+
+      expect(ends()[0].detail.reason).toBe('submit-phrase')
+      expect(ends()[0].detail.matchedPhrase).toBe('send it')
+    })
+
+    it('cuts the command out of every emitted text, end event included', async () => {
+      await handler(phraseConfig, {})
+      instances[0].onresult!(result('what are your opening hours send it', true))
+
+      expect(results()[results().length - 1].detail.text).toBe('what are your opening hours')
+      expect(ends()[0].detail.text).toBe('what are your opening hours')
+    })
+
+    it('hides the command word on an interim WITHOUT acting on it', async () => {
+      await handler(phraseConfig, {})
+      instances[0].onresult!(result('what are your opening hours send it', false))
+
+      expect(results()[0].detail.text).toBe('what are your opening hours')
+      expect(instances[0].stop).not.toHaveBeenCalled()
+      expect(ends()).toHaveLength(0)
+    })
+
+    it('prefers the longest phrase, so a shorter one cannot strand words', async () => {
+      await handler(phraseConfig, {})
+      instances[0].onresult!(result('book me a table stop listening', true))
+
+      expect(ends()[0].detail.text).toBe('book me a table')
+    })
+
+    it('only matches at a word boundary and only at the end', async () => {
+      await handler(phraseConfig, {})
+      instances[0].onresult!(result('please tell me what to enclose', true))
+      instances[0].onresult!(result('how do I stop my subscription', true))
+
+      expect(instances[0].stop).not.toHaveBeenCalled()
+      expect(ends()).toHaveLength(0)
+    })
+
+    it('treats a submit that leaves nothing behind as a plain stop', async () => {
+      await handler(phraseConfig, {})
+      instances[0].onresult!(result('send it', true))
+
+      expect(ends()[0].detail.reason).toBe('stop-phrase')
+      expect(ends()[0].detail.text).toBe('')
+    })
+
+    it('keeps the message’s own punctuation, dropping only the separator', async () => {
+      await handler(phraseConfig, {})
+      instances[0].onresult!(result('what time do you open? send it.', true))
+
+      expect(ends()[0].detail.text).toBe('what time do you open?')
+    })
+
+    it('does nothing at all when no phrases are configured', async () => {
+      await handler({ ...baseConfig, action: 'start', autoRestart: false }, {})
+      instances[0].onresult!(result('please send it', true))
+
+      expect(instances[0].stop).not.toHaveBeenCalled()
+      expect(results()[0].detail.text).toBe('please send it')
+    })
+
+    it('appends to text already in the field without matching against it', async () => {
+      await handler({ ...phraseConfig, initialText: 'draft: send' }, {})
+      instances[0].onresult!(result('and the rest send it', true))
+
+      // The typed "send" is not a command — only what was SPOKEN is matched.
+      expect(ends()[0].detail.text).toBe('draft: send and the rest')
+    })
+  })
+})

--- a/packages/teleport-plugin-next-workflows/__tests__/custom-event-component-scope.test.ts
+++ b/packages/teleport-plugin-next-workflows/__tests__/custom-event-component-scope.test.ts
@@ -1,0 +1,143 @@
+// A custom-event workflow bound to a component must be emitted INTO that
+// component, not into the global workflow module.
+//
+// This is what makes the AI chat's dictation work: the transcript arrives as a
+// custom event, and the workflow that consumes it writes `chatInputValue` — a
+// component-local state. A global workflow is emitted into a module that owns no
+// state setters, so that write would warn and no-op, and the field would never
+// fill in. The routing below is the guarantee that cannot happen.
+
+import { createNextWorkflowPlugin } from '../src/workflow-component-plugin'
+
+const customEventWorkflow = (config: Record<string, unknown>, scope: string) => ({
+  id: 'wf-dictation-result',
+  name: 'Insert Dictated Chat Text',
+  trigger: {
+    type: 'event-custom-triggered',
+    nodeId: 'trigger-custom-event',
+    scope,
+    config,
+  },
+  nodes: [
+    {
+      id: 'update-1',
+      type: 'state-update-local-state',
+      config: {
+        property: 'chatInputValue',
+        value: {
+          type: 'workflowContext',
+          nodeId: 'trigger-custom-event',
+          path: ['trigger-custom-event', 'eventData', 'text'],
+        },
+      },
+      stepNumber: 1,
+      label: 'Store Dictated Text',
+    },
+  ],
+  edges: [{ id: 'e1', source: 'trigger-custom-event', target: 'update-1' }],
+})
+
+// `any` because the chunk is a hand-written Babel AST fragment, not a value
+// produced by @babel/types' builders.
+const jsxComponentChunk = (): any => ({
+  type: 'chunk-type-ast',
+  name: 'jsx-component',
+  content: {
+    type: 'VariableDeclaration',
+    declarations: [
+      {
+        type: 'VariableDeclarator',
+        init: {
+          type: 'ArrowFunctionExpression',
+          body: { type: 'BlockStatement', body: [{ type: 'ReturnStatement', argument: null }] },
+        },
+      },
+    ],
+  },
+})
+
+const getWorkflowModule = async (
+  uidl: Record<string, unknown>,
+  workflow: any,
+  isPage: boolean
+): Promise<string | null> => {
+  const plugin = createNextWorkflowPlugin({ isPage })
+  const structure: any = {
+    uidl: {
+      node: { type: 'element', content: { elementType: 'container', name: 'Container' } },
+      stateDefinitions: { chatInputValue: { type: 'string', defaultValue: '' } },
+      ...uidl,
+    },
+    chunks: [jsxComponentChunk()],
+    options: {
+      workflows: { workflows: { [workflow.id]: workflow }, customNodes: {} },
+    },
+    dependencies: {},
+  }
+  await plugin(structure)
+  const moduleChunk = (structure.chunks as any[]).find((c: any) => c.name === 'workflow-module')
+  return moduleChunk ? String(moduleChunk.content) : null
+}
+
+describe('component-scoped custom-event workflows', () => {
+  it('registers the listener inside the component it is bound to', async () => {
+    const code = await getWorkflowModule(
+      { name: 'ai-assistant-chat' },
+      customEventWorkflow(
+        {
+          eventName: 'ai-chat-dictation-result',
+          componentId: 'TQ_chat',
+          componentName: 'ai-assistant-chat',
+        },
+        'component'
+      ),
+      false
+    )
+    expect(code).not.toBeNull()
+    expect(code).toContain('workflow:custom:ai-chat-dictation-result')
+    // Registered on mount and torn down on unmount, like every other
+    // component-scoped listener.
+    expect(code).toContain('removeEventListener')
+  })
+
+  it('does NOT leak into an unrelated component', async () => {
+    const code = await getWorkflowModule(
+      { name: 'Footer' },
+      customEventWorkflow(
+        {
+          eventName: 'ai-chat-dictation-result',
+          componentId: 'TQ_chat',
+          componentName: 'ai-assistant-chat',
+        },
+        'component'
+      ),
+      false
+    )
+    expect(code).toBeNull()
+  })
+
+  it('does NOT leak into pages', async () => {
+    const code = await getWorkflowModule(
+      { name: 'ai-assistant-chat', outputOptions: { pageId: 'page-1', fileName: 'home' } },
+      customEventWorkflow(
+        {
+          eventName: 'ai-chat-dictation-result',
+          componentId: 'TQ_chat',
+          componentName: 'ai-assistant-chat',
+        },
+        'component'
+      ),
+      true
+    )
+    expect(code).toBeNull()
+  })
+
+  it('leaves an unbound (global-scoped) custom-event workflow out of the component', async () => {
+    const code = await getWorkflowModule(
+      { name: 'ai-assistant-chat' },
+      customEventWorkflow({ eventName: 'order-placed' }, 'global'),
+      false
+    )
+    expect(code).toBeNull()
+  })
+})

--- a/packages/teleport-plugin-next-workflows/src/api-route-generator.ts
+++ b/packages/teleport-plugin-next-workflows/src/api-route-generator.ts
@@ -975,6 +975,7 @@ const CLIENT_ONLY_NODES = new Set([
   'browser-text-to-speech',
   'browser-get-media-devices',
   'browser-speech-to-text',
+  'browser-speech-recognition',
   'general-trigger-download',
   'general-extract-form-data',
   'general-emit-custom-event',

--- a/packages/teleport-plugin-next-workflows/src/nodes/browser/browser-speech-recognition.ts
+++ b/packages/teleport-plugin-next-workflows/src/nodes/browser/browser-speech-recognition.ts
@@ -1,0 +1,474 @@
+import { NodeHandlerGenerator, handlerToString } from '../types'
+
+/**
+ * A long-lived dictation session, as opposed to `browser-speech-to-text`, which
+ * awaits the FIRST phrase, resolves, and offers no way to stop.
+ *
+ * The contract this node exists for:
+ *
+ *  - It RETURNS IMMEDIATELY. A workflow that awaited the transcript could not
+ *    also run a second workflow to stop the microphone, and the node would hold
+ *    the whole run open for as long as the visitor kept talking.
+ *  - Transcripts leave through CUSTOM EVENTS (`resultEventName`), dispatched on
+ *    the `workflow:custom:` channel that `event-custom-triggered` listens on. A
+ *    workflow bound to that event writes the text into a field, so every
+ *    app-visible effect still belongs to a workflow rather than to this handler.
+ *  - The session registry on `window` — not a page state — is the authority on
+ *    whether the microphone is live, so `action: "toggle"` cannot desync from
+ *    reality no matter how the UI state was left.
+ *
+ * Every exit path ends in exactly one `endEventName` dispatch, including the
+ * ones that never started (unsupported browser, `start()` throwing), so the UI
+ * that turned "listening" on always has something to turn it off again.
+ *
+ * ⛔ NOTHING here is reported as an `error`. The runtime's `isFatalNodeResult`
+ * treats any non-empty `error` string as a FAILED node and aborts the rest of
+ * the workflow — which would skip the very state write that puts the button
+ * back to idle, and would fire the error branch of any workflow that has one.
+ * A browser without the API, or a visitor who declines the microphone, is a
+ * normal outcome of asking, not a failure of the workflow, so it comes back as
+ * `reason` and the caller decides what to say about it.
+ */
+async function browser_speech_recognition(config: any, _context: Record<string, unknown>) {
+  const REGISTRY_KEY = '__teleportSpeechSessions'
+  const DEFAULT_MAX_DURATION_MS = 120000
+  // Chrome ends a "continuous" session after a few seconds of silence, so a
+  // dictation of any length is really a chain of restarts. The cap is what
+  // stops a microphone that can never hear anything (muted device, wrong input)
+  // from restarting forever.
+  const MAX_CONSECUTIVE_RESTARTS = 60
+  // A run shorter than this heard nothing at all; see `onend`.
+  const MIN_USEFUL_RUN_MS = 500
+  const MAX_RAPID_RESTARTS = 5
+  // Errors that mean "this will not work, stop trying" rather than "nothing was
+  // said just now". `no-speech` and `aborted` are ordinary and must NOT be here.
+  const FATAL_ERRORS = ['not-allowed', 'service-not-allowed', 'audio-capture', 'bad-grammar']
+  // ⛔ These two strings are a CONTRACT with the builder repo, where they are
+  // `SPEECH_STOP_PHRASE_REASON` / `SPEECH_SUBMIT_PHRASE_REASON` and are what a
+  // workflow gates its follow-up branch on. The handler is emitted as a
+  // standalone string in a separate repo, so it cannot import them: instead
+  // both sides pin the literal in their own tests, and either one changing the
+  // spelling alone fails there.
+  const STOP_PHRASE_REASON = 'stop-phrase'
+  const SUBMIT_PHRASE_REASON = 'submit-phrase'
+
+  const win: any = typeof window === 'undefined' ? null : window
+  if (!win) {
+    return {
+      listening: false,
+      supported: false,
+      action: 'unchanged',
+      sessionId: '',
+      reason: 'no-window',
+    }
+  }
+
+  const sessions = win[REGISTRY_KEY] || (win[REGISTRY_KEY] = {})
+  const sessionId = String(
+    config.sessionId == null || config.sessionId === '' ? 'default' : config.sessionId
+  )
+  const requested = config.action === 'start' || config.action === 'stop' ? config.action : 'toggle'
+  const resultEventName = typeof config.resultEventName === 'string' ? config.resultEventName : ''
+  const endEventName = typeof config.endEventName === 'string' ? config.endEventName : ''
+  // What the end event reports when THIS call is the thing that stops the
+  // session. A caller that stops for a reason of its own — a spoken "send that",
+  // a navigation, a closing panel — needs the end workflow to be able to tell
+  // that apart from the visitor clicking the microphone off, and the end event
+  // is the only place both arrive.
+  const stopReason =
+    typeof config.stopReason === 'string' && config.stopReason ? config.stopReason : 'stopped'
+
+  const dispatch = (eventName: string, detail: any) => {
+    if (!eventName) {
+      return
+    }
+    try {
+      win.dispatchEvent(new CustomEvent('workflow:custom:' + eventName, { detail }))
+    } catch (e) {
+      /* a listener throwing must never take the session down with it */
+    }
+  }
+
+  const existing = sessions[sessionId]
+  const isListening = !!(existing && existing.active)
+
+  // ── stop ──────────────────────────────────────────────────────────────────
+  if (requested === 'stop' || (requested === 'toggle' && isListening)) {
+    if (!existing) {
+      return {
+        listening: false,
+        supported: true,
+        action: 'unchanged',
+        sessionId,
+        reason: '',
+      }
+    }
+    // Cleared BEFORE `.stop()` so the `onend` that follows finalizes instead of
+    // auto-restarting, and so a second click cannot stop the same session twice.
+    existing.active = false
+    existing.reason = stopReason
+    try {
+      existing.recognition.stop()
+    } catch (e) {
+      // Already stopping, or never started. `onend` may therefore never fire,
+      // so finalize here instead of leaving the UI stuck on "listening".
+      if (existing.finalize) {
+        existing.finalize(stopReason, '')
+      }
+    }
+    return {
+      listening: false,
+      supported: true,
+      action: 'stopped',
+      sessionId,
+      reason: '',
+    }
+  }
+
+  // ── start ─────────────────────────────────────────────────────────────────
+  if (isListening) {
+    // `action: "start"` on a live session: leave it alone rather than replacing
+    // the recogniser, which would drop everything said so far.
+    return {
+      listening: true,
+      supported: true,
+      action: 'unchanged',
+      sessionId,
+      reason: '',
+    }
+  }
+
+  const SpeechRecognition = win.SpeechRecognition || win.webkitSpeechRecognition
+  if (!SpeechRecognition) {
+    // Firefox, and every browser with the API behind a flag. The end event is
+    // still emitted so the caller's "listening" state is turned back off and it
+    // has a `reason` to explain the failure with.
+    dispatch(endEventName, {
+      sessionId,
+      text: typeof config.initialText === 'string' ? config.initialText : '',
+      transcript: '',
+      reason: 'unsupported',
+      error: '',
+      listening: false,
+    })
+    return {
+      listening: false,
+      supported: false,
+      action: 'unchanged',
+      sessionId,
+      reason: 'unsupported',
+    }
+  }
+
+  const baseText = typeof config.initialText === 'string' ? config.initialText : ''
+  const continuous = config.continuous !== false
+  const interimResults = config.interimResults !== false
+  const language =
+    (typeof config.language === 'string' && config.language) ||
+    (win.document && win.document.documentElement && win.document.documentElement.lang) ||
+    'en-US'
+  const autoRestart = config.autoRestart !== false && continuous
+  // Spoken commands. Normalised once, longest first: "stop listening" has to
+  // win over "stop", or the longer spelling leaves "listening" in the field.
+  const toPhraseList = (value: any) =>
+    (Array.isArray(value) ? value : [])
+      .map((entry: any) =>
+        String(entry == null ? '' : entry)
+          .toLowerCase()
+          .trim()
+      )
+      .filter(function (entry: string) {
+        return entry !== ''
+      })
+      .sort(function (a: string, b: string) {
+        return b.length - a.length
+      })
+  const stopPhrases = toPhraseList(config.stopPhrases)
+  const submitPhrases = toPhraseList(config.submitPhrases)
+  const maxDurationMs =
+    typeof config.maxDurationMs === 'number' && config.maxDurationMs > 0
+      ? config.maxDurationMs
+      : DEFAULT_MAX_DURATION_MS
+
+  const session: any = {
+    active: true,
+    startedAt: 0,
+    rapidRestarts: 0,
+    baseText,
+    // Finals from recogniser runs that have already ended. Kept apart from the
+    // current run's finals because a restarted recogniser reports its own
+    // results from index 0 again, so the two cannot share one accumulator.
+    committedText: '',
+    currentFinalText: '',
+    lastEmitted: null,
+    restarts: 0,
+    reason: 'ended',
+    matchedPhrase: '',
+    error: '',
+    finished: false,
+    recognition: null,
+    timer: null,
+    finalize: null,
+  }
+  sessions[sessionId] = session
+
+  // Every seam between two pieces of text needs the same rule: without it,
+  // "hello" typed then "there" spoken comes back as "hellothere".
+  const join = (head: string, tail: string) => {
+    if (!head) {
+      return tail
+    }
+    if (!tail) {
+      return head
+    }
+    return /\s$/.test(head) ? head + tail : head + ' ' + tail
+  }
+
+  /** Everything recognised so far in this session, across restarts. */
+  const spokenSoFar = () => join(session.committedText, session.currentFinalText)
+
+  /** What the target field should now contain. */
+  const compose = (spoken: string) => join(session.baseText, spoken)
+
+  // ── spoken commands ───────────────────────────────────────────────────────
+  // A command is the LAST thing said, so matching is anchored to the end of the
+  // text and to a word boundary — "enclose" is not "close", and "how do I
+  // submit a return" is not a submit. Trailing punctuation is the recogniser's,
+  // never the visitor's: "send it." and "send it" are one instruction.
+  const trimCommandTail = (value: string) => value.replace(/[\s.,!?;:]+$/, '')
+  // ⛔ The MESSAGE keeps its own punctuation. Only the separator between it and
+  // the command goes — the pause comma the recogniser writes for "what time do
+  // you open, send it". Trimming the same set would turn a dictated question
+  // into a statement.
+  const trimSeparator = (value: string) => value.replace(/[\s,;:]+$/, '')
+
+  const matchPhraseAtEnd = (text: string, phrases: string[]) => {
+    const trimmed = trimCommandTail(text)
+    const lower = trimmed.toLowerCase()
+    for (let i = 0; i < phrases.length; i += 1) {
+      const phrase = phrases[i]
+      if (!phrase || lower.length < phrase.length) {
+        continue
+      }
+      if (lower.slice(lower.length - phrase.length) !== phrase) {
+        continue
+      }
+      const head = trimmed.slice(0, trimmed.length - phrase.length)
+      if (head !== '' && !/\s$/.test(head)) {
+        continue
+      }
+      return { phrase, rest: trimSeparator(head) }
+    }
+    return null
+  }
+
+  /**
+   * What the field should show, and what the visitor asked for.
+   *
+   * Stripping runs on EVERY update so the command word is never visible, and is
+   * self-correcting: an interim that revises itself puts the word back on the
+   * next one. Only a settled phrase ACTS, which is what stops a half-spoken
+   * sentence from firing.
+   */
+  const readCommand = (text: string, isFinal: boolean) => {
+    if (stopPhrases.length === 0 && submitPhrases.length === 0) {
+      return { text, action: '', phrase: '' }
+    }
+    let hit = matchPhraseAtEnd(text, submitPhrases)
+    let action = hit ? 'submit' : ''
+    if (!hit) {
+      hit = matchPhraseAtEnd(text, stopPhrases)
+      action = hit ? 'stop' : ''
+    }
+    if (!hit) {
+      return { text, action: '', phrase: '' }
+    }
+    // Nothing left to act on is a plain stop, never an empty submission.
+    if (action === 'submit' && hit.rest.trim() === '') {
+      action = 'stop'
+    }
+    return { text: hit.rest, action: isFinal ? action : '', phrase: hit.phrase }
+  }
+
+  const finalize = (reason: string, error: string, matchedPhrase?: string) => {
+    if (session.finished) {
+      return
+    }
+    session.finished = true
+    session.active = false
+    if (session.timer) {
+      clearTimeout(session.timer)
+      session.timer = null
+    }
+    // ⛔ A session that has been REPLACED must die quietly. `onend` arrives a
+    // task after `.stop()`, so a click landing in that gap starts a fresh
+    // session under the same name — and the old one's end event would then turn
+    // the UI off while the new microphone is live.
+    const isCurrent = sessions[sessionId] === session
+    if (!isCurrent) {
+      return
+    }
+    delete sessions[sessionId]
+    // The command word is cut out here too, so the end event's text is the same
+    // thing the field was left showing.
+    const spoken = readCommand(spokenSoFar(), true)
+    dispatch(endEventName, {
+      sessionId,
+      text: compose(spoken.text),
+      transcript: spoken.text,
+      reason,
+      error,
+      matchedPhrase: matchedPhrase || '',
+      listening: false,
+    })
+  }
+  session.finalize = finalize
+
+  const recognition = new SpeechRecognition()
+  session.recognition = recognition
+  recognition.lang = language
+  recognition.continuous = continuous
+  recognition.interimResults = interimResults
+  if (typeof config.maxAlternatives === 'number' && config.maxAlternatives > 0) {
+    recognition.maxAlternatives = config.maxAlternatives
+  }
+
+  recognition.onresult = (event: any) => {
+    // ⛔ REBUILT from the whole result list, never appended from
+    // `event.resultIndex`. An engine is free to re-report a result that is
+    // already final (Chrome does when a later phrase revises an earlier one),
+    // and an append would then say the same sentence twice. Rebuilding is
+    // idempotent whatever the engine re-sends.
+    let currentFinal = ''
+    let interim = ''
+    const results = event.results || []
+    for (let i = 0; i < results.length; i += 1) {
+      const result = results[i]
+      const alternative = result && result[0]
+      const text =
+        alternative && alternative.transcript ? String(alternative.transcript).trim() : ''
+      if (result && result.isFinal) {
+        currentFinal = join(currentFinal, text)
+      } else {
+        interim = join(interim, text)
+      }
+    }
+    session.currentFinalText = currentFinal
+    const isFinal = !interim
+    const spoken = readCommand(join(spokenSoFar(), interim), isFinal)
+    const composed = compose(spoken.text)
+    // The API re-emits an unchanged interim result several times a second;
+    // without this guard each one would run the consuming workflow again.
+    //
+    // ⛔ Finality is part of the key. The last interim of a phrase almost always
+    // has the SAME text as the final that follows it, so keying on the text
+    // alone swallowed the final event entirely — and a consumer that only acts
+    // on settled speech (a spoken command, a submit) would then never fire.
+    const emissionKey = composed + '\u0000' + (isFinal ? '1' : '0')
+    if (emissionKey !== session.lastEmitted) {
+      session.lastEmitted = emissionKey
+      dispatch(resultEventName, {
+        sessionId,
+        text: composed,
+        transcript: spoken.text,
+        isFinal,
+        listening: true,
+      })
+    }
+
+    if (!spoken.action) {
+      return
+    }
+    // A spoken command ends the session itself. The result event above went out
+    // first and carries the text with the command already cut out, so whatever
+    // writes it into the field has the final value before the end event lands.
+    session.active = false
+    session.reason = spoken.action === 'submit' ? SUBMIT_PHRASE_REASON : STOP_PHRASE_REASON
+    session.matchedPhrase = spoken.phrase
+    try {
+      recognition.stop()
+    } catch (e) {
+      finalize(session.reason, '', spoken.phrase)
+    }
+  }
+
+  recognition.onerror = (event: any) => {
+    const code = (event && event.error) || 'unknown'
+    session.error = code
+    if (FATAL_ERRORS.indexOf(code) >= 0) {
+      session.active = false
+      session.reason = code
+    }
+  }
+
+  recognition.onend = () => {
+    // A run that ended almost as soon as it began never listened to anything —
+    // no microphone, or the speech service unreachable. Restarting those as fast
+    // as the browser allows is a tight loop, so they get a much shorter leash
+    // than the ordinary silence-timeout restarts they are counted apart from.
+    const ranFor = Date.now() - session.startedAt
+    session.rapidRestarts = ranFor < MIN_USEFUL_RUN_MS ? session.rapidRestarts + 1 : 0
+
+    const canRestart =
+      session.active &&
+      autoRestart &&
+      session.restarts < MAX_CONSECUTIVE_RESTARTS &&
+      session.rapidRestarts < MAX_RAPID_RESTARTS &&
+      !(win.document && win.document.hidden)
+    if (!canRestart) {
+      finalize(session.active ? 'ended' : session.reason, session.error, session.matchedPhrase)
+      return
+    }
+    // Bank this run's finals before the recogniser starts numbering from 0
+    // again, and drop the error that ended it — `no-speech` from a pause must
+    // not be reported as the reason the whole session eventually stopped.
+    session.committedText = spokenSoFar()
+    session.currentFinalText = ''
+    session.error = ''
+    session.restarts += 1
+    session.startedAt = Date.now()
+    try {
+      recognition.start()
+    } catch (e) {
+      finalize('ended', session.error)
+    }
+  }
+
+  session.startedAt = Date.now()
+  try {
+    recognition.start()
+  } catch (e) {
+    // `InvalidStateError` from a recogniser the browser still considers running.
+    finalize('start-failed', (e as Error).message || 'start-failed')
+    return {
+      listening: false,
+      supported: true,
+      action: 'unchanged',
+      sessionId,
+      reason: 'start-failed',
+    }
+  }
+
+  session.timer = setTimeout(() => {
+    if (!session.active) {
+      return
+    }
+    session.active = false
+    session.reason = 'timeout'
+    try {
+      recognition.stop()
+    } catch (e) {
+      finalize('timeout', '')
+    }
+  }, maxDurationMs)
+
+  return { listening: true, supported: true, action: 'started', sessionId, reason: '' }
+}
+
+export const browserSpeechRecognition: NodeHandlerGenerator = {
+  nodeType: 'browser-speech-recognition',
+  executionEnv: 'client',
+  generateHandler(): string {
+    return handlerToString(browser_speech_recognition)
+  },
+}

--- a/packages/teleport-plugin-next-workflows/src/nodes/index.ts
+++ b/packages/teleport-plugin-next-workflows/src/nodes/index.ts
@@ -32,6 +32,7 @@ import { browserReadClipboard } from './browser/browser-read-clipboard'
 import { browserShare } from './browser/browser-share'
 import { browserShowNotification } from './browser/browser-show-notification'
 import { browserSpeechToText } from './browser/browser-speech-to-text'
+import { browserSpeechRecognition } from './browser/browser-speech-recognition'
 import { browserSubscribeToPush } from './browser/browser-subscribe-to-push'
 import { browserTextToSpeech } from './browser/browser-text-to-speech'
 import { browserWriteClipboard } from './browser/browser-write-clipboard'
@@ -200,6 +201,7 @@ export const nodeRegistry: Record<string, NodeHandlerGenerator> = {
   'browser-share': browserShare,
   'browser-show-notification': browserShowNotification,
   'browser-speech-to-text': browserSpeechToText,
+  'browser-speech-recognition': browserSpeechRecognition,
   'browser-subscribe-to-push': browserSubscribeToPush,
   'browser-text-to-speech': browserTextToSpeech,
   'browser-write-clipboard': browserWriteClipboard,

--- a/packages/teleport-project-generator-next/__tests__/emitted-components-rules-of-hooks.test.ts
+++ b/packages/teleport-project-generator-next/__tests__/emitted-components-rules-of-hooks.test.ts
@@ -28,6 +28,7 @@ import { generateColorPickerComponentCode } from '../src/widgets/color-picker-co
 import { generateFormFileInputComponentCode } from '../src/widgets/form-file-input-component'
 import { COLLAPSIBLE_TEXT_OVERFLOW_COMPONENT_SOURCE } from '../src/collapsible-text/collapsible-text-overflow-component'
 import { NAV_ACTIVE_LINK_COMPONENT_SOURCE } from '../src/nav-active-link/nav-active-link-component'
+import { generateRichContentEmbedsComponentCode } from '../src/rich-content-embeds/embed-activator-component'
 import { TRACKER_COMPONENT_SOURCE } from '../src/analytics/tracker-component'
 
 const EMITTED_COMPONENTS: Array<[string, string]> = [
@@ -35,6 +36,8 @@ const EMITTED_COMPONENTS: Array<[string, string]> = [
   ['tq-kanban', generateKanbanComponentCode()],
   ['tq-drag-drop', generateDragDropComponentCode()],
   ['rich-text-editor', generateRichTextEditorComponentCode()],
+  ['rich-text-editor (with embeds)', generateRichTextEditorComponentCode({ withEmbeds: true })],
+  ['rich-content-embeds', generateRichContentEmbedsComponentCode()],
   ['tq-motion', generateMotionComponentCode()],
   ['tq-signature', generateSignatureComponentCode()],
   ['tq-categories-filter', generateCategoriesFilterComponentCode()],
@@ -60,7 +63,7 @@ describe('emitted React components obey the Rules of Hooks', () => {
 
   it('covers every component source the generator can emit', () => {
     // A new widget added without a row here would ship unguarded.
-    expect(EMITTED_COMPONENTS).toHaveLength(16)
+    expect(EMITTED_COMPONENTS).toHaveLength(18)
   })
 })
 

--- a/packages/teleport-project-generator-next/__tests__/rich-content-embeds-end2end.test.ts
+++ b/packages/teleport-project-generator-next/__tests__/rich-content-embeds-end2end.test.ts
@@ -1,0 +1,160 @@
+import { GeneratedFolder, ProjectUIDL } from '@teleporthq/teleport-types'
+import { RichTextEmbedsCodegen } from '@teleporthq/teleport-shared'
+import uidlSample from '../../../examples/test-samples/project-sample.json'
+import { createNextProjectGenerator } from '../src'
+import NextTemplate from '../src/project-template'
+import { generateRichTextEditorComponentCode } from '../src/rich-text-editor/component-generator'
+
+const template = JSON.parse(JSON.stringify(NextTemplate)) as GeneratedFolder
+
+/**
+ * The blog post details page's Content node, as the GUI emits it: an
+ * `html-node` whose `html` raw attribute carries a binding to the post's body.
+ * This is the node that becomes `<span dangerouslySetInnerHTML>` — the one
+ * place a code embed's `<script>` cannot run on its own.
+ */
+const BOUND_RICH_TEXT_NODE = {
+  type: 'element',
+  content: {
+    elementType: 'html-node',
+    name: 'Content',
+    children: [],
+    attrs: {
+      html: {
+        type: 'raw',
+        content: '<p>Blog post content...</p>',
+        fallback: '<p>Blog post content...</p>',
+        dynamic: {
+          type: 'dynamic',
+          content: { referenceType: 'prop', id: 'post', refPath: ['content'] },
+        },
+      },
+    },
+  },
+}
+
+/** The admin blog form's Content field, with the embed format enabled. */
+const embedEnabledEditorNode = (formats: string[]) => ({
+  type: 'element',
+  content: {
+    elementType: 'rich-text-editor-node',
+    name: 'ContentRichTextEditor',
+    children: [],
+    attrs: {
+      name: { type: 'static', content: 'content' },
+      quillTheme: { type: 'static', content: 'snow' },
+      quillFormats: { type: 'raw', content: JSON.stringify(formats) },
+      html: { type: 'raw', content: '' },
+    },
+  },
+})
+
+const findFile = (folder: GeneratedFolder, folderName: string, fileName: string) =>
+  folder.subFolders
+    .find((sub) => sub.name === folderName)
+    ?.files.find((file) => file.name === fileName)
+
+const buildUidl = (nodes: unknown[]): ProjectUIDL => {
+  const uidl = JSON.parse(JSON.stringify(uidlSample)) as ProjectUIDL
+  const indexPage = (uidl.root.node.content.children || []).find(
+    (child) =>
+      child.type === 'conditional' && (child.content as { value?: string }).value === 'index'
+  )
+  const pageElement = (indexPage as { content: { node: { content: { children: unknown[] } } } })
+    .content.node.content
+  pageElement.children.push(...nodes)
+  return uidl
+}
+
+describe('Next generator with code embeds in rich-text content', () => {
+  const generator = createNextProjectGenerator()
+
+  it('ships the runtime and mounts the activator for a page that binds rich text', async () => {
+    const outputFolder = await generator.generateProject(
+      buildUidl([BOUND_RICH_TEXT_NODE]),
+      template
+    )
+
+    const runtime = findFile(outputFolder, 'components', 'embed-runtime')
+    expect(runtime?.content).toBe(RichTextEmbedsCodegen.generateEmbedRuntimeModuleSource())
+
+    const activator = findFile(outputFolder, 'components', 'rich-content-embeds')
+    expect(activator?.content).toContain("from './embed-runtime'")
+    expect(activator?.content).toContain('export default RichContentEmbeds')
+
+    const appFile = findFile(outputFolder, 'pages', '_app')
+    expect(appFile?.content).toContain(
+      "import RichContentEmbeds from '../components/rich-content-embeds'"
+    )
+    expect(appFile?.content).toContain('<RichContentEmbeds />')
+  })
+
+  it('leaves the bound content rendering exactly as it did before', async () => {
+    const outputFolder = await generator.generateProject(
+      buildUidl([BOUND_RICH_TEXT_NODE]),
+      template
+    )
+    const indexPage = findFile(outputFolder, 'pages', 'index')
+
+    // The markup is untouched: the activator is additive, so a project that
+    // predates embeds renders byte-for-byte what it always did.
+    expect(indexPage?.content).toContain('dangerouslySetInnerHTML')
+    expect(indexPage?.content).toContain('<p>Blog post content...</p>')
+    expect(indexPage?.content).not.toContain('dangerous-html')
+  })
+
+  it('adds no npm dependency for the embed layer', async () => {
+    const outputFolder = await generator.generateProject(
+      buildUidl([BOUND_RICH_TEXT_NODE]),
+      template
+    )
+    const packageJson = JSON.parse(
+      outputFolder.files.find((file) => file.name === 'package')?.content || '{}'
+    )
+
+    expect(Object.keys(packageJson.dependencies)).not.toContain('dangerous-html')
+    expect(JSON.stringify(packageJson)).not.toContain('embed')
+  })
+
+  it('ships nothing at all for a project with no author-written rich text', async () => {
+    const outputFolder = await generator.generateProject(buildUidl([]), template)
+
+    expect(findFile(outputFolder, 'components', 'embed-runtime')).toBeUndefined()
+    expect(findFile(outputFolder, 'components', 'rich-content-embeds')).toBeUndefined()
+    expect(findFile(outputFolder, 'pages', '_app')?.content).not.toContain('RichContentEmbeds')
+  })
+
+  it('wires the admin editor for embeds when a field enables the format', async () => {
+    const outputFolder = await generator.generateProject(
+      buildUidl([embedEnabledEditorNode(['bold', 'link', 'tq-embed'])]),
+      template
+    )
+
+    const editor = findFile(outputFolder, 'components', 'rich-text-editor')
+    expect(editor?.content).toContain("from './embed-runtime'")
+    expect(editor?.content).toContain('registerEmbedBlot')
+    expect(editor?.content).toContain('EmbedDialog')
+    expect(editor?.content).toContain('normalizeEmbedsInEditorHtml')
+
+    const indexPage = findFile(outputFolder, 'pages', 'index')
+    expect(indexPage?.content).toContain('quillFormats')
+    expect(indexPage?.content).toContain("'tq-embed'")
+
+    // The editor and the activator share one runtime module, shipped once.
+    expect(findFile(outputFolder, 'components', 'embed-runtime')?.content).toBe(
+      RichTextEmbedsCodegen.generateEmbedRuntimeModuleSource()
+    )
+  })
+
+  it('leaves an editor without the format exactly as it was generated before', async () => {
+    const outputFolder = await generator.generateProject(
+      buildUidl([embedEnabledEditorNode(['bold', 'link'])]),
+      template
+    )
+
+    expect(findFile(outputFolder, 'components', 'rich-text-editor')?.content).toBe(
+      generateRichTextEditorComponentCode()
+    )
+    expect(findFile(outputFolder, 'components', 'embed-runtime')).toBeUndefined()
+  })
+})

--- a/packages/teleport-project-generator-next/__tests__/rich-content-embeds-project-plugin.test.ts
+++ b/packages/teleport-project-generator-next/__tests__/rich-content-embeds-project-plugin.test.ts
@@ -1,0 +1,190 @@
+import { parse } from '@babel/parser'
+import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
+import { RichTextEmbeds, RichTextEmbedsCodegen } from '@teleporthq/teleport-shared'
+import {
+  NextRichContentEmbedsProjectPlugin,
+  RICH_CONTENT_EMBEDS_COMPONENT_NAME,
+  RICH_CONTENT_EMBEDS_FILE_NAME,
+} from '../src/rich-content-embeds/project-plugin'
+import { EMBED_RUNTIME_FILE_NAME } from '../src/rich-content-embeds/runtime-module'
+
+const APP_CONTENT = `import '../style.css'
+
+const MyApp = ({ Component, pageProps }) => {
+  return (
+    <Component {...pageProps} />
+  )
+}
+
+export default MyApp
+`
+
+const element = (elementType: string, extra: Record<string, unknown> = {}) => ({
+  type: 'element',
+  content: { elementType, children: [] as unknown[], ...extra },
+})
+
+/** The blog details page's Content node: `html` raw, carrying a ctx binding. */
+const boundRichTextNode = () =>
+  element('html-node', {
+    attrs: {
+      html: {
+        type: 'raw',
+        content: '<p>Blog post content...</p>',
+        fallback: '<p>Blog post content...</p>',
+        dynamic: { type: 'dynamic', content: { referenceType: 'prop', id: 'content' } },
+      },
+    },
+  })
+
+/** A design-time code embed: the same attribute, but with no binding. */
+const staticEmbedNode = () =>
+  element('html-node', {
+    attrs: { html: { type: 'raw', content: '<div>hello</div>' } },
+  })
+
+const makeStructure = (pageChild: unknown): ProjectPluginStructure => {
+  const files = new Map()
+  files.set('_app', {
+    path: ['pages'],
+    files: [{ name: '_app', fileType: FileType.JS, content: APP_CONTENT }],
+  })
+
+  return {
+    uidl: {
+      name: 'test-project',
+      globals: { settings: { title: 'Test', language: 'en' }, assets: [] },
+      root: { node: element('container') },
+      components: {
+        'blog-post-details': { node: element('container', { children: [pageChild] }) },
+      },
+    },
+    files,
+    dependencies: {},
+    devDependencies: {},
+    template: { files: [], subFolders: [] },
+  } as unknown as ProjectPluginStructure
+}
+
+const emittedComponent = (structure: ProjectPluginStructure): string | undefined =>
+  structure.files.get(RICH_CONTENT_EMBEDS_FILE_NAME)?.files[0]?.content as string | undefined
+
+const emittedRuntime = (structure: ProjectPluginStructure): string | undefined =>
+  structure.files.get(EMBED_RUNTIME_FILE_NAME)?.files[0]?.content as string | undefined
+
+const appContent = (structure: ProjectPluginStructure): string =>
+  (structure.files.get('_app')?.files[0]?.content as string) ?? ''
+
+describe('NextRichContentEmbedsProjectPlugin', () => {
+  it('ships the activator and mounts it in _app when a page renders bound rich text', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(boundRichTextNode())
+    )
+
+    expect(emittedComponent(structure)).toContain('export default RichContentEmbeds')
+    expect(appContent(structure)).toContain(
+      `import ${RICH_CONTENT_EMBEDS_COMPONENT_NAME} from '../components/${RICH_CONTENT_EMBEDS_FILE_NAME}';`
+    )
+    expect(appContent(structure)).toContain(`<${RICH_CONTENT_EMBEDS_COMPONENT_NAME} />`)
+  })
+
+  it('also ships it for CMS rich text rendered through a markdown node', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(element('div', { semanticType: 'markdown-node' }))
+    )
+
+    expect(emittedComponent(structure)).toBeDefined()
+  })
+
+  it('ships nothing for an editor alone — it previews its own embeds', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(element('RichTextEditor', { semanticType: 'rich-text-editor-node' }))
+    )
+
+    expect(emittedComponent(structure)).toBeUndefined()
+  })
+
+  it('ships nothing for a project with no author-written rich text', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(staticEmbedNode())
+    )
+
+    expect(emittedComponent(structure)).toBeUndefined()
+    expect(appContent(structure)).toBe(APP_CONTENT)
+  })
+
+  it('adds no npm dependency', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(boundRichTextNode())
+    )
+
+    expect(structure.dependencies).toEqual({})
+    expect(structure.devDependencies).toEqual({})
+  })
+
+  it('is idempotent — a second pass does not mount the component twice', async () => {
+    const plugin = new NextRichContentEmbedsProjectPlugin()
+    const once = await plugin.runAfter(makeStructure(boundRichTextNode()))
+    const twice = await plugin.runAfter(once)
+
+    expect(appContent(twice).match(/RichContentEmbeds/g)).toHaveLength(2)
+  })
+
+  it('ships the shared runtime module beside the activator', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(boundRichTextNode())
+    )
+
+    expect(emittedRuntime(structure)).toBe(RichTextEmbedsCodegen.generateEmbedRuntimeModuleSource())
+    expect(emittedComponent(structure)).toContain(`from './${EMBED_RUNTIME_FILE_NAME}'`)
+  })
+
+  it('imports only helpers the runtime module actually exports', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(boundRichTextNode())
+    )
+    const source = emittedComponent(structure) as string
+    const runtime = emittedRuntime(structure) as string
+
+    const importBlock = source.match(
+      new RegExp(`import \\{([^}]+)\\} from '\\./${EMBED_RUNTIME_FILE_NAME}'`)
+    )
+    expect(importBlock).not.toBeNull()
+
+    const imported = (importBlock as RegExpMatchArray)[1]
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean)
+    expect(imported.length).toBeGreaterThan(0)
+
+    imported.forEach((name) => {
+      expect(runtime).toMatch(new RegExp(`^export (?:var|function) ${name}\\b`, 'm'))
+    })
+  })
+
+  it('emits a component that parses as a module', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(boundRichTextNode())
+    )
+
+    expect(() =>
+      parse(emittedComponent(structure) as string, { sourceType: 'module', plugins: ['jsx'] })
+    ).not.toThrow()
+  })
+
+  it('never leaves the sandbox flags open to the host page by default', async () => {
+    const structure = await new NextRichContentEmbedsProjectPlugin().runAfter(
+      makeStructure(boundRichTextNode())
+    )
+    const source = emittedComponent(structure) as string
+
+    // `allow-same-origin` may only reach the DOM through the shared resolver,
+    // driven by the per-embed opt-in — never as a literal in the wiring, and
+    // never as the default when the attribute is missing or misspelled.
+    expect(source).not.toContain('allow-same-origin')
+    expect(source).toContain('resolveEmbedSandboxFlags(level)')
+    expect(source).toContain(
+      "block.getAttribute(EMBED_ATTR.SANDBOX) === 'trusted' ? 'trusted' : 'strict'"
+    )
+  })
+})

--- a/packages/teleport-project-generator-next/__tests__/rich-text-editor-embed-format.test.ts
+++ b/packages/teleport-project-generator-next/__tests__/rich-text-editor-embed-format.test.ts
@@ -1,0 +1,233 @@
+import { parse } from '@babel/parser'
+import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
+import { RichTextEmbeds, RichTextEmbedsCodegen } from '@teleporthq/teleport-shared'
+import { NextRichTextEditorProjectPlugin } from '../src/rich-text-editor/project-plugin'
+import { EMBED_RUNTIME_FILE_NAME } from '../src/rich-content-embeds/runtime-module'
+import { generateRichTextEditorComponentCode } from '../src/rich-text-editor/component-generator'
+
+const EMBED_FORMAT = RichTextEmbeds.EMBED_BLOT_NAME
+
+const APP_CONTENT = `import '../style.css'
+
+const MyApp = ({ Component, pageProps }) => {
+  return (
+    <Component {...pageProps} />
+  )
+}
+
+export default MyApp
+`
+
+const editorNode = (formats: string[] | null) => ({
+  type: 'element',
+  content: {
+    elementType: 'RichTextEditor',
+    semanticType: 'rich-text-editor-node',
+    children: [] as unknown[],
+    attrs: {
+      quillTheme: { type: 'static', content: 'snow' },
+      ...(formats ? { quillFormats: { type: 'raw', content: JSON.stringify(formats) } } : {}),
+    },
+  },
+})
+
+const makeStructure = (...nodes: unknown[]): ProjectPluginStructure => {
+  const files = new Map()
+  files.set('_app', {
+    path: ['pages'],
+    files: [{ name: '_app', fileType: FileType.JS, content: APP_CONTENT }],
+  })
+
+  return {
+    uidl: {
+      name: 'test-project',
+      globals: { settings: { title: 'Test', language: 'en' }, assets: [] },
+      root: { node: { type: 'element', content: { elementType: 'container', children: [] } } },
+      components: {
+        'blog-posts-create': {
+          node: { type: 'element', content: { elementType: 'container', children: nodes } },
+        },
+      },
+    },
+    files,
+    dependencies: {},
+    devDependencies: {},
+    template: { files: [], subFolders: [] },
+  } as unknown as ProjectPluginStructure
+}
+
+const editorSource = (structure: ProjectPluginStructure): string =>
+  (structure.files.get('rich-text-editor-component')?.files[0]?.content as string) ?? ''
+
+describe('the embed format on a generated rich-text editor', () => {
+  it('adds the blot, the toolbar entry and the runtime module when a field asks for it', async () => {
+    const structure = await new NextRichTextEditorProjectPlugin().runAfter(
+      makeStructure(editorNode(['bold', 'link', EMBED_FORMAT]))
+    )
+
+    const source = editorSource(structure)
+    expect(source).toContain(`from './${EMBED_RUNTIME_FILE_NAME}'`)
+    expect(source).toContain('registerEmbedBlot')
+    expect(source).toContain(
+      `if (formats.includes("${EMBED_FORMAT}")) mediaGroup.push("${EMBED_FORMAT}")`
+    )
+    expect(source).toContain('EmbedDialog')
+    expect(structure.files.get(EMBED_RUNTIME_FILE_NAME)?.files[0]?.content).toBe(
+      RichTextEmbedsCodegen.generateEmbedRuntimeModuleSource()
+    )
+  })
+
+  it('leaves the editor exactly as before for a project with no embed field', async () => {
+    const structure = await new NextRichTextEditorProjectPlugin().runAfter(
+      makeStructure(editorNode(['bold', 'link']))
+    )
+
+    expect(editorSource(structure)).toBe(generateRichTextEditorComponentCode())
+    expect(structure.files.has(EMBED_RUNTIME_FILE_NAME)).toBe(false)
+  })
+
+  it('treats a field with no explicit formats as not asking for embeds', async () => {
+    const structure = await new NextRichTextEditorProjectPlugin().runAfter(
+      makeStructure(editorNode(null))
+    )
+
+    expect(editorSource(structure)).toBe(generateRichTextEditorComponentCode())
+  })
+
+  it('turns embeds on for the whole editor when any one field asks for them', async () => {
+    const structure = await new NextRichTextEditorProjectPlugin().runAfter(
+      makeStructure(editorNode(['bold']), editorNode(['bold', EMBED_FORMAT]))
+    )
+
+    expect(editorSource(structure)).toContain('registerEmbedBlot')
+  })
+
+  it('still adds the Quill dependencies and the CSS import', async () => {
+    const structure = await new NextRichTextEditorProjectPlugin().runAfter(
+      makeStructure(editorNode(['bold', EMBED_FORMAT]))
+    )
+
+    expect(structure.dependencies['react-quill-new']).toBe('^3.0.0')
+    expect(structure.dependencies.quill).toBe('^2.0.0')
+    expect(structure.files.get('_app')?.files[0]?.content).toContain(
+      "import 'quill/dist/quill.snow.css';"
+    )
+  })
+
+  it('emits an editor that parses in both shapes', () => {
+    expect(() =>
+      parse(generateRichTextEditorComponentCode(), { sourceType: 'module', plugins: ['jsx'] })
+    ).not.toThrow()
+    expect(() =>
+      parse(generateRichTextEditorComponentCode({ withEmbeds: true }), {
+        sourceType: 'module',
+        plugins: ['jsx'],
+      })
+    ).not.toThrow()
+  })
+
+  it('imports only helpers the runtime module exports', () => {
+    const source = generateRichTextEditorComponentCode({ withEmbeds: true })
+    const runtime = RichTextEmbedsCodegen.generateEmbedRuntimeModuleSource()
+
+    const block = source.match(
+      new RegExp(`import \\{([^}]+)\\} from '\\./${EMBED_RUNTIME_FILE_NAME}'`)
+    )
+    expect(block).not.toBeNull()
+
+    const imported = (block as RegExpMatchArray)[1]
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean)
+    expect(imported.length).toBeGreaterThan(0)
+
+    imported.forEach((name) => {
+      expect(runtime).toMatch(new RegExp(`^export (?:var|function) ${name}\\b`, 'm'))
+      // An import nothing calls is dead weight in every generated project.
+      expect(source.split(name).length).toBeGreaterThan(2)
+    })
+  })
+
+  it('normalizes the preview back out of the value before onChange sees it', () => {
+    const source = generateRichTextEditorComponentCode({ withEmbeds: true })
+
+    expect(source).toContain('normalizeEmbedsInEditorHtml(html)')
+    expect(source).toContain('normalizeEmbedsForStorage(holder)')
+    // The preview is a SIBLING of the block; mounting it inside the frame would
+    // put it in the database.
+    expect(source).toContain('block.appendChild(host)')
+  })
+})
+
+/*
+ * Three defects found by driving the generated admin panel in a browser. Each
+ * is invisible in the emitted source unless you know what to look for, and each
+ * breaks the editor in a way that looks like a different bug entirely.
+ */
+describe('the generated editor survives being driven', () => {
+  const source = generateRichTextEditorComponentCode({ withEmbeds: true })
+  const plain = generateRichTextEditorComponentCode()
+
+  /*
+   * `next/dynamic` attaches a `ref` to its OWN loadable wrapper, so a `ref` on
+   * <ReactQuill> never reaches the editor: `quillRef.current.getEditor` is
+   * undefined, the insert returns early and the dialog closes having done
+   * nothing at all.
+   */
+  it('hands the ref to the editor through a prop, since next/dynamic keeps the ref', () => {
+    expect(source).toContain('const QuillWithRef = (props) => {')
+    expect(source).toContain('const { forwardedRef, ...editorProps } = props')
+    expect(source).toContain('<Editor ref={forwardedRef} {...editorProps} />')
+    expect(source).toContain('forwardedRef={attachEditor}')
+    // The ref that never arrived must not be written on the dynamic component.
+    expect(source).not.toMatch(/<ReactQuill\s+ref=\{/)
+  })
+
+  /*
+   * react-quill rebuilds the editor whenever `modules` is not deep-equal to the
+   * previous one, and its comparison holds functions to reference equality. A
+   * page emits `quillFormats` as a fresh array literal every render, so a memo
+   * keyed on the array rebuilt the handlers object — and Quill with it — on
+   * every keystroke, taking the caret and the scroll position along.
+   */
+  it('keeps modules stable across renders, so typing cannot rebuild the editor', () => {
+    expect(source).toContain(
+      "const formatsKey = Array.isArray(formats) ? formats.join('\\u0000') : String(formats)"
+    )
+    expect(source).toContain('useMemo(() => buildToolbarFromFormats(formats), [formatsKey])')
+    expect(source).toContain(
+      'const openEmbedDialog = useCallback(() => setEmbedDialogOpen(true), [])'
+    )
+    expect(source).toContain('}, [toolbar, embedsEnabled, openEmbedDialog])')
+    // An inline handler here is what made the object differ every render.
+    expect(source).not.toMatch(/handlers: \{\s*"tq-embed": \(\) =>/)
+  })
+
+  /*
+   * The STORED value has previews and activation markers stripped, so it is
+   * never byte-identical to the html the editor emitted — and react-quill
+   * replaces the whole document whenever the `value` prop differs from what it
+   * last produced. Handing the editor its own html back is what stops that.
+   */
+  it('feeds the editor its own html when the form echoes the normalized value', () => {
+    expect(source).toContain('const lastEmittedRef = useRef({ raw: null, stored: null })')
+    expect(source).toContain('lastEmittedRef.current = { raw: html, stored: stored }')
+    expect(source).toContain(
+      'lastEmitted.stored !== null && incoming === lastEmitted.stored ? lastEmitted.raw : incoming'
+    )
+    expect(source).toContain('value={editorValue}')
+  })
+
+  it('mounts previews once the async editor exists, not only when the value changes', () => {
+    expect(source).toContain('const [isEditorReady, setEditorReady] = useState(false)')
+    expect(source).toContain('setEditorReady(!!instance)')
+    expect(source).toContain('}, [embedsEnabled, isEditorReady, value, getEditor])')
+  })
+
+  it('leaves an editor without embeds untouched by any of it', () => {
+    expect(plain).not.toContain('forwardedRef')
+    expect(plain).not.toContain('formatsKey')
+    expect(plain).not.toContain('lastEmittedRef')
+    expect(plain).not.toContain('isEditorReady')
+  })
+})

--- a/packages/teleport-project-generator-next/src/index.ts
+++ b/packages/teleport-project-generator-next/src/index.ts
@@ -46,6 +46,7 @@ import { NextEcommerceProjectPlugin } from './ecommerce/project-plugin'
 import { NextDashboardLayoutPlugin } from './dashboard-layout-plugin'
 import { createEntityMutationSsrFinalizerPlugin } from './entity-mutation-ssr-finalize-plugin'
 import { NextRichTextEditorProjectPlugin } from './rich-text-editor/project-plugin'
+import { NextRichContentEmbedsProjectPlugin } from './rich-content-embeds/project-plugin'
 import { createRichTextEditorComponentPlugin } from './rich-text-editor/component-plugin'
 import { NextCalendarKitProjectPlugin } from './calendar/project-plugin'
 import { NextDragDropProjectPlugin } from './drag-drop/project-plugin'
@@ -97,6 +98,7 @@ export const createNextProjectPlugins = (): ProjectPlugin[] => [
   new NextCollapsibleTextProjectPlugin(),
   new NextDashboardLayoutPlugin(),
   new NextRichTextEditorProjectPlugin(),
+  new NextRichContentEmbedsProjectPlugin(),
   new NextCalendarKitProjectPlugin(),
   new NextDragDropProjectPlugin(),
   new NextKanbanProjectPlugin(),
@@ -279,6 +281,8 @@ export { NextDashboardLayoutPlugin } from './dashboard-layout-plugin'
 export { createEntityMutationSsrFinalizerPlugin } from './entity-mutation-ssr-finalize-plugin'
 export { NextRichTextEditorProjectPlugin } from './rich-text-editor/project-plugin'
 export { createRichTextEditorComponentPlugin } from './rich-text-editor/component-plugin'
+export { NextRichContentEmbedsProjectPlugin } from './rich-content-embeds/project-plugin'
+export { generateRichContentEmbedsComponentCode } from './rich-content-embeds/embed-activator-component'
 export { NextCalendarKitProjectPlugin } from './calendar/project-plugin'
 export { CALENDARKIT_CSS, CALENDARKIT_VERSION } from './calendar/calendarkit-css'
 export { NextDragDropProjectPlugin } from './drag-drop/project-plugin'

--- a/packages/teleport-project-generator-next/src/rich-content-embeds/embed-activator-component.ts
+++ b/packages/teleport-project-generator-next/src/rich-content-embeds/embed-activator-component.ts
@@ -1,0 +1,202 @@
+import { EMBED_RUNTIME_FILE_NAME } from './runtime-module'
+
+/**
+ * Source of the generated `components/rich-content-embeds.js` — a
+ * null-rendering client component, mounted once in `_app`, that brings code
+ * embeds inside rich-text CONTENT to life.
+ *
+ * Why it has to exist at all: a content column bound into a page is emitted as
+ * `<span dangerouslySetInnerHTML={{ __html: post.content }} />`. That renders an
+ * `<iframe>` perfectly well, but it can never run a `<script>` —
+ * innerHTML-inserted scripts are inert by specification. So an embed is stored
+ * in one of two shapes (see `components/embed-runtime.js`):
+ *
+ *   - `inline`  — passive markup, already in the page, nothing to do here. It
+ *                 renders server-side and works with JavaScript disabled.
+ *   - `sandbox` — the markup is base64-encoded on the element and this
+ *                 component mounts it inside a sandboxed iframe, so
+ *                 author-supplied JavaScript runs in an opaque origin and can
+ *                 never reach the hosting page.
+ *
+ * Everything that decides BEHAVIOUR — the sandbox flags, the document handed to
+ * the frame, the height protocol and its bounds — comes from the shared runtime
+ * module. Only the wiring is written here, and three parts of it are
+ * load-bearing:
+ *   - a mutation observer, because content arrives after the first paint and
+ *     React replaces the whole `innerHTML` when the post changes, taking every
+ *     mounted iframe with it;
+ *   - a `routeChangeComplete` hook, for a client-side navigation between posts;
+ *   - an `activated` marker per block, so the two firing together mount once.
+ */
+export const generateRichContentEmbedsComponentCode = (): string => {
+  return `import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import {
+  EMBED_ATTR,
+  EMBED_FRAME_CLASS_NAME,
+  EMBED_INITIAL_HEIGHT,
+  buildEmbedSandboxDocument,
+  createEmbedToken,
+  parseEmbedHeightMessage,
+  readEncodedEmbedCode,
+  resolveEmbedSandboxFlags,
+} from './${EMBED_RUNTIME_FILE_NAME}'
+
+// Tokens this page minted, mapped to the frame that owns them. A sandboxed
+// frame has an opaque origin, so \`event.origin\` cannot identify it — matching
+// on a token generated here is what makes the height message safe to act on.
+const framesByToken = {}
+
+/**
+ * Frames go away with the content that held them and never report again, so
+ * their tokens are dropped on the next pass rather than accumulating for the
+ * life of the session.
+ */
+function pruneDetachedFrames() {
+  Object.keys(framesByToken).forEach(function (token) {
+    if (!framesByToken[token].isConnected) {
+      delete framesByToken[token]
+    }
+  })
+}
+
+function readRatio(block) {
+  const raw = block.getAttribute(EMBED_ATTR.RATIO)
+  const parsed = raw === null ? NaN : parseFloat(raw)
+  return isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function applyHeightMessage(data) {
+  const message = parseEmbedHeightMessage(data)
+  if (!message) {
+    return
+  }
+  const frame = framesByToken[message.token]
+  if (!frame) {
+    return
+  }
+  if (!frame.isConnected) {
+    delete framesByToken[message.token]
+    return
+  }
+  frame.style.height = message.height + 'px'
+}
+
+function mountSandboxedEmbed(block) {
+  const code = readEncodedEmbedCode(block)
+  if (!code) {
+    return
+  }
+
+  const host = block.querySelector('.' + EMBED_FRAME_CLASS_NAME)
+  if (!host) {
+    return
+  }
+
+  const token = createEmbedToken()
+  const ratio = readRatio(block)
+  const level = block.getAttribute(EMBED_ATTR.SANDBOX) === 'trusted' ? 'trusted' : 'strict'
+
+  const frame = document.createElement('iframe')
+  frame.setAttribute('sandbox', resolveEmbedSandboxFlags(level))
+  frame.setAttribute('loading', 'lazy')
+  frame.setAttribute('title', block.getAttribute(EMBED_ATTR.CAPTION) || 'Embedded content')
+  frame.setAttribute('scrolling', 'no')
+  // A ratio means the block already reserves the space, so the frame just fills
+  // it and never needs to report a height. Without one the frame starts at a
+  // neutral height and grows to whatever it reports back.
+  frame.style.cssText = ratio
+    ? 'position:absolute;top:0;left:0;width:100%;height:100%;border:0'
+    : 'display:block;width:100%;border:0;height:' + EMBED_INITIAL_HEIGHT + 'px'
+
+  if (!ratio) {
+    framesByToken[token] = frame
+  }
+
+  // The <noscript> fallback has done its job by the time we get here.
+  host.textContent = ''
+  host.appendChild(frame)
+  frame.srcdoc = buildEmbedSandboxDocument(code, token)
+}
+
+function activateEmbeds() {
+  pruneDetachedFrames()
+
+  let blocks
+  try {
+    // Only what still needs mounting: the pass then costs nothing once every
+    // block is handled, and re-entering from the observer settles immediately.
+    blocks = document.querySelectorAll(
+      '[' + EMBED_ATTR.MARKER + ']:not([' + EMBED_ATTR.ACTIVATED + '])'
+    )
+  } catch (err) {
+    return
+  }
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]
+    // Marked before the work, not after: mounting the iframe is itself a
+    // mutation the observer sees, and an unmarked block would be picked up
+    // again on that pass.
+    block.setAttribute(EMBED_ATTR.ACTIVATED, '1')
+
+    if (block.getAttribute(EMBED_ATTR.MODE) !== 'sandbox') {
+      continue
+    }
+    try {
+      mountSandboxedEmbed(block)
+    } catch (err) {
+      // One broken embed must never take the page down with it.
+    }
+  }
+}
+
+const RichContentEmbeds = () => {
+  const router = useRouter()
+
+  useEffect(() => {
+    let frame = 0
+    const schedule = () => {
+      if (frame) {
+        return
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = 0
+        activateEmbeds()
+      })
+    }
+
+    const onMessage = (event) => {
+      applyHeightMessage(event.data)
+    }
+
+    activateEmbeds()
+    window.addEventListener('message', onMessage)
+
+    let observer = null
+    if (typeof MutationObserver === 'function' && document.body) {
+      observer = new MutationObserver(schedule)
+      observer.observe(document.body, { childList: true, subtree: true })
+    }
+
+    router.events.on('routeChangeComplete', schedule)
+
+    return () => {
+      if (frame) {
+        window.cancelAnimationFrame(frame)
+      }
+      window.removeEventListener('message', onMessage)
+      if (observer) {
+        observer.disconnect()
+      }
+      router.events.off('routeChangeComplete', schedule)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return null
+}
+
+export default RichContentEmbeds
+`
+}

--- a/packages/teleport-project-generator-next/src/rich-content-embeds/project-plugin.ts
+++ b/packages/teleport-project-generator-next/src/rich-content-embeds/project-plugin.ts
@@ -1,0 +1,92 @@
+import {
+  FileType,
+  ProjectPlugin,
+  ProjectPluginStructure,
+  UIDLElement,
+  UIDLRawValue,
+} from '@teleporthq/teleport-types'
+import { traverseProjectElements } from '../uidl-element-traversal'
+import { injectSiblingIntoApp } from '../app-sibling-injection'
+import { generateRichContentEmbedsComponentCode } from './embed-activator-component'
+import { ensureEmbedRuntimeModule } from './runtime-module'
+
+export const RICH_CONTENT_EMBEDS_COMPONENT_NAME = 'RichContentEmbeds'
+export const RICH_CONTENT_EMBEDS_FILE_NAME = 'rich-content-embeds'
+
+/**
+ * True for the elements that DISPLAY author-written rich text at runtime, which
+ * is the only place a stored code embed can surface:
+ *
+ *  - a `markdown-node`, which renders CMS rich text through `<Markdown>`;
+ *  - any element with a raw attribute carrying a DYNAMIC reference — the blog
+ *    post body, a product description, the admin detail panel. That is the node
+ *    `applyDynamicHtmlInjection` turns into `<span dangerouslySetInnerHTML>`,
+ *    the one path where an embed's `<script>` can never run on its own.
+ *
+ * A `rich-text-editor-node` is deliberately NOT a trigger: it is an editor, and
+ * the generated editor previews its own embeds (see the rich-text-editor
+ * plugin). The page that reads that content back is the one that needs this.
+ */
+const rendersAuthoredRichText = (element: UIDLElement): boolean => {
+  if (element.elementType === 'markdown-node' || element.semanticType === 'markdown-node') {
+    return true
+  }
+
+  const attrs = element.attrs
+  if (!attrs) {
+    return false
+  }
+  return Object.keys(attrs).some((key) => {
+    const value = attrs[key]
+    return value?.type === 'raw' && !!(value as UIDLRawValue).dynamic
+  })
+}
+
+const projectRendersAuthoredRichText = (uidl: ProjectPluginStructure['uidl']): boolean => {
+  let found = false
+  traverseProjectElements(uidl, (element) => {
+    if (!found && rendersAuthoredRichText(element)) {
+      found = true
+    }
+  })
+  return found
+}
+
+/**
+ * Ships the code-embed runtime with any project that renders author-written
+ * rich text. Purely additive: no mapping, no emitted markup and no npm
+ * dependency changes — a project without rich text gets nothing at all.
+ */
+export class NextRichContentEmbedsProjectPlugin implements ProjectPlugin {
+  async runBefore(structure: ProjectPluginStructure): Promise<ProjectPluginStructure> {
+    return structure
+  }
+
+  async runAfter(structure: ProjectPluginStructure): Promise<ProjectPluginStructure> {
+    const { uidl, files } = structure
+
+    if (!projectRendersAuthoredRichText(uidl)) {
+      return structure
+    }
+
+    ensureEmbedRuntimeModule(structure)
+
+    files.set(RICH_CONTENT_EMBEDS_FILE_NAME, {
+      path: ['components'],
+      files: [
+        {
+          name: RICH_CONTENT_EMBEDS_FILE_NAME,
+          fileType: FileType.JS,
+          content: generateRichContentEmbedsComponentCode(),
+        },
+      ],
+    })
+
+    injectSiblingIntoApp(structure, {
+      componentName: RICH_CONTENT_EMBEDS_COMPONENT_NAME,
+      importStatement: `import ${RICH_CONTENT_EMBEDS_COMPONENT_NAME} from '../components/${RICH_CONTENT_EMBEDS_FILE_NAME}';\n`,
+    })
+
+    return structure
+  }
+}

--- a/packages/teleport-project-generator-next/src/rich-content-embeds/runtime-module.ts
+++ b/packages/teleport-project-generator-next/src/rich-content-embeds/runtime-module.ts
@@ -1,0 +1,32 @@
+import { FileType, ProjectPluginStructure } from '@teleporthq/teleport-types'
+import { RichTextEmbedsCodegen } from '@teleporthq/teleport-shared'
+
+/** `components/embed-runtime.js` — the shared half of the code-embed feature. */
+export const EMBED_RUNTIME_FILE_NAME = 'embed-runtime'
+
+/**
+ * Writes the embed runtime module into the project, once. Both the activator
+ * (which mounts sandboxed embeds on a rendered page) and the rich-text editor
+ * (which creates them) import it, so whichever project plugin runs first puts
+ * it there and the second one finds it already present.
+ *
+ * The module is EMITTED from `@teleporthq/teleport-shared` rather than written
+ * out here, so a provider added to the registry reaches the generated project
+ * and the studio editor in the same commit.
+ */
+export const ensureEmbedRuntimeModule = (structure: ProjectPluginStructure): void => {
+  if (structure.files.has(EMBED_RUNTIME_FILE_NAME)) {
+    return
+  }
+
+  structure.files.set(EMBED_RUNTIME_FILE_NAME, {
+    path: ['components'],
+    files: [
+      {
+        name: EMBED_RUNTIME_FILE_NAME,
+        fileType: FileType.JS,
+        content: RichTextEmbedsCodegen.generateEmbedRuntimeModuleSource(),
+      },
+    ],
+  })
+}

--- a/packages/teleport-project-generator-next/src/rich-text-editor/component-generator.ts
+++ b/packages/teleport-project-generator-next/src/rich-text-editor/component-generator.ts
@@ -1,18 +1,81 @@
+import { RichTextEmbeds } from '@teleporthq/teleport-shared'
+import { EMBED_RUNTIME_IMPORT, EMBED_SUPPORT_SOURCE } from './embed-support-source'
+
+interface RichTextEditorOptions {
+  /**
+   * Emit the code-embed blot, preview and dialog. Off unless a rich-text field
+   * in the project actually enables the `tq-embed` format, so an editor that
+   * does not offer embeds is generated exactly as it always was.
+   */
+  withEmbeds?: boolean
+}
+
 /**
  * Generates the RichTextEditor wrapper component source code.
  *
  * The component uses `react-quill-new` via `next/dynamic` to avoid SSR issues
  * (Quill accesses `document`). It builds a Quill toolbar configuration from the
  * `quillFormats` prop and supports both the "snow" and "bubble" themes.
+ *
+ * With embeds enabled it also registers the `tq-embed` block blot, adds the
+ * toolbar button that opens the embed dialog, previews sandboxed embeds beside
+ * their block, and normalizes those previews back out of the value before it
+ * reaches `onChange`.
  */
-export const generateRichTextEditorComponentCode = (): string => {
-  return `import { useMemo } from 'react'
-import dynamic from 'next/dynamic'
+export const generateRichTextEditorComponentCode = (
+  options: RichTextEditorOptions = {}
+): string => {
+  const { withEmbeds = false } = options
+  const embedBlotName = RichTextEmbeds.EMBED_BLOT_NAME
 
-const ReactQuill = dynamic(() => import('react-quill-new'), {
+  const imports = withEmbeds
+    ? `import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
+${EMBED_RUNTIME_IMPORT}`
+    : `import { useMemo } from 'react'
+import dynamic from 'next/dynamic'
+`
+
+  // The blot has to exist before Quill parses any content, so registration
+  // rides the same dynamic import that loads the editor.
+  const quillImport = withEmbeds
+    ? `const ReactQuill = dynamic(
+  async () => {
+    const mod = await import('react-quill-new')
+    const Editor = mod.default || mod
+    registerEmbedBlot(mod.Quill || (mod.default && mod.default.Quill))
+    // \`next/dynamic\` attaches a \`ref\` to its OWN loadable wrapper, so a ref
+    // written here never reaches the editor and \`getEditor()\` — the only way to
+    // the Quill instance — is unreachable. Inserting an embed and mounting the
+    // previews both need it, so the ref is handed over as an ordinary prop.
+    const QuillWithRef = (props) => {
+      const { forwardedRef, ...editorProps } = props
+      return <Editor ref={forwardedRef} {...editorProps} />
+    }
+    return QuillWithRef
+  },
+  {
+    ssr: false,
+    loading: () => <div />,
+  }
+)`
+    : `const ReactQuill = dynamic(() => import('react-quill-new'), {
   ssr: false,
   loading: () => <div />,
-})
+})`
+
+  const embedToolbarEntry = withEmbeds
+    ? `  if (formats.includes(${JSON.stringify(embedBlotName)})) mediaGroup.push(${JSON.stringify(
+        embedBlotName
+      )})\n`
+    : ''
+
+  const body = withEmbeds ? richTextEditorWithEmbedsBody(embedBlotName) : richTextEditorPlainBody()
+
+  const preamble = withEmbeds ? `${imports}\n${EMBED_SUPPORT_SOURCE}\n` : imports
+
+  return `${preamble}
+${quillImport}
 
 function buildToolbarFromFormats(formats) {
   if (!formats) {
@@ -77,14 +140,19 @@ function buildToolbarFromFormats(formats) {
   if (formats.includes('image')) mediaGroup.push('image')
   if (formats.includes('video')) mediaGroup.push('video')
   if (formats.includes('formula')) mediaGroup.push('formula')
-  if (mediaGroup.length > 0) toolbar.push(mediaGroup)
+${embedToolbarEntry}  if (mediaGroup.length > 0) toolbar.push(mediaGroup)
 
   toolbar.push(['clean'])
 
   return toolbar
 }
 
-const RichTextEditor = (props) => {
+${body}
+export default RichTextEditor
+`
+}
+
+const richTextEditorPlainBody = (): string => `const RichTextEditor = (props) => {
   const {
     value,
     quillTheme = 'snow',
@@ -118,7 +186,147 @@ const RichTextEditor = (props) => {
     </div>
   )
 }
-
-export default RichTextEditor
 `
+
+const richTextEditorWithEmbedsBody = (
+  embedBlotName: string
+): string => `const RichTextEditor = (props) => {
+  const {
+    value,
+    quillTheme = 'snow',
+    quillFormats,
+    onChange,
+    readOnly = false,
+    ...rest
+  } = props
+
+  const quillRef = useRef(null)
+  const [isEditorReady, setEditorReady] = useState(false)
+  const [isEmbedDialogOpen, setEmbedDialogOpen] = useState(false)
+  const lastEmittedRef = useRef({ raw: null, stored: null })
+
+  // quillFormats: undefined/null → all formats (Quill default)
+  // quillFormats: [] → no formats (plain text)
+  // quillFormats: [...] → specific formats
+  const formats = quillFormats !== undefined ? quillFormats : null
+  const embedsEnabled = Array.isArray(formats) && formats.includes(${JSON.stringify(embedBlotName)})
+
+  // react-quill DESTROYS AND REBUILDS the editor whenever \`modules\` is not
+  // deep-equal to the previous one, and its comparison holds functions to
+  // reference equality. A page renders \`quillFormats\` as a fresh array literal,
+  // so keying the memo on the array itself rebuilt the toolbar — and with it the
+  // handlers object — on every keystroke, taking the caret and the scroll
+  // position with it. The key is the format NAMES, and the handler is made once.
+  const formatsKey = Array.isArray(formats) ? formats.join('\\u0000') : String(formats)
+  const toolbar = useMemo(() => buildToolbarFromFormats(formats), [formatsKey])
+  const openEmbedDialog = useCallback(() => setEmbedDialogOpen(true), [])
+
+  const modules = useMemo(() => {
+    if (toolbar === undefined) {
+      return {}
+    }
+    if (!embedsEnabled || !toolbar) {
+      return { toolbar }
+    }
+    return {
+      toolbar: {
+        container: toolbar,
+        handlers: {
+          ${JSON.stringify(embedBlotName)}: openEmbedDialog,
+        },
+      },
+    }
+  }, [toolbar, embedsEnabled, openEmbedDialog])
+
+  const attachEditor = useCallback((instance) => {
+    quillRef.current = instance
+    setEditorReady(!!instance)
+  }, [])
+
+  const getEditor = useCallback(() => {
+    const instance = quillRef.current
+    return instance && typeof instance.getEditor === 'function' ? instance.getEditor() : null
+  }, [])
+
+  // Content loaded into the editor is PARSED into blots, which never runs the
+  // blot's \`create\`, so previews are mounted from here instead — once the
+  // editor exists, and after every value change.
+  useEffect(() => {
+    if (!embedsEnabled || !isEditorReady) {
+      return
+    }
+    const editor = getEditor()
+    if (editor) {
+      mountEmbedPreviews(editor.root)
+    }
+  }, [embedsEnabled, isEditorReady, value, getEditor])
+
+  useEffect(() => {
+    if (!embedsEnabled) {
+      return undefined
+    }
+    const onMessage = (event) => {
+      applyEmbedHeightMessage(event.data)
+    }
+    window.addEventListener('message', onMessage)
+    return () => {
+      window.removeEventListener('message', onMessage)
+    }
+  }, [embedsEnabled])
+
+  const handleChange = useCallback(
+    (html, delta, source, editor) => {
+      const stored = embedsEnabled ? normalizeEmbedsInEditorHtml(html) : html
+      lastEmittedRef.current = { raw: html, stored: stored }
+      if (!onChange) {
+        return
+      }
+      onChange(stored, delta, source, editor)
+    },
+    [onChange, embedsEnabled]
+  )
+
+  // What is STORED has the previews and their activation markers stripped, so it
+  // is never byte-identical to the html the editor emitted. react-quill compares
+  // the two and replaces the whole document when they differ, which would be
+  // every keystroke once a post holds an embed. When the form is handing back
+  // exactly what this editor last produced, give the editor its own html back.
+  const incoming = value || ''
+  const lastEmitted = lastEmittedRef.current
+  const editorValue =
+    lastEmitted.stored !== null && incoming === lastEmitted.stored ? lastEmitted.raw : incoming
+
+  const insertEmbed = useCallback((embedValue) => {
+    setEmbedDialogOpen(false)
+    const editor = getEditor()
+    if (!editor) {
+      return
+    }
+    const index = embedInsertIndex(editor)
+    editor.insertEmbed(index, ${JSON.stringify(embedBlotName)}, embedValue, 'user')
+    try {
+      editor.setSelection(index + 1, 0, 'silent')
+    } catch (err) {
+      // An edge index can reject a selection; the embed is placed either way.
+    }
+    mountEmbedPreviews(editor.root)
+  }, [getEditor])
+
+  return (
+    <div {...rest}>
+      <ReactQuill
+        forwardedRef={attachEditor}
+        theme={quillTheme}
+        value={editorValue}
+        onChange={handleChange}
+        modules={modules}
+        formats={formats}
+        readOnly={readOnly}
+      />
+      {isEmbedDialogOpen ? (
+        <EmbedDialog onCancel={() => setEmbedDialogOpen(false)} onInsert={insertEmbed} />
+      ) : null}
+    </div>
+  )
 }
+`

--- a/packages/teleport-project-generator-next/src/rich-text-editor/embed-support-source.ts
+++ b/packages/teleport-project-generator-next/src/rich-text-editor/embed-support-source.ts
@@ -1,0 +1,511 @@
+import { EMBED_RUNTIME_FILE_NAME } from '../rich-content-embeds/runtime-module'
+
+/**
+ * The code-embed half of the generated `components/rich-text-editor.js`.
+ *
+ * It is emitted only for projects that actually enable the `tq-embed` format on
+ * a rich-text field, so an editor that does not offer embeds is generated
+ * exactly as before.
+ *
+ * Three pieces:
+ *  - a Quill block-embed blot whose DOM is the STORED shape, built by the
+ *    shared runtime, so what the admin writes is byte-for-byte what the
+ *    published page reads;
+ *  - a preview pass that mounts sandboxed embeds NEXT TO the block rather than
+ *    inside it, because Quill hands its value back as `root.innerHTML` and a
+ *    preview mounted inside would be saved to the database;
+ *  - a dialog with a Link tab (paste a URL, the provider is recognized) and an
+ *    Embed code tab (paste a snippet), plus the caption, width, alignment and
+ *    the same-origin opt-in.
+ */
+
+/** Quill renders toolbar buttons from `ui/icons`; this is the `</>` glyph. */
+const EMBED_TOOLBAR_ICON =
+  '<svg viewBox="0 0 18 18">' +
+  '<polyline class="ql-even ql-stroke" points="5 7 3 9 5 11"></polyline>' +
+  '<polyline class="ql-even ql-stroke" points="13 7 15 9 13 11"></polyline>' +
+  '<line class="ql-stroke" x1="11" x2="7" y1="4" y2="14"></line>' +
+  '</svg>'
+
+export const EMBED_RUNTIME_IMPORT = `import {
+  EMBED_ALIGNMENTS,
+  EMBED_ATTR,
+  EMBED_BLOT_NAME,
+  EMBED_CLASS_NAME,
+  EMBED_INITIAL_HEIGHT,
+  buildEmbedElementHtml,
+  buildEmbedSandboxDocument,
+  buildEmbedHtmlFromUrl,
+  createEmbedToken,
+  createEmbedValue,
+  isSafeEmbedUrl,
+  normalizeEmbedsForStorage,
+  parseEmbedHeightMessage,
+  readEmbedValueFromElement,
+  readEncodedEmbedCode,
+  resolveEmbedSandboxFlags,
+} from './${EMBED_RUNTIME_FILE_NAME}'
+`
+
+export const EMBED_SUPPORT_SOURCE = `const EMBED_ICON = ${JSON.stringify(EMBED_TOOLBAR_ICON)}
+
+// Tokens minted here, mapped to the preview frame that owns them. A sandboxed
+// frame has an opaque origin, so its token is the only safe way to match a
+// height message to the frame that sent it.
+const embedFramesByToken = {}
+let embedBlotRegistered = false
+
+function registerEmbedBlot(Quill) {
+  if (!Quill || embedBlotRegistered) {
+    return
+  }
+  embedBlotRegistered = true
+
+  const BlockEmbed = Quill.import('blots/block/embed')
+
+  class TqEmbedBlot extends BlockEmbed {
+    static create(value) {
+      const holder = document.createElement('div')
+      holder.innerHTML = buildEmbedElementHtml(value)
+      return holder.firstElementChild
+    }
+
+    static value(node) {
+      return readEmbedValueFromElement(node)
+    }
+  }
+
+  TqEmbedBlot.blotName = EMBED_BLOT_NAME
+  TqEmbedBlot.tagName = 'FIGURE'
+  TqEmbedBlot.className = EMBED_CLASS_NAME
+
+  Quill.register(TqEmbedBlot, true)
+  Quill.import('ui/icons')[EMBED_BLOT_NAME] = EMBED_ICON
+}
+
+/**
+ * Previews go away with the content that held them and never report again, so
+ * their tokens are dropped when the next one mounts rather than accumulating
+ * for the life of the editor.
+ */
+function pruneDetachedEmbedFrames() {
+  Object.keys(embedFramesByToken).forEach(function (token) {
+    if (!embedFramesByToken[token].isConnected) {
+      delete embedFramesByToken[token]
+    }
+  })
+}
+
+function readEmbedRatio(block) {
+  const raw = block.getAttribute(EMBED_ATTR.RATIO)
+  const parsed = raw === null ? NaN : parseFloat(raw)
+  return isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+/**
+ * Mounts the sandboxed preview as a SIBLING of the embed block, tagged so
+ * normalizeEmbedsForStorage can strip it back out before the value is saved.
+ */
+function mountEmbedPreview(block) {
+  const code = readEncodedEmbedCode(block)
+  if (!code) {
+    return
+  }
+
+  pruneDetachedEmbedFrames()
+
+  const token = createEmbedToken()
+  const level = block.getAttribute(EMBED_ATTR.SANDBOX) === 'trusted' ? 'trusted' : 'strict'
+  const ratio = readEmbedRatio(block)
+
+  const host = document.createElement('div')
+  host.setAttribute(EMBED_ATTR.PREVIEW, '1')
+  host.setAttribute('contenteditable', 'false')
+  host.style.cssText = ratio
+    ? 'position:relative;width:100%;padding-top:' + ratio + '%'
+    : 'position:relative;width:100%'
+
+  const frame = document.createElement('iframe')
+  frame.setAttribute('sandbox', resolveEmbedSandboxFlags(level))
+  frame.setAttribute('title', block.getAttribute(EMBED_ATTR.CAPTION) || 'Embedded content')
+  frame.setAttribute('scrolling', 'no')
+  frame.style.cssText = ratio
+    ? 'position:absolute;top:0;left:0;width:100%;height:100%;border:0'
+    : 'display:block;width:100%;border:0;height:' + EMBED_INITIAL_HEIGHT + 'px'
+
+  if (!ratio) {
+    embedFramesByToken[token] = frame
+  }
+
+  host.appendChild(frame)
+  block.appendChild(host)
+  frame.srcdoc = buildEmbedSandboxDocument(code, token)
+}
+
+function mountEmbedPreviews(root) {
+  if (!root) {
+    return
+  }
+
+  let blocks
+  try {
+    blocks = root.querySelectorAll(
+      '[' + EMBED_ATTR.MARKER + ']:not([' + EMBED_ATTR.ACTIVATED + '])'
+    )
+  } catch (err) {
+    return
+  }
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]
+    block.setAttribute(EMBED_ATTR.ACTIVATED, '1')
+    if (block.getAttribute(EMBED_ATTR.MODE) !== 'sandbox') {
+      continue
+    }
+    try {
+      mountEmbedPreview(block)
+    } catch (err) {
+      // A preview that cannot mount must not stop the editor from loading.
+    }
+  }
+}
+
+function applyEmbedHeightMessage(data) {
+  const message = parseEmbedHeightMessage(data)
+  if (!message) {
+    return
+  }
+  const frame = embedFramesByToken[message.token]
+  if (!frame) {
+    return
+  }
+  if (!frame.isConnected) {
+    delete embedFramesByToken[message.token]
+    return
+  }
+  frame.style.height = message.height + 'px'
+}
+
+/**
+ * Quill's value is its live root.innerHTML, which by now carries the preview
+ * and the marker that says a block has one. Neither belongs in the database, so
+ * the value is normalized on the way out.
+ */
+function normalizeEmbedsInEditorHtml(html) {
+  if (!html || html.indexOf(EMBED_ATTR.MARKER) === -1) {
+    return html
+  }
+  try {
+    const holder = document.createElement('div')
+    holder.innerHTML = html
+    normalizeEmbedsForStorage(holder)
+    return holder.innerHTML
+  } catch (err) {
+    return html
+  }
+}
+
+/** Inserts at the end of the line the caret is on, never mid-word. */
+function embedInsertIndex(editor) {
+  const selection = editor.getSelection()
+  const end = Math.max(0, editor.getLength() - 1)
+  if (!selection || selection.index < 0) {
+    return end
+  }
+  try {
+    const found = editor.getLine(selection.index)
+    const line = found && found[0]
+    const offset = found && found[1]
+    if (!line) {
+      return end
+    }
+    return Math.min(selection.index - offset + line.length(), end)
+  } catch (err) {
+    return end
+  }
+}
+
+const EMBED_DIALOG_STYLES = {
+  backdrop: {
+    position: 'fixed',
+    inset: 0,
+    background: 'rgba(15, 23, 42, 0.55)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    padding: '16px',
+  },
+  panel: {
+    background: '#fff',
+    borderRadius: '10px',
+    width: '100%',
+    maxWidth: '560px',
+    maxHeight: '90vh',
+    overflowY: 'auto',
+    boxShadow: '0 20px 50px rgba(15, 23, 42, 0.25)',
+    color: '#0f172a',
+    fontSize: '14px',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '16px 20px',
+    borderBottom: '1px solid #e2e8f0',
+    fontWeight: 600,
+  },
+  body: { padding: '20px', display: 'flex', flexDirection: 'column', gap: '14px' },
+  tabs: { display: 'flex', gap: '8px' },
+  tab: {
+    flex: 1,
+    padding: '8px 12px',
+    borderRadius: '6px',
+    border: '1px solid #cbd5f5',
+    background: '#fff',
+    cursor: 'pointer',
+    fontSize: '13px',
+  },
+  activeTab: {
+    flex: 1,
+    padding: '8px 12px',
+    borderRadius: '6px',
+    border: '1px solid #4f46e5',
+    background: '#eef2ff',
+    color: '#4338ca',
+    cursor: 'pointer',
+    fontSize: '13px',
+    fontWeight: 600,
+  },
+  label: { display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '13px' },
+  input: {
+    padding: '8px 10px',
+    border: '1px solid #cbd5f5',
+    borderRadius: '6px',
+    fontSize: '13px',
+    fontFamily: 'inherit',
+  },
+  textarea: {
+    padding: '8px 10px',
+    border: '1px solid #cbd5f5',
+    borderRadius: '6px',
+    fontSize: '12px',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    minHeight: '140px',
+    resize: 'vertical',
+  },
+  row: { display: 'flex', gap: '12px' },
+  hint: { fontSize: '12px', color: '#64748b', lineHeight: 1.5 },
+  error: { fontSize: '12px', color: '#b91c1c' },
+  footer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: '8px',
+    padding: '16px 20px',
+    borderTop: '1px solid #e2e8f0',
+  },
+  cancel: {
+    padding: '8px 14px',
+    borderRadius: '6px',
+    border: '1px solid #cbd5f5',
+    background: '#fff',
+    cursor: 'pointer',
+  },
+  submit: {
+    padding: '8px 14px',
+    borderRadius: '6px',
+    border: '1px solid #4f46e5',
+    background: '#4f46e5',
+    color: '#fff',
+    cursor: 'pointer',
+  },
+}
+
+const EMBED_ALIGN_LABELS = {
+  center: 'Center',
+  'float-left': 'Wrap left',
+  'float-right': 'Wrap right',
+}
+
+const EmbedDialog = (props) => {
+  const { onCancel, onInsert } = props
+  const [tab, setTab] = useState('link')
+  const [url, setUrl] = useState('')
+  const [code, setCode] = useState('')
+  const [caption, setCaption] = useState('')
+  const [width, setWidth] = useState(100)
+  const [align, setAlign] = useState('center')
+  const [trusted, setTrusted] = useState(false)
+  const [error, setError] = useState('')
+
+  const detected = useMemo(() => {
+    if (tab !== 'link' || !url.trim()) {
+      return null
+    }
+    return buildEmbedHtmlFromUrl(url.trim())
+  }, [tab, url])
+
+  const submit = () => {
+    if (tab === 'link') {
+      const trimmed = url.trim()
+      if (!isSafeEmbedUrl(trimmed)) {
+        setError('Enter a full http(s) address.')
+        return
+      }
+      if (!detected) {
+        setError('That address cannot be embedded. Paste the embed code instead.')
+        return
+      }
+      onInsert(
+        createEmbedValue({
+          code: detected.html,
+          provider: detected.provider.id,
+          url: trimmed,
+          ratio: detected.provider.ratio,
+          width: width,
+          align: align,
+          caption: caption,
+          sandboxLevel: trusted ? 'trusted' : 'strict',
+        })
+      )
+      return
+    }
+
+    const snippet = code.trim()
+    if (!snippet) {
+      setError('Paste the embed code you were given.')
+      return
+    }
+    onInsert(
+      createEmbedValue({
+        code: snippet,
+        width: width,
+        align: align,
+        caption: caption,
+        sandboxLevel: trusted ? 'trusted' : 'strict',
+      })
+    )
+  }
+
+  return (
+    <div style={EMBED_DIALOG_STYLES.backdrop} onMouseDown={onCancel}>
+      <div style={EMBED_DIALOG_STYLES.panel} onMouseDown={(event) => event.stopPropagation()}>
+        <div style={EMBED_DIALOG_STYLES.header}>
+          <span>Add an embed</span>
+        </div>
+        <div style={EMBED_DIALOG_STYLES.body}>
+          <div style={EMBED_DIALOG_STYLES.tabs}>
+            <button
+              type="button"
+              style={tab === 'link' ? EMBED_DIALOG_STYLES.activeTab : EMBED_DIALOG_STYLES.tab}
+              onClick={() => { setTab('link'); setError('') }}
+            >
+              Paste a link
+            </button>
+            <button
+              type="button"
+              style={tab === 'code' ? EMBED_DIALOG_STYLES.activeTab : EMBED_DIALOG_STYLES.tab}
+              onClick={() => { setTab('code'); setError('') }}
+            >
+              Embed code
+            </button>
+          </div>
+
+          {tab === 'link' ? (
+            <label style={EMBED_DIALOG_STYLES.label}>
+              <span>Address</span>
+              <input
+                style={EMBED_DIALOG_STYLES.input}
+                type="url"
+                value={url}
+                placeholder="https://www.youtube.com/watch?v=..."
+                onChange={(event) => { setUrl(event.target.value); setError('') }}
+              />
+              <span style={EMBED_DIALOG_STYLES.hint}>
+                {detected
+                  ? 'Recognized as ' + detected.provider.label + '.'
+                  : 'Videos, social posts, maps, forms, design files and code sandboxes.'}
+              </span>
+            </label>
+          ) : (
+            <label style={EMBED_DIALOG_STYLES.label}>
+              <span>Embed code</span>
+              <textarea
+                style={EMBED_DIALOG_STYLES.textarea}
+                value={code}
+                placeholder='<iframe src="..."></iframe>'
+                onChange={(event) => { setCode(event.target.value); setError('') }}
+              />
+              <span style={EMBED_DIALOG_STYLES.hint}>
+                Code that runs scripts is placed in a sandboxed frame, so it cannot
+                affect the rest of the page.
+              </span>
+            </label>
+          )}
+
+          <label style={EMBED_DIALOG_STYLES.label}>
+            <span>Caption (optional)</span>
+            <input
+              style={EMBED_DIALOG_STYLES.input}
+              type="text"
+              value={caption}
+              onChange={(event) => setCaption(event.target.value)}
+            />
+          </label>
+
+          <div style={EMBED_DIALOG_STYLES.row}>
+            <label style={{ ...EMBED_DIALOG_STYLES.label, flex: 1 }}>
+              <span>Width: {width}%</span>
+              <input
+                type="range"
+                min="10"
+                max="100"
+                step="5"
+                value={width}
+                onChange={(event) => setWidth(Number(event.target.value))}
+              />
+            </label>
+            <label style={{ ...EMBED_DIALOG_STYLES.label, flex: 1 }}>
+              <span>Alignment</span>
+              <select
+                style={EMBED_DIALOG_STYLES.input}
+                value={align}
+                onChange={(event) => setAlign(event.target.value)}
+              >
+                {EMBED_ALIGNMENTS.map((value) => (
+                  <option key={value} value={value}>
+                    {EMBED_ALIGN_LABELS[value] || value}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label style={{ ...EMBED_DIALOG_STYLES.label, flexDirection: 'row', alignItems: 'flex-start', gap: '8px' }}>
+            <input
+              type="checkbox"
+              checked={trusted}
+              onChange={(event) => setTrusted(event.target.checked)}
+            />
+            <span style={EMBED_DIALOG_STYLES.hint}>
+              Allow this embed to use its own cookies and storage. Only needed when a
+              widget refuses to load without it, and it gives the embed more access to
+              the page.
+            </span>
+          </label>
+
+          {error ? <span style={EMBED_DIALOG_STYLES.error}>{error}</span> : null}
+        </div>
+        <div style={EMBED_DIALOG_STYLES.footer}>
+          <button type="button" style={EMBED_DIALOG_STYLES.cancel} onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" style={EMBED_DIALOG_STYLES.submit} onClick={submit}>
+            Insert
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+`

--- a/packages/teleport-project-generator-next/src/rich-text-editor/project-plugin.ts
+++ b/packages/teleport-project-generator-next/src/rich-text-editor/project-plugin.ts
@@ -4,12 +4,15 @@ import {
   ProjectPluginStructure,
   UIDLElement,
 } from '@teleporthq/teleport-types'
+import { RichTextEmbeds } from '@teleporthq/teleport-shared'
 import { traverseProjectElements } from '../uidl-element-traversal'
+import { ensureEmbedRuntimeModule } from '../rich-content-embeds/runtime-module'
 import { generateRichTextEditorComponentCode } from './component-generator'
 
 interface RichTextEditorUsageInfo {
   themes: Set<string>
   hasFormulaFormat: boolean
+  hasEmbedFormat: boolean
 }
 
 /**
@@ -22,6 +25,7 @@ const detectRichTextEditorUsage = (
   const info: RichTextEditorUsageInfo = {
     themes: new Set<string>(),
     hasFormulaFormat: false,
+    hasEmbedFormat: false,
   }
 
   let found = false
@@ -45,16 +49,22 @@ const detectRichTextEditorUsage = (
       info.themes.add('snow') // default
     }
 
-    // Detect formula format
+    // Detect the formats that pull extra machinery into the project: KaTeX for
+    // `formula`, and the whole code-embed layer for `tq-embed`.
     const formatsAttr = attrs.quillFormats
     if (formatsAttr && formatsAttr.type === 'raw') {
       try {
         const formats = JSON.parse((formatsAttr as any).content)
-        if (Array.isArray(formats) && formats.includes('formula')) {
-          info.hasFormulaFormat = true
+        if (Array.isArray(formats)) {
+          if (formats.indexOf('formula') !== -1) {
+            info.hasFormulaFormat = true
+          }
+          if (formats.indexOf(RichTextEmbeds.EMBED_BLOT_NAME) !== -1) {
+            info.hasEmbedFormat = true
+          }
         }
       } catch {
-        // Parsing failed — no formula
+        // Parsing failed — neither format is in play
       }
     }
   }
@@ -87,7 +97,12 @@ export class NextRichTextEditorProjectPlugin implements ProjectPlugin {
     }
 
     // 1. Generate the RichTextEditor component file
-    const componentContent = generateRichTextEditorComponentCode()
+    if (usage.hasEmbedFormat) {
+      ensureEmbedRuntimeModule(structure)
+    }
+    const componentContent = generateRichTextEditorComponentCode({
+      withEmbeds: usage.hasEmbedFormat,
+    })
     files.set('rich-text-editor-component', {
       path: ['components'],
       files: [

--- a/packages/teleport-shared/__tests__/utils/rich-text-embeds-runtime-module.ts
+++ b/packages/teleport-shared/__tests__/utils/rich-text-embeds-runtime-module.ts
@@ -1,0 +1,124 @@
+import { parse } from '@babel/parser'
+import { RichTextEmbeds, RichTextEmbedsCodegen } from '../../src'
+
+/**
+ * The generated project gets `components/embed-runtime.js`, emitted from the
+ * very functions in `src/utils/rich-text-embeds.ts` rather than hand-copied
+ * into a template. These tests are what makes that safe: the emitted module has
+ * to parse, evaluate with no module-scoped references left dangling, and answer
+ * exactly what the source module answers.
+ */
+const SOURCE = RichTextEmbedsCodegen.generateEmbedRuntimeModuleSource()
+
+/** Evaluates the ES module source in-process and returns its exports. */
+const loadRuntime = (): Record<string, (...args: never[]) => unknown> => {
+  const exportedNames = Array.from(
+    SOURCE.matchAll(/^export (?:var|function) ([A-Za-z_$][\w$]*)/gm)
+  ).map((match) => match[1])
+  const body = `${SOURCE.replace(/^export /gm, '')}\nreturn { ${exportedNames.join(', ')} }`
+  // eslint-disable-next-line no-new-func
+  return new Function(body)() as Record<string, (...args: never[]) => unknown>
+}
+
+describe('the emitted embed runtime module', () => {
+  it('parses as an ES module', () => {
+    expect(() => parse(SOURCE, { sourceType: 'module' })).not.toThrow()
+  })
+
+  it('carries no reference the module itself does not declare', () => {
+    expect(SOURCE).not.toContain('exports.')
+    expect(() => loadRuntime()).not.toThrow()
+  })
+
+  it('exports every helper the generated editor and activator call', () => {
+    const runtime = loadRuntime()
+    const required = [
+      'isSafeEmbedUrl',
+      'resolveEmbedProvider',
+      'buildEmbedHtmlFromUrl',
+      'resolveEmbedMode',
+      'createEmbedValue',
+      'buildEmbedElementHtml',
+      'buildEmbedFrameChildren',
+      'readEmbedValueFromElement',
+      'readEncodedEmbedCode',
+      'findEmbedFrame',
+      'normalizeEmbedsForStorage',
+      'resolveEmbedSandboxFlags',
+      'buildEmbedSandboxDocument',
+      'parseEmbedHeightMessage',
+      'createEmbedToken',
+      'encodeEmbedCode',
+      'decodeEmbedCode',
+    ]
+
+    required.forEach((name) => {
+      expect(typeof runtime[name]).toBe('function')
+    })
+  })
+
+  it('answers exactly what the source module answers', () => {
+    const runtime = loadRuntime() as unknown as typeof RichTextEmbeds
+
+    const urls = [
+      'https://youtu.be/dQw4w9WgXcQ',
+      'https://x.com/a/status/1',
+      'https://www.figma.com/design/abc/File?node-id=1-2',
+      'https://open.spotify.com/track/abc123',
+      'https://example.com/plain',
+      'javascript:alert(1)',
+    ]
+
+    urls.forEach((url) => {
+      expect(runtime.isSafeEmbedUrl(url)).toBe(RichTextEmbeds.isSafeEmbedUrl(url))
+
+      const built = runtime.buildEmbedHtmlFromUrl(url)
+      const expected = RichTextEmbeds.buildEmbedHtmlFromUrl(url)
+      expect(built?.html).toBe(expected?.html)
+      expect(built?.provider.id).toBe(expected?.provider.id)
+
+      if (!built || !expected) {
+        return
+      }
+
+      const params = {
+        code: built.html,
+        provider: built.provider.id,
+        url,
+        ratio: built.provider.ratio,
+        caption: 'a & "b"',
+      }
+      expect(runtime.createEmbedValue(params)).toEqual(RichTextEmbeds.createEmbedValue(params))
+      expect(runtime.buildEmbedElementHtml(runtime.createEmbedValue(params))).toBe(
+        RichTextEmbeds.buildEmbedElementHtml(RichTextEmbeds.createEmbedValue(params))
+      )
+    })
+  })
+
+  it('produces the same sandbox payload as the source module', () => {
+    const runtime = loadRuntime() as unknown as typeof RichTextEmbeds
+
+    expect(runtime.resolveEmbedSandboxFlags('strict')).toBe(
+      RichTextEmbeds.resolveEmbedSandboxFlags('strict')
+    )
+    expect(runtime.resolveEmbedSandboxFlags('trusted')).toBe(
+      RichTextEmbeds.resolveEmbedSandboxFlags('trusted')
+    )
+    expect(runtime.buildEmbedSandboxDocument('<b>x</b>', 'tok')).toBe(
+      RichTextEmbeds.buildEmbedSandboxDocument('<b>x</b>', 'tok')
+    )
+    expect(
+      runtime.parseEmbedHeightMessage({ type: 'tq-embed-height', token: 'a', height: 9e9 })
+    ).toEqual(
+      RichTextEmbeds.parseEmbedHeightMessage({ type: 'tq-embed-height', token: 'a', height: 9e9 })
+    )
+  })
+
+  it('round-trips base64 the same way in both', () => {
+    const runtime = loadRuntime() as unknown as typeof RichTextEmbeds
+    const code = '<blockquote>café — 日本語 — 🎉</blockquote><script>x()</script>'
+
+    expect(runtime.encodeEmbedCode(code)).toBe(RichTextEmbeds.encodeEmbedCode(code))
+    expect(runtime.decodeEmbedCode(RichTextEmbeds.encodeEmbedCode(code))).toBe(code)
+  })
+})

--- a/packages/teleport-shared/__tests__/utils/rich-text-embeds.ts
+++ b/packages/teleport-shared/__tests__/utils/rich-text-embeds.ts
@@ -1,0 +1,254 @@
+import { parse } from '@babel/parser'
+import { RichTextEmbeds, RichTextEmbedsCodegen } from '../../src'
+
+const {
+  EMBED_ATTR,
+  applyEmbedTemplate,
+  buildEmbedElementHtml,
+  buildEmbedHtmlFromUrl,
+  clampEmbedWidth,
+  createEmbedValue,
+  decodeEmbedCode,
+  embedBlockStyle,
+  embedFrameStyle,
+  encodeEmbedCode,
+  isSafeEmbedUrl,
+  normalizeEmbedAlign,
+  resolveEmbedMode,
+  resolveEmbedProvider,
+} = RichTextEmbeds
+
+// The DOM half of the contract (`readEmbedValueFromElement`, the layout and
+// caption editors) is covered in teleport-gui, whose test runner has a DOM —
+// this repo's jest runs in a node environment.
+
+describe('provider resolution', () => {
+  it('matches every YouTube URL spelling to the same embed', () => {
+    const urls = [
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://www.youtube.com/watch?list=PL123&v=dQw4w9WgXcQ',
+      'https://youtu.be/dQw4w9WgXcQ',
+      'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+      'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+    ]
+
+    urls.forEach((url) => {
+      const built = buildEmbedHtmlFromUrl(url)
+      expect(built).not.toBeNull()
+      expect(built?.provider.id).toBe('youtube')
+      expect(built?.html).toContain('https://www.youtube.com/embed/dQw4w9WgXcQ')
+    })
+  })
+
+  it('URL-encodes the whole URL where a provider takes it as a query parameter', () => {
+    const built = buildEmbedHtmlFromUrl('https://www.figma.com/design/abc123/My-File?node-id=1-2')
+    expect(built?.provider.id).toBe('figma')
+    expect(built?.html).toContain(
+      'url=https%3A%2F%2Fwww.figma.com%2Fdesign%2Fabc123%2FMy-File%3Fnode-id%3D1-2'
+    )
+  })
+
+  it('falls back to a generic iframe only after every specific provider missed', () => {
+    expect(resolveEmbedProvider('https://example.com/some/page')?.provider.id).toBe('iframe-url')
+    expect(resolveEmbedProvider('https://vimeo.com/76979871')?.provider.id).toBe('vimeo')
+    expect(resolveEmbedProvider('https://codepen.io/team/pen/abcDEF')?.provider.id).toBe('codepen')
+  })
+
+  it('refuses anything that is not an http(s) URL', () => {
+    expect(isSafeEmbedUrl('javascript:alert(1)')).toBe(false)
+    expect(isSafeEmbedUrl('data:text/html;base64,PHNjcmlwdD4=')).toBe(false)
+    expect(isSafeEmbedUrl('//evil.example.com')).toBe(false)
+    expect(isSafeEmbedUrl('')).toBe(false)
+    expect(isSafeEmbedUrl('https://ok.example.com/x')).toBe(true)
+    expect(resolveEmbedProvider('javascript:alert(1)')).toBeNull()
+  })
+
+  it('keeps `$$` literal and never honours the replacement patterns String.replace reserves', () => {
+    const match = 'https://x.test/1'.match(/^https:\/\/x\.test\/(\d+)$/) as RegExpMatchArray
+    expect(applyEmbedTemplate("[$1][$$][$'][$`]", match, 'https://x.test/1')).toBe("[1][$][$'][$`]")
+  })
+
+  it('gives every provider patterns that agree on their capture groups', () => {
+    RichTextEmbeds.EMBED_PROVIDERS.forEach((provider) => {
+      const groupCounts = provider.patterns.map(
+        (pattern) => new RegExp(`${pattern.source}|`).exec('')?.length ?? 0
+      )
+      expect(new Set(groupCounts).size).toBe(1)
+    })
+  })
+})
+
+describe('mode resolution', () => {
+  it('quarantines anything that can execute', () => {
+    expect(resolveEmbedMode('<script src="https://x.test/a.js"></script>')).toBe('sandbox')
+    expect(resolveEmbedMode('<img src=x onerror="alert(1)">')).toBe('sandbox')
+    expect(resolveEmbedMode('<a href="javascript:alert(1)">x</a>')).toBe('sandbox')
+    expect(resolveEmbedMode('<iframe src="https://x.test"></iframe>')).toBe('inline')
+  })
+
+  it('does not mistake an attribute merely starting with "on" for a handler', () => {
+    expect(resolveEmbedMode('<iframe data-only="1" title="one"></iframe>')).toBe('inline')
+  })
+
+  it('sends every script-based provider to the sandbox and the rest inline', () => {
+    expect(resolveEmbedMode(buildEmbedHtmlFromUrl('https://x.com/a/status/1')?.html ?? '')).toBe(
+      'sandbox'
+    )
+    expect(
+      resolveEmbedMode(buildEmbedHtmlFromUrl('https://youtu.be/dQw4w9WgXcQ')?.html ?? '')
+    ).toBe('inline')
+  })
+})
+
+describe('base64 round-trip', () => {
+  it('survives non-ASCII markup', () => {
+    const code = '<blockquote>café — 日本語 — 🎉</blockquote>'
+    expect(decodeEmbedCode(encodeEmbedCode(code))).toBe(code)
+  })
+})
+
+describe('stored markup', () => {
+  it('keeps an inline embed as real children so it renders without JavaScript', () => {
+    const value = createEmbedValue({
+      code: '<iframe src="https://www.youtube.com/embed/abc"></iframe>',
+      provider: 'youtube',
+      url: 'https://youtu.be/abc',
+      ratio: 56.25,
+      caption: 'A "quoted" caption & more',
+    })
+    const html = buildEmbedElementHtml(value)
+
+    expect(html).toContain(`${EMBED_ATTR.MODE}="inline"`)
+    expect(html).not.toContain(EMBED_ATTR.CODE)
+    expect(html).toContain('<iframe src="https://www.youtube.com/embed/abc"></iframe>')
+    expect(html).toContain('padding-top:56.25%')
+    expect(html).toContain('A &quot;quoted&quot; caption &amp; more')
+  })
+
+  it('encodes a script embed and leaves only a noscript fallback in the page', () => {
+    const code =
+      '<blockquote class="twitter-tweet"></blockquote><script src="https://x.test/w.js"></script>'
+    const value = createEmbedValue({ code, provider: 'twitter', url: 'https://x.com/a/status/1' })
+    const html = buildEmbedElementHtml(value)
+
+    expect(html).toContain(`${EMBED_ATTR.MODE}="sandbox"`)
+    expect(html).toContain(`${EMBED_ATTR.SANDBOX}="strict"`)
+    expect(html).toContain(`${EMBED_ATTR.CODE}="${encodeEmbedCode(code)}"`)
+    expect(html).not.toContain('<script')
+    expect(html).toContain('<noscript>')
+  })
+
+  it('omits the noscript fallback for a pasted snippet that has no source URL', () => {
+    const html = buildEmbedElementHtml(createEmbedValue({ code: '<script>x()</script>' }))
+    expect(html).not.toContain('<noscript>')
+    expect(html).toContain(`${EMBED_ATTR.PROVIDER}="custom"`)
+  })
+})
+
+describe('layout vocabulary', () => {
+  it('clamps the width to a usable range', () => {
+    expect(clampEmbedWidth(0)).toBe(10)
+    expect(clampEmbedWidth(1000)).toBe(100)
+    expect(clampEmbedWidth(NaN)).toBe(100)
+  })
+
+  it('falls back to center for an unknown alignment', () => {
+    expect(normalizeEmbedAlign('diagonal')).toBe('center')
+    expect(normalizeEmbedAlign('float-right')).toBe('float-right')
+  })
+
+  it('only floats when the alignment asks for it', () => {
+    expect(embedBlockStyle({ width: 50, align: 'center' })).toContain('margin-left:auto')
+    expect(embedBlockStyle({ width: 50, align: 'center' })).not.toContain('float')
+    expect(embedBlockStyle({ width: 50, align: 'float-right' })).toContain('float:right')
+  })
+
+  it('only builds a padding-top box for a usable ratio', () => {
+    expect(embedFrameStyle(56.25)).toContain('padding-top:56.25%')
+    expect(embedFrameStyle(null)).not.toContain('padding-top')
+    expect(embedFrameStyle(0)).not.toContain('padding-top')
+  })
+})
+
+describe('runtime serialization', () => {
+  it('emits a registry the generated module can evaluate', () => {
+    // tslint:disable-next-line:no-eval
+    const providers = eval(RichTextEmbedsCodegen.serializeEmbedProvidersForRuntime()) as Array<{
+      id: string
+      patterns: RegExp[]
+    }>
+
+    expect(providers).toHaveLength(RichTextEmbeds.EMBED_PROVIDERS.length)
+    expect(providers[0].patterns[0]).toBeInstanceOf(RegExp)
+    expect(providers.map((entry) => entry.id)).toEqual(
+      RichTextEmbeds.EMBED_PROVIDERS.map((entry) => entry.id)
+    )
+  })
+})
+
+describe('the sandbox payload', () => {
+  const {
+    EMBED_MAX_HEIGHT,
+    EMBED_MIN_HEIGHT,
+    buildEmbedSandboxDocument,
+    createEmbedToken,
+    parseEmbedHeightMessage,
+    resolveEmbedSandboxFlags,
+  } = RichTextEmbeds
+
+  it('withholds allow-same-origin unless the author opted in', () => {
+    expect(resolveEmbedSandboxFlags('strict')).not.toContain('allow-same-origin')
+    expect(resolveEmbedSandboxFlags('trusted')).toContain('allow-same-origin')
+  })
+
+  it('hands the frame a bootstrap script that is valid JavaScript', () => {
+    // The document is assembled from concatenated fragments, so a stray
+    // character would only surface as a silent parse failure inside a sandboxed
+    // frame — where nothing can report it. Parse it here instead.
+    const doc = buildEmbedSandboxDocument('', 'tok')
+    const script = /<script>([\s\S]*?)<\/script>/.exec(doc)
+
+    expect(script).not.toBeNull()
+    expect(() => parse((script as RegExpExecArray)[1], { sourceType: 'script' })).not.toThrow()
+  })
+
+  it('closes every tag it opens, so the embed lands inside the body', () => {
+    const doc = buildEmbedSandboxDocument('<b>x</b>', 'tok')
+
+    expect(doc.indexOf('<body>')).toBeLessThan(doc.indexOf('<b>x</b>'))
+    expect(doc.indexOf('<b>x</b>')).toBeLessThan(doc.indexOf('</body>'))
+    expect(doc.endsWith('</body></html>')).toBe(true)
+  })
+
+  it('bakes the frame token into the document it hands the iframe', () => {
+    const token = createEmbedToken()
+    const doc = buildEmbedSandboxDocument('<blockquote>hi</blockquote>', token)
+
+    expect(doc).toContain(token)
+    expect(doc).not.toContain(RichTextEmbeds.EMBED_TOKEN_PLACEHOLDER)
+    expect(doc).toContain('<blockquote>hi</blockquote>')
+    expect(doc.indexOf('</head>')).toBeLessThan(doc.indexOf('<blockquote>'))
+  })
+
+  it('mints a distinct token per frame', () => {
+    expect(createEmbedToken()).not.toBe(createEmbedToken())
+  })
+
+  it('accepts only a well-formed height message, and clamps it', () => {
+    expect(parseEmbedHeightMessage(null)).toBeNull()
+    expect(parseEmbedHeightMessage('tq-embed-height')).toBeNull()
+    expect(parseEmbedHeightMessage({ type: 'other', token: 'a', height: 10 })).toBeNull()
+    expect(parseEmbedHeightMessage({ type: 'tq-embed-height', token: 1, height: 10 })).toBeNull()
+    expect(parseEmbedHeightMessage({ type: 'tq-embed-height', token: 'a', height: 'x' })).toBeNull()
+    expect(parseEmbedHeightMessage({ type: 'tq-embed-height', token: 'a', height: -5 })).toBeNull()
+
+    expect(parseEmbedHeightMessage({ type: 'tq-embed-height', token: 'a', height: 1 })).toEqual({
+      token: 'a',
+      height: EMBED_MIN_HEIGHT,
+    })
+    expect(parseEmbedHeightMessage({ type: 'tq-embed-height', token: 'a', height: 1e9 })).toEqual({
+      token: 'a',
+      height: EMBED_MAX_HEIGHT,
+    })
+  })
+})

--- a/packages/teleport-shared/src/index.ts
+++ b/packages/teleport-shared/src/index.ts
@@ -14,6 +14,8 @@ import * as StyleDeclarations from './utils/style-declarations'
 import * as StorefrontTax from './utils/storefront-tax'
 import * as ProductDiscounts from './utils/product-discounts'
 import * as EmailDate from './utils/email-date'
+import * as RichTextEmbeds from './utils/rich-text-embeds'
+import * as RichTextEmbedsCodegen from './utils/rich-text-embeds-codegen'
 import * as DataCache from './cache'
 
 export {
@@ -33,5 +35,7 @@ export {
   StorefrontTax,
   ProductDiscounts,
   EmailDate,
+  RichTextEmbeds,
+  RichTextEmbedsCodegen,
   DataCache,
 }

--- a/packages/teleport-shared/src/utils/rich-text-embeds-codegen.ts
+++ b/packages/teleport-shared/src/utils/rich-text-embeds-codegen.ts
@@ -1,0 +1,216 @@
+/**
+ * Code-generation helpers for the rich-text embed contract.
+ *
+ * Kept apart from `rich-text-embeds.ts` on purpose: that module is imported by
+ * the studio editor and the canvas renderer, which are BROWSER bundles, and the
+ * function registry below holds a live reference to every helper so that none
+ * of them can be tree-shaken. Only the project generator imports this file.
+ */
+import {
+  CUSTOM_EMBED_PROVIDER_ID,
+  DEFAULT_EMBED_ALIGN,
+  DEFAULT_EMBED_SANDBOX_LEVEL,
+  DEFAULT_EMBED_WIDTH,
+  EMBED_ALIGNMENTS,
+  EMBED_ATTR,
+  EMBED_BLOT_NAME,
+  EMBED_CAPTION_CLASS_NAME,
+  EMBED_CAPTION_STYLE,
+  EMBED_CLASS_NAME,
+  EMBED_FRAME_CLASS_NAME,
+  EMBED_HEIGHT_MESSAGE_TYPE,
+  EMBED_INITIAL_HEIGHT,
+  EMBED_MAX_HEIGHT,
+  EMBED_MIN_HEIGHT,
+  EMBED_PROVIDERS,
+  EMBED_SANDBOX_DOC_HEAD,
+  EMBED_SANDBOX_DOC_TAIL,
+  EMBED_SANDBOX_FLAGS_STRICT,
+  EMBED_SANDBOX_FLAGS_TRUSTED,
+  EMBED_TOKEN_PLACEHOLDER,
+  GENERIC_EMBED_PROVIDER_ID,
+  WIDESCREEN_EMBED_RATIO,
+  applyEmbedTemplate,
+  buildEmbedElementHtml,
+  buildEmbedFrameChildren,
+  buildEmbedHtmlFromUrl,
+  buildEmbedSandboxDocument,
+  clampEmbedWidth,
+  createEmbedToken,
+  createEmbedValue,
+  decodeEmbedCode,
+  embedBlockStyle,
+  embedFrameStyle,
+  encodeEmbedCode,
+  escapeEmbedAttribute,
+  escapeEmbedText,
+  findEmbedFrame,
+  isSafeEmbedUrl,
+  normalizeEmbedAlign,
+  normalizeEmbedsForStorage,
+  parseEmbedHeightMessage,
+  readEmbedValueFromElement,
+  readEncodedEmbedCode,
+  resolveEmbedMode,
+  resolveEmbedProvider,
+  resolveEmbedSandboxFlags,
+} from './rich-text-embeds'
+
+/**
+ * The provider registry as a JavaScript literal, so the component the Next
+ * generator writes is built from THIS array rather than a hand-copied one.
+ * Regexes are re-created from their source and flags because `JSON.stringify`
+ * flattens a `RegExp` to `{}`.
+ */
+export function serializeEmbedProvidersForRuntime(): string {
+  const entries = EMBED_PROVIDERS.map((provider) => {
+    const patterns = provider.patterns
+      .map(
+        (pattern) =>
+          `new RegExp(${JSON.stringify(pattern.source)}, ${JSON.stringify(pattern.flags)})`
+      )
+      .join(', ')
+    return (
+      `{ id: ${JSON.stringify(provider.id)}, label: ${JSON.stringify(provider.label)}, ` +
+      `patterns: [${patterns}], template: ${JSON.stringify(provider.template)}, ` +
+      `ratio: ${provider.ratio === null ? 'null' : String(provider.ratio)} }`
+    )
+  })
+  return `[\n  ${entries.join(',\n  ')}\n]`
+}
+
+/* ── The generated runtime module ───────────────────────────────────────────
+ *
+ * The exported project needs these same helpers at runtime: its rich-text
+ * editor builds embeds with them and its activator mounts them. Rather than
+ * hand-copying the logic into a code-generator template — where it would drift
+ * from this file the first time a provider is added — the module is EMITTED
+ * from the very functions above: the constants are serialized, the functions
+ * are printed with `Function.prototype.toString`, and the result is written to
+ * the generated project as `components/embed-runtime.js`.
+ *
+ * Two rules keep that safe, and `__tests__/utils/rich-text-embeds.ts` pins both:
+ *   - every emitted function may only reference other emitted functions and the
+ *     constants below, never a module-private helper or an import;
+ *   - the emitted module must parse and behave identically to this one.
+ */
+
+/**
+ * Every function the generated editor and activator reach — the ones they
+ * import, plus everything those call in turn. Deliberately not the whole of
+ * `rich-text-embeds`: the editor overlay helpers belong to the studio, and an
+ * export nothing calls is dead weight in every generated project.
+ */
+const RUNTIME_EXPORTS: Array<(...args: never[]) => unknown> = [
+  isSafeEmbedUrl,
+  resolveEmbedProvider,
+  applyEmbedTemplate,
+  buildEmbedHtmlFromUrl,
+  resolveEmbedMode,
+  clampEmbedWidth,
+  normalizeEmbedAlign,
+  escapeEmbedAttribute,
+  escapeEmbedText,
+  encodeEmbedCode,
+  decodeEmbedCode,
+  createEmbedValue,
+  embedBlockStyle,
+  embedFrameStyle,
+  buildEmbedElementHtml,
+  buildEmbedFrameChildren,
+  findEmbedFrame,
+  readEmbedValueFromElement,
+  readEncodedEmbedCode,
+  normalizeEmbedsForStorage,
+  resolveEmbedSandboxFlags,
+  buildEmbedSandboxDocument,
+  parseEmbedHeightMessage,
+  createEmbedToken,
+]
+
+interface RuntimeConstant {
+  name: string
+  literal: string
+}
+
+const runtimeConstant = (name: string, literal: string): RuntimeConstant => ({ name, literal })
+
+/**
+ * TypeScript's CommonJS emit rewrites every reference to an exported CONSTANT
+ * as `exports.NAME` (exported functions keep their bare names, which is why
+ * they can call each other). The generator runs against that CommonJS build, so
+ * printed function bodies arrive carrying `exports.` prefixes that mean nothing
+ * in the emitted module — where each constant is re-declared as a plain
+ * top-level binding of the same name. Rewriting them back is therefore exact,
+ * not a heuristic: only names this module emits are rewritten, and
+ * `generateEmbedRuntimeModuleSource` asserts nothing module-scoped is left.
+ */
+const bindRuntimeConstantReferences = (source: string, names: string[]): string =>
+  names.reduce((acc, name) => acc.replace(new RegExp(`\\bexports\\.${name}\\b`, 'g'), name), source)
+
+export function generateEmbedRuntimeModuleSource(): string {
+  const constants: RuntimeConstant[] = [
+    runtimeConstant('EMBED_CLASS_NAME', JSON.stringify(EMBED_CLASS_NAME)),
+    runtimeConstant('EMBED_FRAME_CLASS_NAME', JSON.stringify(EMBED_FRAME_CLASS_NAME)),
+    runtimeConstant('EMBED_CAPTION_CLASS_NAME', JSON.stringify(EMBED_CAPTION_CLASS_NAME)),
+    runtimeConstant('EMBED_BLOT_NAME', JSON.stringify(EMBED_BLOT_NAME)),
+    runtimeConstant('EMBED_ATTR', JSON.stringify(EMBED_ATTR, null, 2)),
+    runtimeConstant('EMBED_ALIGNMENTS', JSON.stringify(EMBED_ALIGNMENTS)),
+    runtimeConstant('CUSTOM_EMBED_PROVIDER_ID', JSON.stringify(CUSTOM_EMBED_PROVIDER_ID)),
+    runtimeConstant('GENERIC_EMBED_PROVIDER_ID', JSON.stringify(GENERIC_EMBED_PROVIDER_ID)),
+    runtimeConstant('DEFAULT_EMBED_WIDTH', String(DEFAULT_EMBED_WIDTH)),
+    runtimeConstant('DEFAULT_EMBED_ALIGN', JSON.stringify(DEFAULT_EMBED_ALIGN)),
+    runtimeConstant('DEFAULT_EMBED_SANDBOX_LEVEL', JSON.stringify(DEFAULT_EMBED_SANDBOX_LEVEL)),
+    runtimeConstant('WIDESCREEN_EMBED_RATIO', String(WIDESCREEN_EMBED_RATIO)),
+    runtimeConstant('EMBED_CAPTION_STYLE', JSON.stringify(EMBED_CAPTION_STYLE)),
+    runtimeConstant('EMBED_PROVIDERS', serializeEmbedProvidersForRuntime()),
+    runtimeConstant('EMBED_SANDBOX_FLAGS_STRICT', JSON.stringify(EMBED_SANDBOX_FLAGS_STRICT)),
+    runtimeConstant('EMBED_SANDBOX_FLAGS_TRUSTED', JSON.stringify(EMBED_SANDBOX_FLAGS_TRUSTED)),
+    runtimeConstant('EMBED_HEIGHT_MESSAGE_TYPE', JSON.stringify(EMBED_HEIGHT_MESSAGE_TYPE)),
+    runtimeConstant('EMBED_TOKEN_PLACEHOLDER', JSON.stringify(EMBED_TOKEN_PLACEHOLDER)),
+    runtimeConstant('EMBED_MIN_HEIGHT', String(EMBED_MIN_HEIGHT)),
+    runtimeConstant('EMBED_MAX_HEIGHT', String(EMBED_MAX_HEIGHT)),
+    runtimeConstant('EMBED_INITIAL_HEIGHT', String(EMBED_INITIAL_HEIGHT)),
+    runtimeConstant('EMBED_SANDBOX_DOC_HEAD', JSON.stringify(EMBED_SANDBOX_DOC_HEAD)),
+    runtimeConstant('EMBED_SANDBOX_DOC_TAIL', JSON.stringify(EMBED_SANDBOX_DOC_TAIL)),
+    // `createEmbedToken` closes over this counter.
+    runtimeConstant('embedTokenCounter', '0'),
+  ]
+
+  const names = constants.map((entry) => entry.name)
+  const declarations = constants.map((entry) => `export var ${entry.name} = ${entry.literal}`)
+  const functions = RUNTIME_EXPORTS.map(
+    (fn) => `export ${bindRuntimeConstantReferences(fn.toString(), names)}`
+  )
+
+  const source = `${RUNTIME_MODULE_HEADER}\n${declarations.join('\n\n')}\n\n${functions.join(
+    '\n\n'
+  )}\n`
+
+  // An `exports.` reference that survived means a function reached for a
+  // constant left off the list above. That crashes every generated project at
+  // runtime, so it fails here instead. (Import leakage is covered by the
+  // emitted module being evaluated in this package's tests — this module has
+  // no imports, and must not gain any.)
+  const leaked = source.match(/\bexports\.[A-Za-z_$][\w$]*/g)
+  if (leaked) {
+    throw new Error(
+      `Embed runtime module cannot be emitted: unresolved module references ${leaked.join(', ')}`
+    )
+  }
+
+  return source
+}
+
+const RUNTIME_MODULE_HEADER = `/**
+ * Code embeds inside rich-text content — the shape the editor writes and the
+ * page reads back. Generated from @teleporthq/teleport-shared; edit it there.
+ *
+ * An embed is stored inside the content HTML as a <figure class="tq-embed">.
+ * Passive markup (a provider iframe) lives in the figure as real children, so
+ * it renders server-side with no JavaScript. Markup that can execute — a
+ * <script>, an on* handler, a javascript: URL — is base64-encoded onto the
+ * element instead, and mounted at runtime inside a sandboxed iframe so it can
+ * never reach this page.
+ */
+`

--- a/packages/teleport-shared/src/utils/rich-text-embeds.ts
+++ b/packages/teleport-shared/src/utils/rich-text-embeds.ts
@@ -1,0 +1,966 @@
+/**
+ * The "code embed" contract for rich-text CONTENT — the blog post body, and any
+ * other column authored through a rich-text editor.
+ *
+ * A code embed is a block a post author drops into the body to pull in content
+ * from another site (a video, a social post, a design frame, a form, or a raw
+ * snippet they pasted). It is stored INSIDE the content HTML, so the same shape
+ * has to be produced by the studio's Quill editor, produced by the generated
+ * admin panel's Quill editor, previewed by the studio canvas and rendered by
+ * the exported Next.js app. This module is that single shape.
+ *
+ * Two rendering modes, decided by one rule (`resolveEmbedMode`):
+ *
+ *  - `inline`  — the markup is provably passive (no `<script>`, no `on*`
+ *                handler, no `javascript:` URL). It is stored as the element's
+ *                own children, so it renders server-side, needs no JavaScript
+ *                and is crawlable. Most provider embeds are a bare `<iframe>`
+ *                and land here.
+ *  - `sandbox` — anything else. The markup is base64-encoded into
+ *                `data-tq-embed-code` and the runtime materializes it inside a
+ *                sandboxed `srcdoc` iframe, so author-supplied JavaScript can
+ *                never touch the hosting page. The children hold only a
+ *                `<noscript>` link fallback.
+ *
+ * The provider registry is deliberately DECLARATIVE — patterns plus a
+ * replacement template, never functions — so `rich-text-embeds-codegen` can
+ * serialize it verbatim into the module the generated project gets, and the
+ * editor and the published site can never drift.
+ */
+
+export type EmbedAlign = 'center' | 'float-left' | 'float-right'
+export type EmbedMode = 'inline' | 'sandbox'
+/**
+ * `strict` (the default) omits `allow-same-origin`, so the embed runs in an
+ * opaque origin and cannot reach the host page's storage or DOM. `trusted` adds
+ * it back for the widgets that refuse to render without storage access — an
+ * explicit, per-embed opt-in the author has to make.
+ */
+export type EmbedSandboxLevel = 'strict' | 'trusted'
+
+export interface EmbedValue {
+  /** Registry id, or `custom` when the author pasted the markup themselves. */
+  provider: string
+  /** The source URL, when there was one. Lets the editor re-open the Link tab. */
+  url: string
+  /** The embed markup itself. */
+  code: string
+  mode: EmbedMode
+  /** Responsive box height as a padding-top percentage; `null` = intrinsic. */
+  ratio: number | null
+  /** Block width as a percentage of the content column, 10-100. */
+  width: number
+  align: EmbedAlign
+  caption: string
+  sandboxLevel: EmbedSandboxLevel
+}
+
+export const EMBED_CLASS_NAME = 'tq-embed'
+export const EMBED_FRAME_CLASS_NAME = 'tq-embed-frame'
+export const EMBED_CAPTION_CLASS_NAME = 'tq-embed-caption'
+
+/** The Quill blot name, shared by the studio editor and the generated one. */
+export const EMBED_BLOT_NAME = 'tq-embed'
+
+export const EMBED_ATTR = {
+  MARKER: 'data-tq-embed',
+  PROVIDER: 'data-tq-embed-provider',
+  URL: 'data-tq-embed-url',
+  MODE: 'data-tq-embed-mode',
+  CODE: 'data-tq-embed-code',
+  RATIO: 'data-tq-embed-ratio',
+  WIDTH: 'data-tq-embed-width',
+  ALIGN: 'data-tq-embed-align',
+  CAPTION: 'data-tq-embed-caption',
+  SANDBOX: 'data-tq-embed-sandbox',
+  /** Written by a runtime once a sandbox embed has been mounted. */
+  ACTIVATED: 'data-tq-embed-activated',
+  /**
+   * Marks an element an EDITOR added purely to preview the embed. Editors read
+   * their value back out of the live DOM, so a preview must be recognizable in
+   * order to be stripped again — see `normalizeEmbedsForStorage`.
+   */
+  PREVIEW: 'data-tq-embed-preview',
+} as const
+
+export const EMBED_ALIGNMENTS: EmbedAlign[] = ['center', 'float-left', 'float-right']
+
+export const CUSTOM_EMBED_PROVIDER_ID = 'custom'
+export const GENERIC_EMBED_PROVIDER_ID = 'iframe-url'
+
+export const DEFAULT_EMBED_WIDTH = 100
+export const DEFAULT_EMBED_ALIGN: EmbedAlign = 'center'
+export const DEFAULT_EMBED_SANDBOX_LEVEL: EmbedSandboxLevel = 'strict'
+/** 16:9, as a padding-top percentage. */
+export const WIDESCREEN_EMBED_RATIO = 56.25
+
+export interface EmbedProviderDefinition {
+  id: string
+  label: string
+  /**
+   * Alternative spellings of the same URL. Every pattern of one provider must
+   * expose the same capture groups, because `template` indexes them by number.
+   */
+  patterns: RegExp[]
+  /**
+   * The markup, with `$1`-`$9` replaced by the capture groups and `$&` by the
+   * whole URL. Prefix the token with `E` (`$E1`, `$E&`) to URL-encode it.
+   * A literal dollar is written `$$`.
+   */
+  template: string
+  /**
+   * When set, the frame becomes a responsive padding-top box of this
+   * percentage and the template's iframe is expected to fill it absolutely.
+   * `null` means the template carries its own height.
+   */
+  ratio: number | null
+}
+
+const FILL_FRAME_STYLE =
+  'position:absolute;top:0;left:0;width:100%;height:100%;border:0;border-radius:inherit'
+const BLOCK_FRAME_STYLE = 'display:block;width:100%;border:0;border-radius:inherit'
+
+const iframeTemplate = (
+  src: string,
+  options: { title: string; fill: boolean; height?: number }
+) => {
+  const style = options.fill
+    ? FILL_FRAME_STYLE
+    : `${BLOCK_FRAME_STYLE};height:${options.height ?? 400}px`
+  return (
+    `<iframe src="${src}" title="${options.title}" loading="lazy" frameborder="0" ` +
+    `referrerpolicy="strict-origin-when-cross-origin" ` +
+    `allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share" ` +
+    `allowfullscreen style="${style}"></iframe>`
+  )
+}
+
+/**
+ * Ordered most-specific first: `resolveEmbedProvider` returns the first match,
+ * and the generic `iframe-url` fallback is deliberately last.
+ */
+export const EMBED_PROVIDERS: EmbedProviderDefinition[] = [
+  {
+    id: 'youtube',
+    label: 'YouTube',
+    patterns: [
+      /^https?:\/\/(?:www\.|m\.)?youtube\.com\/watch\?(?:[^#]*&)?v=([A-Za-z0-9_-]{6,})/i,
+      /^https?:\/\/youtu\.be\/([A-Za-z0-9_-]{6,})/i,
+      /^https?:\/\/(?:www\.)?youtube\.com\/shorts\/([A-Za-z0-9_-]{6,})/i,
+      /^https?:\/\/(?:www\.)?youtube(?:-nocookie)?\.com\/embed\/([A-Za-z0-9_-]{6,})/i,
+    ],
+    template: iframeTemplate('https://www.youtube.com/embed/$1', {
+      title: 'YouTube video',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'vimeo',
+    label: 'Vimeo',
+    patterns: [
+      /^https?:\/\/(?:www\.)?vimeo\.com\/(\d+)/i,
+      /^https?:\/\/player\.vimeo\.com\/video\/(\d+)/i,
+    ],
+    template: iframeTemplate('https://player.vimeo.com/video/$1', {
+      title: 'Vimeo video',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'loom',
+    label: 'Loom',
+    patterns: [/^https?:\/\/(?:www\.)?loom\.com\/(?:share|embed)\/([A-Za-z0-9]+)/i],
+    template: iframeTemplate('https://www.loom.com/embed/$1', {
+      title: 'Loom video',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'dailymotion',
+    label: 'Dailymotion',
+    patterns: [
+      /^https?:\/\/(?:www\.)?dailymotion\.com\/video\/([A-Za-z0-9]+)/i,
+      /^https?:\/\/dai\.ly\/([A-Za-z0-9]+)/i,
+    ],
+    template: iframeTemplate('https://www.dailymotion.com/embed/video/$1', {
+      title: 'Dailymotion video',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'spotify',
+    label: 'Spotify',
+    patterns: [
+      /^https?:\/\/open\.spotify\.com\/(?:embed\/)?(track|album|playlist|episode|show|artist)\/([A-Za-z0-9]+)/i,
+    ],
+    template: iframeTemplate('https://open.spotify.com/embed/$1/$2', {
+      title: 'Spotify player',
+      fill: false,
+      height: 352,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'soundcloud',
+    label: 'SoundCloud',
+    patterns: [/^https?:\/\/soundcloud\.com\/[^?#]+/i],
+    template: iframeTemplate(
+      'https://w.soundcloud.com/player/?url=$E&&color=%23ff5500&auto_play=false&show_teaser=false',
+      { title: 'SoundCloud player', fill: false, height: 166 }
+    ),
+    ratio: null,
+  },
+  {
+    id: 'apple-podcasts',
+    label: 'Apple Podcasts',
+    patterns: [/^https?:\/\/podcasts\.apple\.com\/(.+)$/i],
+    template: iframeTemplate('https://embed.podcasts.apple.com/$1', {
+      title: 'Apple Podcasts player',
+      fill: false,
+      height: 175,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'twitter',
+    label: 'X (Twitter)',
+    patterns: [/^https?:\/\/(?:www\.)?(?:twitter|x)\.com\/[^/]+\/status\/(\d+)/i],
+    template:
+      '<blockquote class="twitter-tweet"><a href="$&"></a></blockquote>' +
+      '<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
+    ratio: null,
+  },
+  {
+    id: 'instagram',
+    label: 'Instagram',
+    patterns: [/^https?:\/\/(?:www\.)?instagram\.com\/(?:p|reel|tv)\/([A-Za-z0-9_-]+)/i],
+    template:
+      '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/$1/" data-instgrm-version="14"></blockquote>' +
+      '<script async src="https://www.instagram.com/embed.js"></script>',
+    ratio: null,
+  },
+  {
+    id: 'tiktok',
+    label: 'TikTok',
+    patterns: [/^https?:\/\/(?:www\.)?tiktok\.com\/@[^/]+\/video\/(\d+)/i],
+    template:
+      '<blockquote class="tiktok-embed" cite="$&" data-video-id="$1"><section></section></blockquote>' +
+      '<script async src="https://www.tiktok.com/embed.js"></script>',
+    ratio: null,
+  },
+  {
+    id: 'reddit',
+    label: 'Reddit',
+    patterns: [/^https?:\/\/(?:www\.)?reddit\.com\/r\/[^/]+\/comments\/.+/i],
+    template:
+      '<blockquote class="reddit-embed-bq"><a href="$&"></a></blockquote>' +
+      '<script async src="https://embed.reddit.com/widgets.js" charset="UTF-8"></script>',
+    ratio: null,
+  },
+  {
+    id: 'pinterest',
+    label: 'Pinterest',
+    patterns: [/^https?:\/\/(?:[a-z]{2}\.)?pinterest\.[a-z.]+\/pin\/[0-9]+/i],
+    template:
+      '<a data-pin-do="embedPin" href="$&"></a>' +
+      '<script async defer src="https://assets.pinterest.com/js/pinit.js"></script>',
+    ratio: null,
+  },
+  {
+    id: 'facebook',
+    label: 'Facebook',
+    patterns: [/^https?:\/\/(?:www\.|web\.)?facebook\.com\/.+\/(?:posts|videos)\/.+/i],
+    template: iframeTemplate('https://www.facebook.com/plugins/post.php?href=$E&&show_text=true', {
+      title: 'Facebook post',
+      fill: false,
+      height: 500,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'github-gist',
+    label: 'GitHub Gist',
+    patterns: [/^https?:\/\/gist\.github\.com\/([^/]+\/[a-f0-9]+)/i],
+    template: '<script src="https://gist.github.com/$1.js"></script>',
+    ratio: null,
+  },
+  {
+    id: 'codepen',
+    label: 'CodePen',
+    patterns: [/^https?:\/\/codepen\.io\/([^/]+)\/(?:pen|embed|details|full)\/([A-Za-z0-9]+)/i],
+    template: iframeTemplate('https://codepen.io/$1/embed/$2?default-tab=result', {
+      title: 'CodePen',
+      fill: false,
+      height: 400,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'codesandbox',
+    label: 'CodeSandbox',
+    patterns: [
+      /^https?:\/\/codesandbox\.io\/(?:s|embed)\/([A-Za-z0-9_-]+)/i,
+      /^https?:\/\/codesandbox\.io\/p\/(?:sandbox|devbox)\/([A-Za-z0-9_-]+)/i,
+    ],
+    template: iframeTemplate('https://codesandbox.io/embed/$1', {
+      title: 'CodeSandbox',
+      fill: false,
+      height: 500,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'jsfiddle',
+    label: 'JSFiddle',
+    patterns: [/^https?:\/\/(?:www\.)?jsfiddle\.net\/((?:[^/]+\/)?[A-Za-z0-9]+)\/?/i],
+    template: iframeTemplate('https://jsfiddle.net/$1/embedded/', {
+      title: 'JSFiddle',
+      fill: false,
+      height: 400,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'figma',
+    label: 'Figma',
+    patterns: [/^https?:\/\/(?:www\.)?figma\.com\/(?:file|design|proto|board|slides)\/.+/i],
+    template: iframeTemplate('https://www.figma.com/embed?embed_host=share&url=$E&', {
+      title: 'Figma',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'canva',
+    label: 'Canva',
+    patterns: [
+      /^https?:\/\/(?:www\.)?canva\.com\/design\/([A-Za-z0-9_-]+)\/([A-Za-z0-9_-]+)\/(?:view|watch)/i,
+    ],
+    template: iframeTemplate('https://www.canva.com/design/$1/$2/view?embed', {
+      title: 'Canva design',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'miro',
+    label: 'Miro',
+    patterns: [/^https?:\/\/miro\.com\/app\/(?:board|live-embed)\/([A-Za-z0-9_=-]+)/i],
+    template: iframeTemplate('https://miro.com/app/live-embed/$1/', {
+      title: 'Miro board',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'google-maps',
+    label: 'Google Maps',
+    patterns: [/^https?:\/\/(?:www\.)?google\.[a-z.]+\/maps\/embed\?(.+)$/i],
+    template: iframeTemplate('https://www.google.com/maps/embed?$1', {
+      title: 'Google Maps',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'google-maps-place',
+    label: 'Google Maps',
+    patterns: [/^https?:\/\/(?:(?:www\.)?google\.[a-z.]+\/maps|maps\.app\.goo\.gl)\/.+/i],
+    template: iframeTemplate('https://maps.google.com/maps?q=$E&&output=embed', {
+      title: 'Google Maps',
+      fill: true,
+    }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+  {
+    id: 'google-forms',
+    label: 'Google Forms',
+    patterns: [/^https?:\/\/docs\.google\.com\/forms\/d\/(?:e\/)?([A-Za-z0-9_-]+)/i],
+    template: iframeTemplate('https://docs.google.com/forms/d/e/$1/viewform?embedded=true', {
+      title: 'Google Form',
+      fill: false,
+      height: 700,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'google-docs',
+    label: 'Google Docs',
+    patterns: [
+      /^https?:\/\/docs\.google\.com\/(document|spreadsheets|presentation)\/d\/([A-Za-z0-9_-]+)/i,
+    ],
+    template: iframeTemplate('https://docs.google.com/$1/d/$2/preview', {
+      title: 'Google Docs',
+      fill: false,
+      height: 600,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'airtable',
+    label: 'Airtable',
+    patterns: [/^https?:\/\/airtable\.com\/(?:embed\/)?(app[A-Za-z0-9/?=&_-]+)/i],
+    template: iframeTemplate('https://airtable.com/embed/$1', {
+      title: 'Airtable',
+      fill: false,
+      height: 533,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'typeform',
+    label: 'Typeform',
+    patterns: [/^https?:\/\/(?:[A-Za-z0-9-]+\.)?typeform\.com\/to\/([A-Za-z0-9]+)/i],
+    template: iframeTemplate('https://form.typeform.com/to/$1', {
+      title: 'Typeform',
+      fill: false,
+      height: 500,
+    }),
+    ratio: null,
+  },
+  {
+    id: 'calendly',
+    label: 'Calendly',
+    patterns: [/^https?:\/\/calendly\.com\/(.+)$/i],
+    template: iframeTemplate('https://calendly.com/$1', {
+      title: 'Calendly',
+      fill: false,
+      height: 700,
+    }),
+    ratio: null,
+  },
+  {
+    id: GENERIC_EMBED_PROVIDER_ID,
+    label: 'Web page',
+    patterns: [/^https:\/\/[^\s"'<>]+$/i],
+    template: iframeTemplate('$&', { title: 'Embedded page', fill: true }),
+    ratio: WIDESCREEN_EMBED_RATIO,
+  },
+]
+
+export interface EmbedProviderMatch {
+  provider: EmbedProviderDefinition
+  match: RegExpMatchArray
+}
+
+/** `javascript:`, `data:` and protocol-relative URLs never become an embed. */
+export function isSafeEmbedUrl(url: string): boolean {
+  return /^https?:\/\/[^\s"'<>]+$/i.test((url || '').trim())
+}
+
+/** How an embed names itself in the editor: the provider, or "Custom code". */
+export function embedProviderLabel(providerId: string): string {
+  const provider = EMBED_PROVIDERS.filter((entry) => entry.id === providerId)[0]
+  return provider ? provider.label : 'Custom code'
+}
+
+export function resolveEmbedProvider(url: string): EmbedProviderMatch | null {
+  const trimmed = (url || '').trim()
+  if (!isSafeEmbedUrl(trimmed)) {
+    return null
+  }
+
+  for (const provider of EMBED_PROVIDERS) {
+    for (const pattern of provider.patterns) {
+      const match = trimmed.match(pattern)
+      if (match) {
+        return { provider, match }
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Substitutes `$1`-`$9` / `$E1`-`$E9` / `$&` / `$E&` in a provider template.
+ * Written by hand rather than through `String.replace` so the replacement
+ * patterns `String.replace` reserves (`$'`, "$`", `$<name>`) stay literal.
+ */
+export function applyEmbedTemplate(template: string, match: RegExpMatchArray, url: string): string {
+  return template.replace(/\$(\$|E?(?:[1-9]|&))/g, (_token, spec: string) => {
+    if (spec === '$') {
+      return '$'
+    }
+    const encoded = spec.charAt(0) === 'E'
+    const key = encoded ? spec.slice(1) : spec
+    const raw = key === '&' ? url : match[Number(key)] ?? ''
+    return encoded ? encodeURIComponent(raw) : raw
+  })
+}
+
+/** The embed markup for a pasted URL, or `null` when nothing recognizes it. */
+export function buildEmbedHtmlFromUrl(url: string): {
+  provider: EmbedProviderDefinition
+  html: string
+} | null {
+  const resolved = resolveEmbedProvider(url)
+  if (!resolved) {
+    return null
+  }
+  return {
+    provider: resolved.provider,
+    html: applyEmbedTemplate(resolved.provider.template, resolved.match, url.trim()),
+  }
+}
+
+/**
+ * Markup that can execute anything — a `<script>`, an inline `on*` handler or a
+ * `javascript:` URL — is quarantined in a sandboxed iframe. Everything else is
+ * passive and can be rendered straight into the page.
+ */
+export function resolveEmbedMode(html: string): EmbedMode {
+  const markup = html || ''
+  const executes =
+    /<script[\s/>]/i.test(markup) ||
+    /\son[a-z]+\s*=/i.test(markup) ||
+    /(?:href|src|action|formaction)\s*=\s*["']?\s*javascript:/i.test(markup)
+  return executes ? 'sandbox' : 'inline'
+}
+
+export function clampEmbedWidth(width: number): number {
+  if (!isFinite(width)) {
+    return DEFAULT_EMBED_WIDTH
+  }
+  return Math.max(10, Math.min(100, Math.round(width)))
+}
+
+export function normalizeEmbedAlign(align: string): EmbedAlign {
+  return (EMBED_ALIGNMENTS as string[]).indexOf(align) !== -1
+    ? (align as EmbedAlign)
+    : DEFAULT_EMBED_ALIGN
+}
+
+export function escapeEmbedAttribute(value: string): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export function escapeEmbedText(value: string): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * UTF-8 safe base64, working in both the browser (`btoa`) and Node (`Buffer`).
+ * The intermediate `%xx` round-trip is what makes non-ASCII captions and
+ * markup survive — `btoa` alone throws on anything above U+00FF.
+ */
+export function encodeEmbedCode(code: string): string {
+  const binary = encodeURIComponent(code).replace(/%([0-9A-F]{2})/gi, (_m, hex: string) =>
+    String.fromCharCode(parseInt(hex, 16))
+  )
+  if (typeof btoa === 'function') {
+    return btoa(binary)
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(binary, 'binary').toString('base64')
+  }
+  throw new Error('No base64 encoder available')
+}
+
+export function decodeEmbedCode(encoded: string): string {
+  let binary: string
+  if (typeof atob === 'function') {
+    binary = atob(encoded)
+  } else if (typeof Buffer !== 'undefined') {
+    binary = Buffer.from(encoded, 'base64').toString('binary')
+  } else {
+    throw new Error('No base64 decoder available')
+  }
+  let percent = ''
+  for (let index = 0; index < binary.length; index += 1) {
+    percent += `%${`00${binary.charCodeAt(index).toString(16)}`.slice(-2)}`
+  }
+  return decodeURIComponent(percent)
+}
+
+export function createEmbedValue(params: {
+  code: string
+  provider?: string
+  url?: string
+  ratio?: number | null
+  width?: number
+  align?: string
+  caption?: string
+  sandboxLevel?: EmbedSandboxLevel
+}): EmbedValue {
+  const code = params.code || ''
+  return {
+    provider: params.provider || CUSTOM_EMBED_PROVIDER_ID,
+    url: params.url || '',
+    code,
+    mode: resolveEmbedMode(code),
+    ratio: params.ratio ?? null,
+    width: clampEmbedWidth(params.width ?? DEFAULT_EMBED_WIDTH),
+    align: normalizeEmbedAlign(params.align ?? DEFAULT_EMBED_ALIGN),
+    caption: params.caption || '',
+    sandboxLevel: params.sandboxLevel === 'trusted' ? 'trusted' : DEFAULT_EMBED_SANDBOX_LEVEL,
+  }
+}
+
+/**
+ * The outer block's own layout — width, float and the margins each align needs.
+ *
+ * `position:relative` is deliberate: an editor overlays a click catcher on the
+ * block (an embed's own iframe swallows the click that should select it), and
+ * that overlay needs the block as its positioning context.
+ */
+export function embedBlockStyle(value: Pick<EmbedValue, 'width' | 'align'>): string {
+  const declarations = [
+    'position:relative',
+    `width:${clampEmbedWidth(value.width)}%`,
+    'max-width:100%',
+    'margin:16px 0',
+  ]
+  if (value.align === 'center') {
+    declarations.push('margin-left:auto', 'margin-right:auto')
+  } else if (value.align === 'float-left') {
+    declarations.push('float:left', 'margin-right:16px', 'margin-bottom:8px')
+  } else if (value.align === 'float-right') {
+    declarations.push('float:right', 'margin-left:16px', 'margin-bottom:8px')
+  }
+  return declarations.join(';')
+}
+
+/**
+ * The frame is what holds the embed itself. With a `ratio` it becomes the
+ * responsive padding-top box the provider templates fill absolutely; without
+ * one the template carries its own height.
+ */
+export function embedFrameStyle(ratio: number | null): string {
+  if (ratio === null || !isFinite(ratio) || ratio <= 0) {
+    return 'position:relative;width:100%'
+  }
+  return `position:relative;width:100%;padding-top:${ratio}%`
+}
+
+export const EMBED_CAPTION_STYLE =
+  'margin-top:8px;font-size:0.875em;line-height:1.5;opacity:0.75;text-align:center'
+
+/**
+ * The stored markup for one embed. This is the exact string both editors write
+ * into the content column and both runtimes read back.
+ */
+export function buildEmbedElementHtml(value: EmbedValue): string {
+  const attrs = [
+    `class="${EMBED_CLASS_NAME}"`,
+    `${EMBED_ATTR.MARKER}="1"`,
+    `${EMBED_ATTR.PROVIDER}="${escapeEmbedAttribute(value.provider)}"`,
+    `${EMBED_ATTR.MODE}="${value.mode}"`,
+    `${EMBED_ATTR.WIDTH}="${clampEmbedWidth(value.width)}"`,
+    `${EMBED_ATTR.ALIGN}="${value.align}"`,
+    `${EMBED_ATTR.SANDBOX}="${value.sandboxLevel}"`,
+  ]
+  if (value.url) {
+    attrs.push(`${EMBED_ATTR.URL}="${escapeEmbedAttribute(value.url)}"`)
+  }
+  if (value.ratio !== null) {
+    attrs.push(`${EMBED_ATTR.RATIO}="${value.ratio}"`)
+  }
+  if (value.caption) {
+    attrs.push(`${EMBED_ATTR.CAPTION}="${escapeEmbedAttribute(value.caption)}"`)
+  }
+  if (value.mode === 'sandbox') {
+    attrs.push(`${EMBED_ATTR.CODE}="${escapeEmbedAttribute(encodeEmbedCode(value.code))}"`)
+  }
+  attrs.push('contenteditable="false"')
+  attrs.push(`style="${embedBlockStyle(value)}"`)
+
+  const caption = value.caption
+    ? `<figcaption class="${EMBED_CAPTION_CLASS_NAME}" style="${EMBED_CAPTION_STYLE}">${escapeEmbedText(
+        value.caption
+      )}</figcaption>`
+    : ''
+
+  return (
+    `<figure ${attrs.join(' ')}>` +
+    `<div class="${EMBED_FRAME_CLASS_NAME}" style="${embedFrameStyle(value.ratio)}">` +
+    `${buildEmbedFrameChildren(value)}</div>${caption}</figure>`
+  )
+}
+
+/**
+ * `inline` keeps the markup as real children so it renders with no JavaScript.
+ * `sandbox` keeps only a `<noscript>` link — the markup itself lives, encoded,
+ * on `data-tq-embed-code` and the runtime mounts it in a sandboxed iframe.
+ */
+export function buildEmbedFrameChildren(value: EmbedValue): string {
+  if (value.mode === 'inline') {
+    return value.code
+  }
+  if (!value.url) {
+    return ''
+  }
+  return (
+    `<noscript><a href="${escapeEmbedAttribute(value.url)}" rel="noopener noreferrer" ` +
+    `target="_blank">${escapeEmbedText(value.url)}</a></noscript>`
+  )
+}
+
+/* ── Reading a stored embed back out of the DOM ─────────────────────────────
+ *
+ * Used by the studio blot (`static value(node)`), by the selection overlay and
+ * by the runtime activator. The frame element is the single place the markup
+ * lives, so both directions agree on where to look.
+ */
+
+export function findEmbedFrame(element: Element): Element | null {
+  return element.querySelector(`.${EMBED_FRAME_CLASS_NAME}`)
+}
+
+export function readEmbedValueFromElement(element: Element): EmbedValue {
+  const mode: EmbedMode = element.getAttribute(EMBED_ATTR.MODE) === 'sandbox' ? 'sandbox' : 'inline'
+  const frame = findEmbedFrame(element)
+  const rawRatio = element.getAttribute(EMBED_ATTR.RATIO)
+  const parsedRatio = rawRatio === null ? NaN : parseFloat(rawRatio)
+
+  let code = ''
+  if (mode === 'sandbox') {
+    code = readEncodedEmbedCode(element)
+  } else if (frame) {
+    code = frame.innerHTML
+  }
+
+  return {
+    provider: element.getAttribute(EMBED_ATTR.PROVIDER) || CUSTOM_EMBED_PROVIDER_ID,
+    url: element.getAttribute(EMBED_ATTR.URL) || '',
+    code,
+    mode,
+    ratio: isFinite(parsedRatio) ? parsedRatio : null,
+    width: clampEmbedWidth(parseFloat(element.getAttribute(EMBED_ATTR.WIDTH) || '')),
+    align: normalizeEmbedAlign(element.getAttribute(EMBED_ATTR.ALIGN) || ''),
+    caption: element.getAttribute(EMBED_ATTR.CAPTION) || '',
+    sandboxLevel:
+      element.getAttribute(EMBED_ATTR.SANDBOX) === 'trusted'
+        ? 'trusted'
+        : DEFAULT_EMBED_SANDBOX_LEVEL,
+  }
+}
+
+/**
+ * A corrupted `data-tq-embed-code` (truncated by an export round-trip, mangled
+ * by a content rewrite) must degrade to "render nothing", never to a thrown
+ * exception inside a render pass.
+ */
+export function readEncodedEmbedCode(element: Element): string {
+  const encoded = element.getAttribute(EMBED_ATTR.CODE)
+  if (!encoded) {
+    return ''
+  }
+  try {
+    return decodeEmbedCode(encoded)
+  } catch {
+    return ''
+  }
+}
+
+/** Writes one `style` declaration block, replacing whatever was there. */
+function writeStyle(element: Element, style: string): void {
+  element.setAttribute('style', style)
+}
+
+export function applyEmbedElementLayout(
+  element: Element,
+  updates: { width?: number; align?: string }
+): void {
+  if (updates.width !== undefined) {
+    element.setAttribute(EMBED_ATTR.WIDTH, String(clampEmbedWidth(updates.width)))
+  }
+  if (updates.align !== undefined) {
+    element.setAttribute(EMBED_ATTR.ALIGN, normalizeEmbedAlign(updates.align))
+  }
+  writeStyle(
+    element,
+    embedBlockStyle({
+      width: clampEmbedWidth(parseFloat(element.getAttribute(EMBED_ATTR.WIDTH) || '')),
+      align: normalizeEmbedAlign(element.getAttribute(EMBED_ATTR.ALIGN) || ''),
+    })
+  )
+}
+
+/**
+ * Adds, updates or removes the caption element in place. The caption lives both
+ * as an attribute (so it survives a sandbox re-render) and as visible text.
+ */
+export function applyEmbedElementCaption(element: Element, caption: string): void {
+  const trimmed = caption || ''
+  let node = element.querySelector(`.${EMBED_CAPTION_CLASS_NAME}`)
+
+  if (!trimmed) {
+    element.removeAttribute(EMBED_ATTR.CAPTION)
+    if (node && node.parentNode) {
+      node.parentNode.removeChild(node)
+    }
+    return
+  }
+
+  element.setAttribute(EMBED_ATTR.CAPTION, trimmed)
+  if (!node) {
+    node = element.ownerDocument.createElement('figcaption')
+    node.setAttribute('class', EMBED_CAPTION_CLASS_NAME)
+    writeStyle(node, EMBED_CAPTION_STYLE)
+    element.appendChild(node)
+  }
+  node.textContent = trimmed
+}
+
+/* ── The sandbox payload ────────────────────────────────────────────────────
+ *
+ * Three surfaces mount a sandboxed embed: the studio's Quill editor preview,
+ * the studio canvas (Solid) and the exported Next.js app (React). The WIRING
+ * has to differ — each framework owns its own effect and cleanup — but the
+ * payload must not, or an embed would behave differently depending on where it
+ * is looked at. Everything that decides behaviour lives here as data: the
+ * sandbox flags, the document the iframe is given, the height protocol and its
+ * bounds. Each surface only concatenates and mounts.
+ */
+
+/**
+ * `allow-same-origin` is deliberately absent: combined with `allow-scripts` it
+ * lets a frame reach into the host page and even remove its own sandbox, which
+ * is the whole thing this mode exists to prevent.
+ */
+export const EMBED_SANDBOX_FLAGS_STRICT =
+  'allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms allow-presentation'
+
+/** The opt-in for widgets that refuse to render without storage access. */
+export const EMBED_SANDBOX_FLAGS_TRUSTED = `${EMBED_SANDBOX_FLAGS_STRICT} allow-same-origin`
+
+export function resolveEmbedSandboxFlags(level: EmbedSandboxLevel): string {
+  return level === 'trusted' ? EMBED_SANDBOX_FLAGS_TRUSTED : EMBED_SANDBOX_FLAGS_STRICT
+}
+
+export const EMBED_HEIGHT_MESSAGE_TYPE = 'tq-embed-height'
+export const EMBED_TOKEN_PLACEHOLDER = '__TQ_EMBED_TOKEN__'
+export const EMBED_MIN_HEIGHT = 80
+export const EMBED_MAX_HEIGHT = 6000
+/** Until the frame reports back, this is what it occupies. */
+export const EMBED_INITIAL_HEIGHT = 320
+
+export const EMBED_SANDBOX_DOC_HEAD =
+  '<!doctype html><html><head><meta charset="utf-8">' +
+  '<meta name="viewport" content="width=device-width, initial-scale=1">' +
+  '<base target="_blank">' +
+  '<style>html,body{margin:0;padding:0;background:transparent}' +
+  'img,iframe,video,blockquote{max-width:100%}</style>' +
+  '<script>(function(){' +
+  `var token=${JSON.stringify(EMBED_TOKEN_PLACEHOLDER)};` +
+  'var last=0;' +
+  'function report(){try{' +
+  'var doc=document.documentElement;var body=document.body;' +
+  'var height=Math.max(doc?doc.scrollHeight:0,doc?doc.offsetHeight:0,' +
+  'body?body.scrollHeight:0,body?body.offsetHeight:0);' +
+  'if(!height||height===last){return;}last=height;' +
+  `parent.postMessage({type:${JSON.stringify(
+    EMBED_HEIGHT_MESSAGE_TYPE
+  )},token:token,height:height},"*");` +
+  '}catch(e){}}' +
+  'function watch(){report();' +
+  'if(typeof ResizeObserver==="function"&&document.documentElement){' +
+  'new ResizeObserver(report).observe(document.documentElement);}' +
+  'if(typeof MutationObserver==="function"&&document.body){' +
+  'new MutationObserver(report).observe(document.body,' +
+  '{childList:true,subtree:true,attributes:true});}' +
+  // Several providers paint well after `load` (they fetch, then swap in their
+  // own iframe), so a few late reports are what stops a widget from sitting in
+  // a box sized for its placeholder.
+  'var delays=[150,400,900,1800,3500];' +
+  'for(var i=0;i<delays.length;i++){setTimeout(report,delays[i]);}}' +
+  'if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",watch);}' +
+  'else{watch();}window.addEventListener("load",report);' +
+  '})();</script></head><body>'
+
+export const EMBED_SANDBOX_DOC_TAIL = '</body></html>'
+
+/**
+ * The document a sandboxed embed is given. Assign it to `iframe.srcdoc` as a
+ * property — writing it into the attribute would need HTML escaping.
+ */
+export function buildEmbedSandboxDocument(code: string, token: string): string {
+  return (
+    EMBED_SANDBOX_DOC_HEAD.replace(EMBED_TOKEN_PLACEHOLDER, token) +
+    (code || '') +
+    EMBED_SANDBOX_DOC_TAIL
+  )
+}
+
+/**
+ * A sandboxed frame has an opaque origin, so `event.origin` is `"null"` and
+ * cannot identify it. The per-frame token baked into its document is the guard
+ * instead: a message is only ever matched against tokens this page minted.
+ */
+export function parseEmbedHeightMessage(data: unknown): { token: string; height: number } | null {
+  if (!data || typeof data !== 'object') {
+    return null
+  }
+  const message = data as { type?: unknown; token?: unknown; height?: unknown }
+  if (message.type !== EMBED_HEIGHT_MESSAGE_TYPE || typeof message.token !== 'string') {
+    return null
+  }
+  const height = Number(message.height)
+  if (!isFinite(height) || height <= 0) {
+    return null
+  }
+  return {
+    token: message.token,
+    height: Math.min(Math.max(Math.round(height), EMBED_MIN_HEIGHT), EMBED_MAX_HEIGHT),
+  }
+}
+
+let embedTokenCounter = 0
+
+export function createEmbedToken(): string {
+  embedTokenCounter += 1
+  return `tqe-${Date.now().toString(36)}-${embedTokenCounter.toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`
+}
+
+/**
+ * Restores every embed inside `root` to its canonical STORED form, in place.
+ *
+ * An editor reads its value back out of the live DOM (Quill hands back
+ * `root.innerHTML`), and by then the DOM carries things the content column must
+ * never keep: the preview an editor mounted next to a sandboxed embed, and the
+ * marker a runtime writes once it has handled a block. The editor normalizes a
+ * detached CLONE of its root through this before emitting a value, so what is
+ * stored is exactly what `buildEmbedElementHtml` would have produced — whatever
+ * the preview did to the live DOM.
+ *
+ * The frame restore is a self-heal for the other mounting strategy: the canvas
+ * and the published page mount INTO the frame, because they never read back.
+ */
+export function normalizeEmbedsForStorage(root: Element): void {
+  const previews = root.querySelectorAll(`[${EMBED_ATTR.PREVIEW}]`)
+  for (let index = previews.length - 1; index >= 0; index -= 1) {
+    const preview = previews[index]
+    if (preview.parentNode) {
+      preview.parentNode.removeChild(preview)
+    }
+  }
+
+  const blocks = root.querySelectorAll(`[${EMBED_ATTR.MARKER}]`)
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index]
+    block.removeAttribute(EMBED_ATTR.ACTIVATED)
+
+    const frame = findEmbedFrame(block)
+    if (!frame) {
+      continue
+    }
+    const value = readEmbedValueFromElement(block)
+    if (value.mode !== 'sandbox') {
+      continue
+    }
+    frame.innerHTML = buildEmbedFrameChildren(value)
+  }
+}

--- a/packages/teleport-types/src/uidl.ts
+++ b/packages/teleport-types/src/uidl.ts
@@ -588,6 +588,13 @@ export interface UIDLLocalFontAsset {
 export interface UIDLCanonicalAsset {
   type: 'canonical'
   path: string
+  /**
+   * A prop reference whose runtime value, when truthy, replaces the canonical
+   * href (and the mirrored og:url). Used by details pages whose entity rows
+   * carry their own canonical URL (e.g. a blog post's `canonical_url` column);
+   * `path` remains the fallback for rows without one.
+   */
+  dynamicOverride?: UIDLDynamicReference
 }
 
 export interface UIDLIconAsset {
@@ -664,6 +671,17 @@ export interface UIDLInitialPropsData {
   */
   cache?: {
     revalidate: number
+  }
+  /*
+    Entity-level redirect support for details pages. When set, the generated
+    getStaticProps/getServerSideProps returns a redirect whenever the fetched
+    row's `destinationField` (a field on the transformed entity, e.g.
+    `redirectUrl`) holds a non-empty value. `typeField` names the field holding
+    '301' | '302'; anything other than '302' redirects with statusCode 301.
+  */
+  redirect?: {
+    destinationField: string
+    typeField?: string
   }
 }
 

--- a/packages/teleport-uidl-validator/__tests__/decoder/seo-overrides.test.ts
+++ b/packages/teleport-uidl-validator/__tests__/decoder/seo-overrides.test.ts
@@ -1,0 +1,99 @@
+import { canonicalAssetDecoder, initialPropsDecoder } from '../../src/decoders/utils'
+
+// The object decoders are strict whitelists: any key they do not declare is
+// silently dropped from the decoded UIDL (and the decoded object REPLACES the
+// input in the generation pipeline). These tests pin the two per-entity SEO
+// fields so a decoder regression cannot silently disable the feature.
+
+describe('canonicalAssetDecoder: per-entity dynamicOverride', () => {
+  it('keeps a prop dynamicOverride intact', () => {
+    const decoded = canonicalAssetDecoder.runWithException({
+      type: 'canonical',
+      path: 'https://example.com/blog/[slug]',
+      dynamicOverride: {
+        type: 'dynamic',
+        content: {
+          referenceType: 'prop',
+          id: 'root',
+          refPath: ['blogPost', 'canonicalUrl'],
+        },
+      },
+    })
+
+    expect(decoded.dynamicOverride).toEqual({
+      type: 'dynamic',
+      content: {
+        referenceType: 'prop',
+        id: 'root',
+        refPath: ['blogPost', 'canonicalUrl'],
+      },
+    })
+  })
+
+  it('decodes a plain canonical asset without one (unchanged behavior)', () => {
+    const decoded = canonicalAssetDecoder.runWithException({
+      type: 'canonical',
+      path: 'https://example.com/about',
+    })
+
+    expect(decoded).toEqual({ type: 'canonical', path: 'https://example.com/about' })
+  })
+})
+
+describe('initialPropsDecoder: entity redirect', () => {
+  const base = {
+    exposeAs: { name: 'blogPost', valuePath: ['data', '0'] },
+    resource: { id: 'TQ_fetchBlogPostDetail' },
+  }
+
+  it('keeps the redirect field config intact', () => {
+    const decoded = initialPropsDecoder.runWithException({
+      ...base,
+      redirect: { destinationField: 'redirectUrl', typeField: 'redirectType' },
+    })
+
+    expect(decoded.redirect).toEqual({
+      destinationField: 'redirectUrl',
+      typeField: 'redirectType',
+    })
+  })
+
+  it('accepts a redirect without typeField', () => {
+    const decoded = initialPropsDecoder.runWithException({
+      ...base,
+      redirect: { destinationField: 'redirectUrl' },
+    })
+
+    expect(decoded.redirect).toEqual({ destinationField: 'redirectUrl' })
+  })
+
+  it('decodes initialPropsData without a redirect (unchanged behavior)', () => {
+    const decoded = initialPropsDecoder.runWithException(base)
+
+    expect(decoded.redirect).toBeUndefined()
+  })
+})
+
+describe('dynamic metaTag fallback survives decoding', () => {
+  it('keeps `fallback` on a dynamic prop reference', () => {
+    // The robots meta relies on `fallback` reaching the head plugin — it is the
+    // page-level inheritance channel.
+    const decoded = canonicalAssetDecoder.runWithException({
+      type: 'canonical',
+      path: 'https://example.com/x',
+      dynamicOverride: {
+        type: 'dynamic',
+        content: {
+          referenceType: 'prop',
+          id: 'root',
+          refPath: ['blogPost', 'canonicalUrl'],
+          fallback: 'https://example.com/fallback',
+        },
+      },
+    })
+
+    expect((decoded.dynamicOverride as { content: { fallback?: string } }).content.fallback).toBe(
+      'https://example.com/fallback'
+    )
+  })
+})

--- a/packages/teleport-uidl-validator/src/decoders/utils.ts
+++ b/packages/teleport-uidl-validator/src/decoders/utils.ts
@@ -251,6 +251,12 @@ export const initialPropsDecoder: Decoder<UIDLInitialPropsData> = object({
     })
   ),
   cache: optional(object({ revalidate: number() })),
+  redirect: optional(
+    object({
+      destinationField: string(),
+      typeField: optional(string()),
+    })
+  ),
 })
 
 export const initialPathsDecoder: Decoder<UIDLInitialPathsData> = object({
@@ -407,6 +413,7 @@ export const localFontDecoder: Decoder<UIDLLocalFontAsset> = object({
 export const canonicalAssetDecoder: Decoder<UIDLCanonicalAsset> = object({
   type: constant('canonical' as const),
   path: string(),
+  dynamicOverride: optional(dynamicValueDecoder),
 })
 
 export const iconAssetDecoder: Decoder<UIDLIconAsset> = object({


### PR DESCRIPTION
## Rich-text code embeds, per-entity SEO overrides & redirects, speech-recognition workflow node

### 1. Code embeds in rich-text content (`tq-embed`)

Adds a full "code embed" pipeline for rich-text content (blog post bodies and any
column authored through the rich-text editor):

- **New shared contract** (`teleport-shared/src/utils/rich-text-embeds.ts` +
  `rich-text-embeds-codegen.ts`): a single module defining the embed shape used by the
  studio editor, the generated admin panel, the canvas preview and the exported Next.js
  app, so none of them can drift. Two rendering modes decided by one rule:
  - `inline` — provably passive markup (no `<script>`, no `on*` handlers, no
    `javascript:` URLs) is stored as real children: SSR-rendered, crawlable, zero JS.
  - `sandbox` — everything else is base64-encoded and materialized at runtime inside a
    sandboxed `srcdoc` iframe, so author-supplied JavaScript can never touch the host
    page. A `strict`/`trusted` sandbox level controls `allow-same-origin` as an explicit
    per-embed opt-in.
  - The provider registry is declarative (patterns + templates, no functions) so it can
    be serialized verbatim into generated projects.
- **New `NextRichContentEmbedsProjectPlugin`** (`teleport-project-generator-next/src/rich-content-embeds/`):
  emits the embed activator component and the shared runtime module into generated projects.
- **Rich-text editor generator** now accepts `{ withEmbeds }`: when a rich-text field
  enables the `tq-embed` format, the generated editor registers the embed blot, adds a
  toolbar button + insert dialog, mounts sandboxed previews, and normalizes previews back
  out of the stored HTML. Includes careful handling of react-quill pitfalls (module
  identity rebuilds destroying the editor on each keystroke, `next/dynamic` swallowing
  refs, stored-vs-emitted HTML feedback loops). Editors without the format are generated
  byte-identical to before.

### 2. Per-entity SEO overrides and redirects (details pages)

- **New UIDL fields** (+ decoders):
  - `UIDLCanonicalAsset.dynamicOverride` — a prop reference that, when truthy at runtime,
    replaces the canonical href and the mirrored `og:url` (e.g. a blog post's
    `canonical_url` column). The page-level path remains the fallback; the override
    always replaces the whole expression and is never spliced into locale/param templates.
  - `UIDLInitialPropsData.redirect` — `{ destinationField, typeField? }` for entity-level
    redirects.
- **`teleport-plugin-next-static-props`**: when `redirect` is configured, the generated
  `getStaticProps`/`getServerSideProps` returns an HTTP redirect (real 301/302, not
  307/308) whenever the fetched row's destination field is set. Runs after the notFound
  check, is locale-aware for site-internal destinations, and deliberately avoids adding a
  top-level `ReturnStatement` so downstream plugins that locate the props return keep working.
- **`teleport-plugin-jsx-head-config`**: canonical/og:url emit `{override || fallback}`
  across all three branches (i18n, dynamic params, static), and prop-driven meta tags
  now support a literal `fallback` via `??` (e.g. a robots meta inheriting the page default).
- **Blog post data transform**: normalizes the new per-post SEO columns
  (`noIndex`, `canonicalUrl`, `redirectUrl`, `redirectType`, `robotsContent`) in one
  place, tolerating tables provisioned before these columns existed.

### 3. New workflow node: `browser-speech-recognition`

A long-lived dictation session (vs. `browser-speech-to-text`, which resolves after the
first phrase with no way to stop):

- Returns immediately; transcripts leave via custom events so all app-visible effects
  stay in workflows. A `window` session registry is the source of truth for
  start/stop/toggle, so the UI can't desync from the microphone.
- Every exit path (unsupported browser, denied permission, silence cap, manual stop)
  dispatches exactly one end event, and none report as node `error`s — declining the
  microphone is a normal outcome, not a workflow failure.
- Handles Chrome's continuous-mode silence cutoffs via bounded auto-restarts.
- Registered as client-only in the API route generator.

### 4. Fix: literal `expr` condition references crashed generated pages

The domain-to-UIDL mapper emits the literal `false` when a condition's state/prop
reference can't be resolved ("renders nothing"). The reserved-word sanitiser rewrote it
to `false_`, and the generated page died server-side with
`ReferenceError: false_ is not defined`. `expr` references are now flagged
(`ConditionalIdentifier.isExpression`) and complete JS literals (`true`, `false`, `null`,
`undefined`, numbers) are emitted as literals; real expressions and genuine binding names
(e.g. a state named `class`) keep their existing behavior.

### Tests

- Rich-content embeds: end-to-end + project-plugin + embed format tests, runtime-module
  tests, and inclusion in the emitted-components Rules-of-Hooks suite (now 18 sources).
- SEO: decoder + head-config override tests, entity-redirect tests.
- Workflows: browser-speech-recognition and custom-event component-scope tests.
- Condition codegen: literal `expr` reference tests (including the exact shape that crashed).
- `jest.config.js`: the embed helper module is excluded from coverage instrumentation
  because it's emitted into generated projects via `fn.toString()` (istanbul counters
  would travel with it).
- `examples/uidl-samples/project.json` regenerated to exercise the new features.
